### PR TITLE
Improve session copy, filtering, and dialog behavior

### DIFF
--- a/frontend/src/pages/coslash/CoslashPage.tsx
+++ b/frontend/src/pages/coslash/CoslashPage.tsx
@@ -198,11 +198,11 @@ export function CoslashPage() {
     windowStart == null
       ? sessions
       : sessions.filter((session) => session.status != null || session.mtime >= windowStart);
+  const sessionsForVendor = sessionsInWindow.filter(
+    (session) => vendor === 'all' || session.agent === vendor,
+  );
   const visibleSessions = sortSessions(
-    sessionsInWindow.filter(
-      (session) =>
-        (vendor === 'all' || session.agent === vendor) && sessionMatchesSearchTerm(session, searchTerm),
-    ),
+    sessionsForVendor.filter((session) => sessionMatchesSearchTerm(session, searchTerm)),
     sortKey,
     sortDir,
   );
@@ -239,7 +239,7 @@ export function CoslashPage() {
         </div>
         <div className="flex min-h-7 items-center">
           <LoadingSpinner isLoading={isLoading}>
-            <SessionsStats sessions={sessionsInWindow} loadFailed={loadFailed} timeWindow={timeWindow} />
+            <SessionsStats sessions={sessionsForVendor} loadFailed={loadFailed} timeWindow={timeWindow} />
           </LoadingSpinner>
         </div>
       </div>

--- a/frontend/src/pages/coslash/CoslashPage.tsx
+++ b/frontend/src/pages/coslash/CoslashPage.tsx
@@ -22,7 +22,7 @@ import {
 } from '@/pages/coslash/CoslashTabMenus';
 import { useSessions } from '@/pages/coslash/hooks/use-sessions';
 import { formatEstimatedCost } from '@/pages/coslash/lib/format';
-import { sessionsEmptyStateCopy, sessionsFooterText } from '@/pages/coslash/lib/page-copy';
+import { sessionsEmptyStateCopy } from '@/pages/coslash/lib/page-copy';
 import { getEstimatedCost } from '@/pages/coslash/lib/pricing';
 import { sessionMatchesSearchTerm } from '@/pages/coslash/lib/search';
 import { getStatus, type Session } from '@/pages/coslash/lib/session';
@@ -63,33 +63,6 @@ function SessionSearch({
         value={searchTerm}
         onChange={(event) => onSearchTermChange(event.target.value)}
       />
-    </div>
-  );
-}
-
-function CoslashPageFooter({
-  sessions,
-  isLoading,
-  loadFailed,
-  timeWindow,
-}: {
-  sessions: Session[];
-  isLoading: boolean;
-  loadFailed: boolean;
-  timeWindow: TimeWindow;
-}) {
-  const sessionCount = sessionsFooterText({
-    count: sessions.length,
-    timeWindow,
-    isLoading,
-    loadFailed,
-  });
-
-  return (
-    <div className="bg-background flex items-center gap-2 border-t px-4 py-2 font-mono text-xs">
-      <span>{sessionCount}</span>
-      <span>·</span>
-      <span>Source logs are read-only</span>
     </div>
   );
 }
@@ -284,12 +257,6 @@ export function CoslashPage() {
           />
         </LoadingSpinner>
       </div>
-      <CoslashPageFooter
-        sessions={sessionsInWindow}
-        isLoading={isLoading}
-        loadFailed={loadFailed}
-        timeWindow={timeWindow}
-      />
       <SessionInspector
         session={selectedSession}
         sessionsVersion={sessionsVersion}

--- a/frontend/src/pages/coslash/CoslashPage.tsx
+++ b/frontend/src/pages/coslash/CoslashPage.tsx
@@ -21,7 +21,8 @@ import {
   type ViewMode,
 } from '@/pages/coslash/CoslashTabMenus';
 import { useSessions } from '@/pages/coslash/hooks/use-sessions';
-import { formatCost } from '@/pages/coslash/lib/format';
+import { formatEstimatedCost } from '@/pages/coslash/lib/format';
+import { sessionsEmptyStateCopy, sessionsFooterText } from '@/pages/coslash/lib/page-copy';
 import { getEstimatedCost } from '@/pages/coslash/lib/pricing';
 import { sessionMatchesSearchTerm } from '@/pages/coslash/lib/search';
 import { getStatus, type Session } from '@/pages/coslash/lib/session';
@@ -70,22 +71,25 @@ function CoslashPageFooter({
   sessions,
   isLoading,
   loadFailed,
+  timeWindow,
 }: {
   sessions: Session[];
   isLoading: boolean;
   loadFailed: boolean;
+  timeWindow: TimeWindow;
 }) {
-  const sessionCount = loadFailed
-    ? 'session count unavailable'
-    : isLoading
-      ? 'loading sessions'
-      : `${sessions.length} sessions in selected window`;
+  const sessionCount = sessionsFooterText({
+    count: sessions.length,
+    timeWindow,
+    isLoading,
+    loadFailed,
+  });
 
   return (
     <div className="bg-background flex items-center gap-2 border-t px-4 py-2 font-mono text-xs">
       <span>{sessionCount}</span>
       <span>·</span>
-      <span>read-only</span>
+      <span>Source logs are read-only</span>
     </div>
   );
 }
@@ -116,13 +120,13 @@ function SessionsStats({
           {sessions.filter((session) => session.agent === 'codex').length} Codex ·
         </span>
         <UnpricedModelWarning tokens={sessions.map((session) => session.tokens)}>
-          {formatCost(sessions.reduce((sum, session) => sum + getEstimatedCost(session.tokens), 0))}
+          {formatEstimatedCost(sessions.reduce((sum, session) => sum + getEstimatedCost(session.tokens), 0))}
         </UnpricedModelWarning>
         <span
           className="shrink-0 cursor-help underline decoration-dotted underline-offset-2"
-          title="Full-session totals for sessions with activity in the selected window."
+          title="Includes each session’s full history, not only activity in this window."
         >
-          at API list prices
+          at list API prices
         </span>
       </div>
       <div className="text-muted-foreground flex shrink-0 items-center gap-3 text-xs">
@@ -143,12 +147,18 @@ function CoslashContent({
   loadFailed,
   onRetry,
   visibleSessions,
+  hasSessions,
+  searchTerm,
+  outsideWindowMatches,
   view,
   onSelectSession,
 }: {
   loadFailed: boolean;
   onRetry: () => void;
   visibleSessions: Session[];
+  hasSessions: boolean;
+  searchTerm: string;
+  outsideWindowMatches: number;
   view: ViewMode;
   onSelectSession: (session: Session) => void;
 }) {
@@ -156,7 +166,7 @@ function CoslashContent({
     return (
       <div role="alert" className="text-destructive grid h-full place-items-center bg-neutral-50 text-sm">
         <div className="flex flex-col items-center gap-3">
-          <div>Unable to load sessions</div>
+          <div>CoSlash couldn’t load sessions from the API.</div>
           <Button variant="outline" size="sm" onClick={onRetry}>
             Try again
           </Button>
@@ -165,11 +175,12 @@ function CoslashContent({
     );
   }
   if (visibleSessions.length === 0) {
+    const emptyState = sessionsEmptyStateCopy({ hasSessions, searchTerm, outsideWindowMatches });
     return (
       <div role="status" className="grid h-full place-items-center bg-neutral-50 text-center">
         <div>
-          <div className="text-sm font-semibold">No sessions found</div>
-          <div className="text-muted-foreground pt-1 text-xs">Try another vendor or a wider time window.</div>
+          <div className="text-sm font-semibold">{emptyState.title}</div>
+          {emptyState.detail && <div className="text-muted-foreground pt-1 text-xs">{emptyState.detail}</div>}
         </div>
       </div>
     );
@@ -222,6 +233,16 @@ export function CoslashPage() {
     sortKey,
     sortDir,
   );
+  const outsideWindowMatches =
+    windowStart == null
+      ? 0
+      : sessions.filter(
+          (session) =>
+            session.status == null &&
+            session.mtime < windowStart &&
+            (vendor === 'all' || session.agent === vendor) &&
+            sessionMatchesSearchTerm(session, searchTerm),
+        ).length;
 
   return (
     <div className="flex h-svh flex-col">
@@ -255,12 +276,20 @@ export function CoslashPage() {
             loadFailed={loadFailed}
             onRetry={retrySessions}
             visibleSessions={visibleSessions}
+            hasSessions={sessions.length > 0}
+            searchTerm={searchTerm}
+            outsideWindowMatches={outsideWindowMatches}
             view={view}
             onSelectSession={(session) => setSelectedSessionId(session.id)}
           />
         </LoadingSpinner>
       </div>
-      <CoslashPageFooter sessions={sessionsInWindow} isLoading={isLoading} loadFailed={loadFailed} />
+      <CoslashPageFooter
+        sessions={sessionsInWindow}
+        isLoading={isLoading}
+        loadFailed={loadFailed}
+        timeWindow={timeWindow}
+      />
       <SessionInspector
         session={selectedSession}
         sessionsVersion={sessionsVersion}

--- a/frontend/src/pages/coslash/components/SessionBoard.tsx
+++ b/frontend/src/pages/coslash/components/SessionBoard.tsx
@@ -2,7 +2,7 @@ import { Fragment } from 'react';
 import { cn } from '@/lib/utils';
 import { SessionCard } from '@/pages/coslash/components/SessionCard';
 import { UnpricedModelWarning } from '@/pages/coslash/components/UnpricedModelWarning';
-import { formatCost, formatTokens } from '@/pages/coslash/lib/format';
+import { formatEstimatedCost, formatTokens } from '@/pages/coslash/lib/format';
 import { getEstimatedCost } from '@/pages/coslash/lib/pricing';
 import { getStatus, getTotalTokens, STATUSES, type Session, type Status } from '@/pages/coslash/lib/session';
 
@@ -41,7 +41,7 @@ function RepoGroupHeader({ repo, sessions }: { repo: string; sessions: Session[]
       <span className="text-muted-foreground text-xs">
         {sessions.length} {sessions.length === 1 ? 'session' : 'sessions'} · {formatTokens(tokens)} tok ·{' '}
         <UnpricedModelWarning tokens={sessions.map((session) => session.tokens)}>
-          {formatCost(cost)}
+          {formatEstimatedCost(cost)}
         </UnpricedModelWarning>
       </span>
     </div>
@@ -92,7 +92,7 @@ function BranchRow({
         <span className="text-muted-foreground text-xs">
           {sessions.length} {sessions.length === 1 ? 'session' : 'sessions'} · {formatTokens(tokens)} tok ·{' '}
           <UnpricedModelWarning tokens={sessions.map((session) => session.tokens)}>
-            {formatCost(cost)}
+            {formatEstimatedCost(cost)}
           </UnpricedModelWarning>
         </span>
       </div>

--- a/frontend/src/pages/coslash/components/SessionBoard.tsx
+++ b/frontend/src/pages/coslash/components/SessionBoard.tsx
@@ -76,10 +76,12 @@ function SessionCardColumn({
 function BranchRow({
   branch,
   sessions,
+  visibleStatuses,
   onSelectSession,
 }: {
   branch: string;
   sessions: Session[];
+  visibleStatuses: [string, Status][];
   onSelectSession: (session: Session) => void;
 }) {
   const tokens = sessions.reduce((sum, session) => sum + getTotalTokens(session.tokens), 0);
@@ -96,7 +98,7 @@ function BranchRow({
           </UnpricedModelWarning>
         </span>
       </div>
-      {Object.keys(STATUSES).map((status) => (
+      {visibleStatuses.map(([status]) => (
         <div
           key={status}
           data-status={status}
@@ -116,10 +118,17 @@ export function SessionBoard({
   sessions: Session[];
   onSelectSession: (session: Session) => void;
 }) {
+  const visibleStatuses = Object.entries(STATUSES).filter(([status]) =>
+    sessions.some((session) => getStatus(session.status) === status),
+  );
+
   return (
-    <div className="grid grid-cols-5 bg-neutral-50">
+    <div
+      className="grid bg-neutral-50"
+      style={{ gridTemplateColumns: `repeat(${visibleStatuses.length + 1}, minmax(0, 1fr))` }}
+    >
       <div className="sticky top-0 z-10 border-b bg-neutral-50" />
-      {Object.entries(STATUSES).map(([key, status]) => (
+      {visibleStatuses.map(([key, status]) => (
         <StatusColumnHeader
           key={key}
           status={status}
@@ -134,6 +143,7 @@ export function SessionBoard({
               key={branch}
               branch={branch}
               sessions={branchSessions}
+              visibleStatuses={visibleStatuses}
               onSelectSession={onSelectSession}
             />
           ))}

--- a/frontend/src/pages/coslash/components/SessionCard.tsx
+++ b/frontend/src/pages/coslash/components/SessionCard.tsx
@@ -1,14 +1,11 @@
 import { useState } from 'react';
 import { ChevronDownIcon, ChevronRightIcon } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import {
   Dialog,
-  DialogClose,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -290,14 +287,20 @@ export function SubagentDialogContent({
           <DialogTitle className="min-w-0 text-base">{subagent.name}</DialogTitle>
         </div>
         <DialogDescription asChild>
-          <div className="flex flex-wrap items-center gap-2 pt-1">
-            <span className="text-muted-foreground text-xs">
-              Spawned by{' '}
-              <span className="text-foreground font-semibold">{parentName ?? 'Untitled session'}</span>
-              {subagent.spawnedAtTurn != null && ` at turn ${subagent.spawnedAtTurn}`}
-            </span>
-            <SubagentStatusBadge status={subagent.status} />
-            <SubagentModelBadge model={subagent.model} />
+          <div className="flex flex-col gap-2 pt-1">
+            <div className="text-muted-foreground text-xs">
+              Subagents run in their own context window and return one result to the parent — they aren't
+              resumed on their own.
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-muted-foreground text-xs">
+                Spawned by{' '}
+                <span className="text-foreground font-semibold">{parentName ?? 'Untitled session'}</span>
+                {subagent.spawnedAtTurn != null && ` at turn ${subagent.spawnedAtTurn}`}
+              </span>
+              <SubagentStatusBadge status={subagent.status} />
+              <SubagentModelBadge model={subagent.model} />
+            </div>
           </div>
         </DialogDescription>
       </DialogHeader>
@@ -305,17 +308,6 @@ export function SubagentDialogContent({
       <SubagentProse label="Task" labelClass="text-subagent" text={subagent.task} italic />
       <SubagentCommands commands={subagent.commands} />
       <SubagentProse label="Result" labelClass="text-success-fg" text={subagent.result} />
-      <DialogFooter className="flex items-center gap-4">
-        <div className="text-muted-foreground text-xs">
-          Subagents run in their own context window and return one result to the parent — they aren't resumed
-          on their own.
-        </div>
-        <DialogClose>
-          <Button>
-            <span>Close</span>
-          </Button>
-        </DialogClose>
-      </DialogFooter>
     </DialogContent>
   );
 }

--- a/frontend/src/pages/coslash/components/SessionCard.tsx
+++ b/frontend/src/pages/coslash/components/SessionCard.tsx
@@ -16,7 +16,7 @@ import {
 import { cn } from '@/lib/utils';
 import { CopyableBadge } from '@/pages/coslash/components/CopyableBadge';
 import { UnpricedModelWarning } from '@/pages/coslash/components/UnpricedModelWarning';
-import { formatCost, formatDuration, formatTimeAgo, formatTokens } from '@/pages/coslash/lib/format';
+import { formatDuration, formatEstimatedCost, formatTimeAgo, formatTokens } from '@/pages/coslash/lib/format';
 import { getEstimatedCost } from '@/pages/coslash/lib/pricing';
 import {
   getModality,
@@ -79,7 +79,7 @@ export function SessionName({
         'opacity-75': name == null && variant === 'detailed',
       })}
     >
-      {name ?? 'no name'}
+      {name ?? 'Untitled session'}
     </span>
   );
 }
@@ -129,8 +129,7 @@ function TokenUsageAndCost({ session }: { session: Session }) {
     <div className="flex-none text-right">
       <div className="text-base font-bold">
         <UnpricedModelWarning tokens={[session.tokens]}>
-          {formatCost(getEstimatedCost(session.tokens))}{' '}
-          <span className="text-muted-foreground text-xs font-normal">est.</span>
+          {formatEstimatedCost(getEstimatedCost(session.tokens))}
         </UnpricedModelWarning>
       </div>
       <div className="text-muted-foreground pt-1 font-mono text-xs">
@@ -154,7 +153,7 @@ function CompactSessionCard({ session }: { session: Session }) {
         </div>
         <span className="text-xs font-semibold whitespace-nowrap">
           <UnpricedModelWarning tokens={[session.tokens]}>
-            {formatCost(getEstimatedCost(session.tokens))}
+            {formatEstimatedCost(getEstimatedCost(session.tokens))}
           </UnpricedModelWarning>
         </span>
       </div>
@@ -190,17 +189,8 @@ function DetailedSessionCard({ session }: { session: Session }) {
   );
 }
 
-function SubagentBadge({ abbreviated = false }: { abbreviated?: boolean }) {
-  return (
-    <Badge
-      className={cn('text-subagent bg-subagent-bg shrink-0 text-xs', {
-        'font-mono font-bold': abbreviated,
-        'font-semibold': !abbreviated,
-      })}
-    >
-      {abbreviated ? 'SUB' : 'SUBAGENT'}
-    </Badge>
-  );
+function SubagentBadge() {
+  return <Badge className="text-subagent bg-subagent-bg shrink-0 text-xs font-semibold">Subagent</Badge>;
 }
 
 export function SubagentModelBadge({ model }: { model: string | null }) {
@@ -224,7 +214,7 @@ function SubagentTokenSummary({ subagent }: { subagent: Subagent }) {
           {formatDuration(subagent.durationMs)} · {subagent.toolUses} tools ·{' '}
           {formatTokens(getTotalTokens(subagent.tokens))} tok
         </span>
-        <span className="font-bold">{formatCost(getEstimatedCost(subagent.tokens))} est.</span>
+        <span className="font-bold">{formatEstimatedCost(getEstimatedCost(subagent.tokens))}</span>
       </div>
       <div className="text-muted-foreground pt-1">
         in {formatTokens(sumTokens(subagent.tokens, 'input_tokens'))} · out{' '}
@@ -244,7 +234,7 @@ function SubagentCommands({ commands }: { commands: SubagentCommand[] }) {
   if (commands.length === 0) return null;
   return (
     <div className="flex min-w-0 flex-col gap-2">
-      <div className="text-xs font-bold tracking-widest">WHAT IT DID</div>
+      <div className="text-xs font-bold tracking-widest">Steps</div>
       <div className="bg-muted max-h-44 overflow-auto rounded-lg border p-3">
         <div className="flex w-max flex-col gap-1">
           {commands.map(({ label, command }, index) => (
@@ -302,9 +292,9 @@ export function SubagentDialogContent({
         <DialogDescription asChild>
           <div className="flex flex-wrap items-center gap-2 pt-1">
             <span className="text-muted-foreground text-xs">
-              ↳ spawned by{' '}
-              <span className="text-foreground font-semibold">{parentName ?? 'unnamed session'}</span>
-              {subagent.spawnedAtTurn != null && ` · turn ${subagent.spawnedAtTurn}`}
+              Spawned by{' '}
+              <span className="text-foreground font-semibold">{parentName ?? 'Untitled session'}</span>
+              {subagent.spawnedAtTurn != null && ` at turn ${subagent.spawnedAtTurn}`}
             </span>
             <SubagentStatusBadge status={subagent.status} />
             <SubagentModelBadge model={subagent.model} />
@@ -312,9 +302,9 @@ export function SubagentDialogContent({
         </DialogDescription>
       </DialogHeader>
       <SubagentTokenSummary subagent={subagent} />
-      <SubagentProse label="TASK FROM PARENT" labelClass="text-subagent" text={subagent.task} italic />
+      <SubagentProse label="Task" labelClass="text-subagent" text={subagent.task} italic />
       <SubagentCommands commands={subagent.commands} />
-      <SubagentProse label="RETURNED TO PARENT" labelClass="text-success-fg" text={subagent.result} />
+      <SubagentProse label="Result" labelClass="text-success-fg" text={subagent.result} />
       <DialogFooter className="flex items-center gap-4">
         <div className="text-muted-foreground text-xs">
           Subagents run in their own context window and return one result to the parent — they aren't resumed
@@ -322,7 +312,7 @@ export function SubagentDialogContent({
         </div>
         <DialogClose>
           <Button>
-            <span>Back to session</span>
+            <span>Close</span>
           </Button>
         </DialogClose>
       </DialogFooter>
@@ -341,7 +331,7 @@ function DetailedSubagentRow({ subagent }: { subagent: Subagent }) {
       </div>
       <div className="flex flex-none items-center gap-2">
         <span className="text-xs font-light whitespace-nowrap">
-          {formatCost(getEstimatedCost(subagent.tokens))}
+          {formatEstimatedCost(getEstimatedCost(subagent.tokens))}
         </span>
         <span className="text-muted-foreground font-mono text-xs whitespace-nowrap">
           {formatTokens(getTotalTokens(subagent.tokens))} tok
@@ -355,11 +345,11 @@ function CompactSubagentRow({ subagent }: { subagent: Subagent }) {
   return (
     <div className="flex items-center justify-between gap-2">
       <div className="flex min-w-0 items-center gap-2">
-        <SubagentBadge abbreviated />
+        <SubagentBadge />
         <span className="min-w-0 truncate text-xs font-semibold">{subagent.name}</span>
       </div>
       <span className="text-xs font-light whitespace-nowrap">
-        {formatCost(getEstimatedCost(subagent.tokens))}
+        {formatEstimatedCost(getEstimatedCost(subagent.tokens))}
       </span>
     </div>
   );

--- a/frontend/src/pages/coslash/components/SessionInspector.tsx
+++ b/frontend/src/pages/coslash/components/SessionInspector.tsx
@@ -762,6 +762,7 @@ export function SessionInspector({
   onClose: () => void;
 }) {
   const detail = useSessionDetail(session, sessionsVersion);
+  const contentRef = useRef<HTMLDivElement>(null);
   const isOpen = session != null;
 
   return (
@@ -771,7 +772,16 @@ export function SessionInspector({
         if (!open) onClose();
       }}
     >
-      <SheetContent className="w-1/2! max-w-none! gap-0" showCloseButton={true}>
+      <SheetContent
+        ref={contentRef}
+        tabIndex={-1}
+        className="w-1/2! max-w-none! gap-0 outline-none"
+        showCloseButton={true}
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          contentRef.current?.focus();
+        }}
+      >
         {isOpen && detail != null && (
           <>
             <SheetHeader>

--- a/frontend/src/pages/coslash/components/SessionInspector.tsx
+++ b/frontend/src/pages/coslash/components/SessionInspector.tsx
@@ -26,7 +26,7 @@ import {
 } from '@/pages/coslash/components/SessionCard';
 import { UnpricedModelWarning } from '@/pages/coslash/components/UnpricedModelWarning';
 import { useLaunchTerminal } from '@/pages/coslash/hooks/use-launch-terminal';
-import { formatCost, formatDuration, formatTimeAgo, formatTokens } from '@/pages/coslash/lib/format';
+import { formatDuration, formatEstimatedCost, formatTimeAgo, formatTokens } from '@/pages/coslash/lib/format';
 import { handoffBrief } from '@/pages/coslash/lib/handoff';
 import { getEstimatedCost } from '@/pages/coslash/lib/pricing';
 import {
@@ -115,12 +115,15 @@ function contextFillReadiness(detail: SessionDetail): { value: string; tone: str
 
 function branchDriftReadiness(git: SessionDetail['git']): { value: string; tone: string } | null {
   if (git == null) return null;
-  return { value: `+${git.ahead} −${git.behind} on ${git.baseBranch}`, tone: driftTone(git.behind) };
+  return {
+    value: `${git.ahead} ahead, ${git.behind} behind ${git.baseBranch}.`,
+    tone: driftTone(git.behind),
+  };
 }
 
 function treeStaleReadiness(lastEditAt: number | null): { value: string; tone: string } | null {
   if (lastEditAt == null) return null;
-  return { value: `edits ${formatTimeAgo(lastEditAt)}`, tone: staleTone(Date.now() - lastEditAt) };
+  return { value: `Last edit ${formatTimeAgo(lastEditAt)}.`, tone: staleTone(Date.now() - lastEditAt) };
 }
 
 function fillTone(pct: number): string {
@@ -218,7 +221,7 @@ function HeaderMeta({ detail }: { detail: SessionDetail }) {
           <SessionModelUsage agent={detail.agent} model={detail.model} tokens={detail.tokens} />
           <span className="font-bold">
             <UnpricedModelWarning tokens={[detail.tokens]}>
-              {formatCost(getEstimatedCost(detail.tokens))} est.
+              {formatEstimatedCost(getEstimatedCost(detail.tokens))}
             </UnpricedModelWarning>
           </span>
         </div>
@@ -297,7 +300,7 @@ function ResumeSessionButton({ detail }: { detail: SessionDetail }) {
     <div className="flex flex-col gap-1">
       <Button className="bg-brand w-fit p-2 text-xs" onClick={() => launch('resume')}>
         <PlayIcon />
-        <span>Resume session</span>
+        <span>Resume</span>
       </Button>
       <LaunchError message={launchError} />
     </div>
@@ -324,7 +327,7 @@ function StartNewSessionButton({
     <div className="flex flex-col gap-1">
       <Button className="bg-brand w-fit p-2 text-xs" onClick={startNewSession}>
         <TerminalIcon />
-        <span>Copy debrief & start new session</span>
+        <span>Start fresh with handoff</span>
       </Button>
       <LaunchError message={launchError} />
     </div>
@@ -347,19 +350,19 @@ function HandoffSection({ detail }: { detail: SessionDetail }) {
 
   return (
     <div className="flex flex-col gap-2">
-      <SectionLabel title="HANDOFF" note="resume-readiness" />
+      <SectionLabel title="RESUME OR HAND OFF" />
       <div className="bg-border grid grid-cols-5 gap-px overflow-hidden rounded-lg border">
-        <ReadinessCell label="Context fill" value={contextFill?.value} tone={contextFill?.tone} />
+        <ReadinessCell label="Context used" value={contextFill?.value} tone={contextFill?.tone} />
         <ReadinessCell label="Compactions" value={String(detail.compactions)} />
-        <ReadinessCell label="Branch drift" value={branchDrift?.value} tone={branchDrift?.tone} />
-        <ReadinessCell label="Tree staleness" value={treeStale?.value} tone={treeStale?.tone} />
+        <ReadinessCell label="Branch" value={branchDrift?.value} tone={branchDrift?.tone} />
+        <ReadinessCell label="Working tree" value={treeStale?.value} tone={treeStale?.tone} />
         <PromptCacheCell lastAccessAt={detail.mtime} />
       </div>
 
       <div className="flex items-center gap-2">
         <StartNewSessionButton detail={detail} brief={brief} onCopy={copyBrief} />
         <Button variant="outline" className="w-fit p-2 text-xs" onClick={copyBrief}>
-          <span>Copy handoff debrief</span>
+          <span>Copy handoff</span>
         </Button>
         {copied && <span className="text-xs text-neutral-300">copied to clipboard</span>}
       </div>
@@ -379,7 +382,7 @@ function RecapSection({ detail }: { detail: SessionDetail }) {
 
   return (
     <div>
-      <SectionLabel title="DEBRIEF" note="outcome & digest" />
+      <SectionLabel title="DEBRIEF" />
       <div className="rounded-lg border p-3">
         <div className="flex items-center gap-2">
           <span className="text-muted-foreground text-xs">GOAL</span>
@@ -433,7 +436,7 @@ const DEFAULT_HIDDEN_CATEGORIES: DigestCategory[] = ['user', 'compaction'];
 const DIGEST_CATEGORIES: Record<DigestCategory, { label: string; fg: string; dot: string }> = {
   first_prompt: { label: 'FIRST PROMPT', fg: 'text-success-fg', dot: 'bg-success-fg' },
   question: { label: 'QUESTION', fg: 'text-question', dot: 'bg-question' },
-  subagent: { label: 'SUBAGENT', fg: 'text-subagent', dot: 'bg-subagent' },
+  subagent: { label: 'Subagent', fg: 'text-subagent', dot: 'bg-subagent' },
   todos: { label: 'TODOS', fg: 'text-muted-foreground', dot: 'bg-muted-foreground' },
   recap: { label: 'RECAP', fg: 'text-recap', dot: 'bg-recap' },
   user: { label: 'USER TURN', fg: 'text-brand', dot: 'bg-brand' },
@@ -511,14 +514,14 @@ function SubagentDigestRow({ subagentId, detail }: { subagentId: string; detail:
     <Dialog>
       <DialogTrigger asChild>
         <div className="bg-subagent-card border-subagent-rail flex cursor-pointer items-baseline gap-2 rounded-lg border p-2">
-          <span className="text-subagent w-24 shrink-0 text-xs font-bold tracking-wide">SUBAGENT</span>
+          <span className="text-subagent w-24 shrink-0 text-xs font-bold tracking-wide">Subagent</span>
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
               <span className="min-w-0 truncate text-sm font-semibold">{subagent.name}</span>
               <SubagentModelBadge model={subagent.model} />
             </div>
             <div className="text-muted-foreground truncate pt-1 text-xs">
-              ↳ {subagent.result === '' ? status : `${status}: ${subagent.result}`}
+              {subagent.result === '' ? status : `${status}: ${subagent.result}`}
             </div>
           </div>
           <div className="text-brand flex shrink-0 items-center gap-1 text-xs">
@@ -557,10 +560,10 @@ function DigestSection({ detail }: { detail: SessionDetail }) {
     <div>
       <div className="flex items-baseline justify-between gap-2 pb-2">
         <div className="flex items-baseline gap-2">
-          <span className="text-muted-foreground text-xs font-semibold tracking-wide">DIGEST</span>
-          <span className="text-muted-foreground text-xs">mined candidates</span>
+          <span className="text-muted-foreground text-xs font-semibold tracking-wide">TIMELINE</span>
+          <span className="text-muted-foreground text-xs">key events from this session</span>
         </div>
-        <span className="text-muted-foreground text-xs">tap to filter categories</span>
+        <span className="text-muted-foreground text-xs">Click a category to show or hide it.</span>
       </div>
       <div className="flex flex-wrap gap-1 pb-2">
         {(Object.keys(DIGEST_CATEGORIES) as DigestCategory[])
@@ -620,9 +623,10 @@ function ArtifactStats({ detail }: { detail: SessionDetail }) {
 
 function FilesChangedList({ detail }: { detail: SessionDetail }) {
   if (detail.fileEdits.length === 0) return null;
+  const newFiles = detail.fileEdits.filter((fileEdit) => fileEdit.isNew).length;
   return (
     <div>
-      <FieldLabel>DIFFS - per edit, grouped by file</FieldLabel>
+      <FieldLabel>{`FILES CHANGED · ${detail.fileEdits.length} TOTAL${newFiles ? `, ${newFiles} NEW` : ''}`}</FieldLabel>
       <div className="rounded-sm border p-2">
         {detail.fileEdits.map((fileEdit) => (
           <div key={fileEdit.path} className="flex items-center justify-between gap-2 py-1 font-mono text-xs">
@@ -652,7 +656,7 @@ function CommitsAndTodos({ detail }: { detail: SessionDetail }) {
   return (
     <div className="flex gap-4 pt-4">
       <div className="min-w-0 flex-1">
-        <FieldLabel>COMMITS / PRS</FieldLabel>
+        <FieldLabel>COMMITS</FieldLabel>
         {detail.commits.length === 0 ? (
           <div className="text-muted-foreground text-xs">—</div>
         ) : (
@@ -740,7 +744,7 @@ function InspectorFooter({ detail }: { detail: SessionDetail }) {
       <div className="flex min-w-0 flex-col">
         <span className="text-xs">Resume this exact session</span>
         <span className="text-muted-foreground text-xs font-light">
-          Reopens the full context in {getVendor(detail.agent).label}
+          Reopens this session in {getVendor(detail.agent).label} with its full context.
         </span>
       </div>
       <ResumeSessionButton detail={detail} />

--- a/frontend/src/pages/coslash/components/SessionSortDropdownMenu.tsx
+++ b/frontend/src/pages/coslash/components/SessionSortDropdownMenu.tsx
@@ -24,7 +24,7 @@ export type SortDir = 'asc' | 'desc';
 
 const SORT_LABELS: Record<SortKey, string> = {
   [SortKey.Recency]: 'Recency',
-  [SortKey.Value]: 'Est. value',
+  [SortKey.Value]: 'Est. cost',
   [SortKey.Tokens]: 'Tokens',
   [SortKey.Duration]: 'Duration',
 };

--- a/frontend/src/pages/coslash/lib/format.ts
+++ b/frontend/src/pages/coslash/lib/format.ts
@@ -1,8 +1,8 @@
 import { MINUTE } from '@/pages/coslash/lib/time';
 
-export function formatCost(usd: number): string {
+export function formatEstimatedCost(usd: number): string {
   if (usd > 0 && usd < 0.01) return '<$0.01';
-  return `$${usd.toFixed(2)}`;
+  return `≈$${usd.toFixed(2)}`;
 }
 
 export function formatDuration(ms: number | null): string {

--- a/frontend/src/pages/coslash/lib/handoff.ts
+++ b/frontend/src/pages/coslash/lib/handoff.ts
@@ -1,4 +1,4 @@
-import { formatCost, formatDuration, formatTokens } from '@/pages/coslash/lib/format';
+import { formatDuration, formatEstimatedCost, formatTokens } from '@/pages/coslash/lib/format';
 import { getEstimatedCost } from '@/pages/coslash/lib/pricing';
 import {
   getTotalTokens,
@@ -40,7 +40,7 @@ export function handoffBrief(detail: SessionDetail): string {
     '## Key decisions',
     ...decisions,
     '',
-    '## Digest',
+    '## Timeline',
     ...digest,
     '',
     '## Files',
@@ -59,7 +59,7 @@ export function handoffBrief(detail: SessionDetail): string {
     `- Working directory: ${detail.cwd}`,
     `- Runtime: ${formatDuration(detail.durationMs)}`,
     `- Tokens: ${formatTokens(getTotalTokens(detail.tokens))}`,
-    `- Estimated API value: ${formatCost(getEstimatedCost(detail.tokens))}`,
+    `- Estimated cost at list API prices: ${formatEstimatedCost(getEstimatedCost(detail.tokens))}`,
     `- Errors: ${detail.errors}; subagents: ${detail.subagents.length}`,
   ].join('\n');
 }

--- a/frontend/src/pages/coslash/lib/page-copy.ts
+++ b/frontend/src/pages/coslash/lib/page-copy.ts
@@ -1,29 +1,3 @@
-import { type TimeWindow } from '@/pages/coslash/lib/time-window';
-
-const TIME_WINDOW_SCOPE_LABELS: Record<TimeWindow, string> = {
-  'week': 'this week',
-  'month': 'this month',
-  '7d': 'in the last 7 days',
-  '30d': 'in the last 30 days',
-  'all': 'across all time',
-};
-
-export function sessionsFooterText({
-  count,
-  timeWindow,
-  isLoading,
-  loadFailed,
-}: {
-  count: number;
-  timeWindow: TimeWindow;
-  isLoading: boolean;
-  loadFailed: boolean;
-}): string {
-  if (loadFailed) return 'Session count unavailable';
-  if (isLoading) return 'Loading sessions…';
-  return `${count} ${count === 1 ? 'session' : 'sessions'} ${TIME_WINDOW_SCOPE_LABELS[timeWindow]}`;
-}
-
 export function sessionsEmptyStateCopy({
   hasSessions,
   searchTerm,

--- a/frontend/src/pages/coslash/lib/page-copy.ts
+++ b/frontend/src/pages/coslash/lib/page-copy.ts
@@ -1,0 +1,50 @@
+import { type TimeWindow } from '@/pages/coslash/lib/time-window';
+
+const TIME_WINDOW_SCOPE_LABELS: Record<TimeWindow, string> = {
+  'week': 'this week',
+  'month': 'this month',
+  '7d': 'in the last 7 days',
+  '30d': 'in the last 30 days',
+  'all': 'across all time',
+};
+
+export function sessionsFooterText({
+  count,
+  timeWindow,
+  isLoading,
+  loadFailed,
+}: {
+  count: number;
+  timeWindow: TimeWindow;
+  isLoading: boolean;
+  loadFailed: boolean;
+}): string {
+  if (loadFailed) return 'Session count unavailable';
+  if (isLoading) return 'Loading sessions…';
+  return `${count} ${count === 1 ? 'session' : 'sessions'} ${TIME_WINDOW_SCOPE_LABELS[timeWindow]}`;
+}
+
+export function sessionsEmptyStateCopy({
+  hasSessions,
+  searchTerm,
+  outsideWindowMatches,
+}: {
+  hasSessions: boolean;
+  searchTerm: string;
+  outsideWindowMatches: number;
+}): { title: string; detail?: string } {
+  if (!hasSessions) return { title: 'No sessions yet.' };
+
+  const term = searchTerm.trim();
+  if (term !== '') {
+    return {
+      title: `Nothing matches “${term}” in this window.`,
+      detail:
+        outsideWindowMatches > 0
+          ? `${outsideWindowMatches} matching ${outsideWindowMatches === 1 ? 'session' : 'sessions'} outside this window.`
+          : undefined,
+    };
+  }
+
+  return { title: 'No sessions match these filters.' };
+}

--- a/frontend/src/pages/coslash/lib/session.ts
+++ b/frontend/src/pages/coslash/lib/session.ts
@@ -112,8 +112,12 @@ export function getSessionOutcome(session: Pick<Session, 'synthesis' | 'summary'
   return session.summary?.trim() || null;
 }
 
-export function getSessionCardSummary(session: Pick<Session, 'synthesis' | 'summary'>): string {
-  return firstSentence(getSessionOutcome(session)) ?? 'No summary';
+export function getSessionCardSummary(
+  session: Pick<Session, 'synthesis' | 'summary' | 'synthesisPending'>,
+): string {
+  const summary = firstSentence(getSessionOutcome(session));
+  if (summary) return summary;
+  return session.synthesisPending ? 'Summary still generating' : 'No summary available';
 }
 
 export type Vendor = { label: string; mono: string; fg: string; bg: string };


### PR DESCRIPTION
## Context

CoSlash’s session UI mixes internal terminology with ambiguous cost, state, and handoff labels. This update makes the language more direct, aligns summaries and board layouts with active filters, and removes redundant or distracting UI behavior.

## Changes

### Copy and messaging

- Clarify session, subagent, timeline, handoff, cost, and readiness terminology.
- Improve loading, failure, search, and empty-state messages.

### Filtering and board layout

- Make summary costs and session counts follow the vendor filter.
- Hide empty board status columns and expand the remaining columns.

### UI cleanup

- Remove the redundant page footer.
- Prevent the session UUID tooltip from appearing automatically when the inspector opens.
- Move the subagent context note below the dialog title and remove its redundant footer and Close button.

## Test
- Verified summary costs and counts across All vendors, Claude Code, and Codex.
- Verified vendor-filtered board views hide empty status columns and reflow correctly.
- Verified the session inspector opens without showing the UUID tooltip.
- Verified the subagent dialog note placement and removal of the footer.

### Screenshots

- Sessions list and inspector — updated copy and removed footer
<img width="1454" height="901" alt="Sessions list and inspector" src="https://github.com/user-attachments/assets/b320043d-e745-4d4a-8dde-b556f1f696e7" />

- Board view — filtered totals and empty status columns hidden
<img width="1454" height="901" alt="Board view" src="https://github.com/user-attachments/assets/1d7ca36b-ecab-4367-9208-3a611ed0e1a2" />
<img width="1454" height="901" alt="Filtered board view" src="https://github.com/user-attachments/assets/f26de98c-0e1a-4d26-8ef5-ea4104e9f1bb" />
- Subagent dialog — context note below title with no footer
<img width="722" height="423" alt="Screenshot 2026-08-02 at 3 23 08 PM" src="https://github.com/user-attachments/assets/4d5ac612-d620-4003-8c33-8a7db22a00b0" />
