### PR TITLE
Fix Codex todo and pull request collection

### DIFF
--- a/collector/internal/vendors/codex/parse.go
+++ b/collector/internal/vendors/codex/parse.go
@@ -243,6 +243,7 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 				if question, ok := questionFrom(row.Payload); ok {
 					analysis.digest.Push(analysis.prompts, session.DigestQuestion, question)
 				}
+				analysis.notePlan(row.Payload)
 			case "function_call_output":
 				if id := spawnedAgentID(row.Payload.Output); id != "" {
 					analysis.spawnTurns[id] = max(analysis.prompts, 1)
@@ -468,7 +469,9 @@ func unifiedDiffStat(diff string) (additions, deletions int) {
 	return session.DiffStat(lines)
 }
 
-var execCmdPattern = regexp.MustCompile(`"cmd":\s*("(?:[^"\\]|\\.)*")`)
+var execCmdPattern = regexp.MustCompile(
+	`(?:^|[{,]\s*)(?:"cmd"|cmd)\s*:\s*("(?:[^"\\]|\\.)*")`,
+)
 var questionPattern = regexp.MustCompile(`"question"\s*:\s*("(?:[^"\\]|\\.)*")`)
 var planStepPattern = regexp.MustCompile(
 	`"?step"?\s*:\s*("(?:[^"\\]|\\.)*")\s*,\s*"?status"?\s*:\s*"(\w+)"`,


### PR DESCRIPTION
## Context

Codex tool calls can wrap plans and shell commands in JavaScript-style exec payloads. The collector previously omitted valid todos and pull request creation commands from these calls.

## Changes

- Collect nested `update_plan` calls from Codex tool-call inputs.
- Accept both quoted JSON `"cmd"` and unquoted JavaScript `cmd` keys when collecting commands and pull requests.

## Test

- `go test ./...` — passed


Before:
no Todo's and missing commands and PRs
<img width="714" height="611" alt="Screenshot 2026-08-02 at 4 29 22 PM" src="https://github.com/user-attachments/assets/bbd1e615-7817-4079-8e8a-6fb0d6df9674" />
<img width="717" height="600" alt="Screenshot 2026-08-02 at 4 29 09 PM" src="https://github.com/user-attachments/assets/214ef89a-3001-498f-8b3b-4b3e5d3300ad" />


After:
Todos displayed, many more commands, and PR count shows
<img width="712" height="643" alt="Screenshot 2026-08-02 at 4 26 35 PM" src="https://github.com/user-attachments/assets/05c69968-b27a-42e0-b2be-4dc4a64f3ddd" />
<img width="717" height="584" alt="Screenshot 2026-08-02 at 4 26 25 PM" src="https://github.com/user-attachments/assets/6464fa10-45ec-4674-a181-d88197deb986" />
