### PR TITLE
Speed up session loading with windowed collection

### DIFF
--- a/collector/cmd/coslash/main.go
+++ b/collector/cmd/coslash/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strconv"
 	"time"
 	"unicode/utf8"
 
@@ -22,12 +23,16 @@ func main() {
 		log.Printf("initialize synthesis cache: %v", err)
 		mgr = synthesis.NewManager(nil)
 	}
-	go mgr.Run(context.Background(), collector.List)
+	go mgr.Run(context.Background(), func() ([]*session.Session, error) {
+		now := time.Now()
+		today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+		return collector.List(today.UnixMilli())
+	})
 	go cleanupHandoffs()
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/sessions", func(w http.ResponseWriter, _ *http.Request) {
-		handleList(w, mgr)
+	mux.HandleFunc("/api/sessions", func(w http.ResponseWriter, r *http.Request) {
+		handleList(w, r, mgr)
 	})
 	mux.HandleFunc("GET /api/synthesis", func(w http.ResponseWriter, r *http.Request) {
 		handleSynthesis(w, r.URL.Query().Get("id"), mgr)
@@ -40,11 +45,15 @@ func main() {
 	}
 }
 
-// /api/sessions → every session, each a complete record; only synthesis is
-// served separately. Time-window filtering is the frontend's, since parsing
-// happens regardless of window.
-func handleList(w http.ResponseWriter, mgr *synthesis.Manager) {
-	sessions, err := collector.List()
+// /api/sessions → complete session records, optionally limited by an
+// epoch-millisecond activity cutoff before transcript parsing.
+func handleList(w http.ResponseWriter, r *http.Request, mgr *synthesis.Manager) {
+	since, err := parseSince(r.URL.Query().Get("since"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	sessions, err := collector.List(since)
 	if err != nil {
 		log.Printf("list sessions: %v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -59,6 +68,17 @@ func handleList(w http.ResponseWriter, mgr *synthesis.Manager) {
 	}
 	writeJSON(w, sessions)
 	log.Printf("list sessions: %d", len(sessions))
+}
+
+func parseSince(value string) (int64, error) {
+	if value == "" {
+		return 0, nil
+	}
+	since, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || since < 0 {
+		return 0, fmt.Errorf("invalid 'since' parameter")
+	}
+	return since, nil
 }
 
 // /api/synthesis?id=X → cached synthesis for one session, triggering a run

--- a/collector/internal/collector/collector.go
+++ b/collector/internal/collector/collector.go
@@ -17,7 +17,10 @@ import (
 	"github.com/centauri-ai/coslash/collector/internal/vendors/codex"
 )
 
-const maxProbeWorkers = 8
+const (
+	maxProbeWorkers     = 8
+	windowContextBuffer = 24 * time.Hour
+)
 
 type vendorSource struct {
 	name     string
@@ -26,26 +29,33 @@ type vendorSource struct {
 	parse    func(path string) (*vendors.ParsedTranscript, error)
 	metadata func() (*vendors.SessionMetadata, error) // information not extractable from logs alone
 	fork     func(parsed []*vendors.ParsedTranscript)
+	window   func(files []string, live map[string]string, since int64) []string
 }
 
 var vendorSources = []vendorSource{
 	{
 		vendors.AgentClaude, claude.Files, claude.IDFromPath,
-		claude.Parse, claude.LoadMetadata, claude.ApplyForkedUsage,
+		claude.Parse, claude.LoadMetadata, claude.ApplyForkedUsage, claude.FilesSince,
 	},
 	{
 		vendors.AgentCodex, codex.Files, codex.SessionIDFromRollout,
-		codex.Parse, codex.LoadMetadata, codex.ApplyForkedUsage,
+		codex.Parse, codex.LoadMetadata, codex.ApplyForkedUsage, codex.FilesSince,
 	},
 }
 
-func List() ([]*session.Session, error) {
-	parsed, metadata, err := collect()
+func List(since int64) ([]*session.Session, error) {
+	parsed, metadata, err := collect(max(0, since-windowContextBuffer.Milliseconds()))
 	if err != nil {
 		return nil, err
 	}
 	applyForkedUsage(parsed)
 	roots := groupSubagents(parsed, metadata)
+	if since > 0 {
+		roots = slices.DeleteFunc(roots, func(root *vendors.ParsedTranscript) bool {
+			_, live := metadata[root.Session.Agent].Live[root.Session.ID]
+			return !live && root.Session.LastActivityTime < since
+		})
+	}
 	probeEnvironment(roots)
 	resolveNames(roots, metadata)
 	resolveStatus(roots, metadata)
@@ -62,12 +72,12 @@ func applyForkedUsage(parsed []*vendors.ParsedTranscript) {
 	}
 }
 
-func collect() ([]*vendors.ParsedTranscript, map[string]*vendors.SessionMetadata, error) {
+func collect(since int64) ([]*vendors.ParsedTranscript, map[string]*vendors.SessionMetadata, error) {
 	parsed := []*vendors.ParsedTranscript{}
 	metadata := map[string]*vendors.SessionMetadata{}
 	var failures []error
 	for _, source := range vendorSources {
-		vendorParsed, vendorMetadata, err := collectAndParseVendor(source)
+		vendorParsed, vendorMetadata, err := collectAndParseVendor(source, since)
 		if err != nil {
 			log.Printf("%s session collection failed: %v; serving other vendors", source.name, err)
 			failures = append(failures, fmt.Errorf("%s: %w", source.name, err))

--- a/collector/internal/collector/helpers.go
+++ b/collector/internal/collector/helpers.go
@@ -14,6 +14,7 @@ const maxParseWorkers = 8
 
 func collectAndParseVendor(
 	source vendorSource,
+	since int64,
 ) ([]*vendors.ParsedTranscript, *vendors.SessionMetadata, error) {
 	files, err := source.files()
 	if err != nil {
@@ -22,6 +23,9 @@ func collectAndParseVendor(
 	metadata, err := source.metadata()
 	if err != nil {
 		return nil, nil, err
+	}
+	if since > 0 {
+		files = source.window(files, metadata.Live, since)
 	}
 	// parsing can be done in parallel, but file order must be preserved
 	results := make([]*vendors.ParsedTranscript, len(files))

--- a/collector/internal/vendors/claude/discovery.go
+++ b/collector/internal/vendors/claude/discovery.go
@@ -32,7 +32,6 @@ func ParentIDFromPath(path string) string {
 	}
 	return ""
 }
-
 func Files() ([]string, error) {
 	root, err := Root()
 	if err != nil {
@@ -51,4 +50,31 @@ func Files() ([]string, error) {
 		files = append(files, file)
 	}
 	return files, nil
+}
+
+// FilesSince keeps recent/live roots and every subagent file in those sessions.
+func FilesSince(files []string, live map[string]string, since int64) []string {
+	selectedRoots := map[string]struct{}{}
+	for _, file := range files {
+		if ParentIDFromPath(file) != "" {
+			continue
+		}
+		id := IDFromPath(file)
+		info, err := os.Stat(file)
+		_, isLive := live[id]
+		if err != nil || isLive || info.ModTime().UnixMilli() >= since {
+			selectedRoots[id] = struct{}{}
+		}
+	}
+	selected := make([]string, 0, len(files))
+	for _, file := range files {
+		rootID := ParentIDFromPath(file)
+		if rootID == "" {
+			rootID = IDFromPath(file)
+		}
+		if _, ok := selectedRoots[rootID]; ok {
+			selected = append(selected, file)
+		}
+	}
+	return selected
 }

--- a/collector/internal/vendors/codex/discovery.go
+++ b/collector/internal/vendors/codex/discovery.go
@@ -1,6 +1,7 @@
 package codex
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -14,6 +15,23 @@ var rolloutID = regexp.MustCompile(`[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]
 
 func SessionIDFromRollout(path string) string {
 	return rolloutID.FindString(filepath.Base(path))
+}
+
+func readHeader(path string) (string, string, bool) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", "", false
+	}
+	defer file.Close()
+	var row codexRow
+	if err := json.NewDecoder(file).Decode(&row); err != nil {
+		return "", "", false
+	}
+	id := SessionIDFromRollout(path)
+	if row.Type != "session_meta" || id == "" || row.Payload.ID != id {
+		return "", "", false
+	}
+	return id, row.Payload.ParentThreadID, true
 }
 
 // root/subagents: ~/.codex/sessions/<YYYY>/<MM>/<DD>/rollout-<timestamp>-<session-uuid>.jsonl
@@ -31,4 +49,48 @@ func Files() ([]string, error) {
 		return nil, err
 	}
 	return vendors.JSONLFilesUnder(root)
+}
+
+// FilesSince keeps recent/live roots and their complete descendant graph.
+func FilesSince(files []string, live map[string]string, since int64) []string {
+	byID := make(map[string]string, len(files))
+	children := map[string][]string{}
+	selected := map[string]struct{}{}
+	queue := []string{}
+	for _, file := range files {
+		id, parentID, ok := readHeader(file)
+		if !ok {
+			selected[file] = struct{}{}
+			continue
+		}
+		byID[id] = file
+		if parentID != "" {
+			children[parentID] = append(children[parentID], id)
+			continue
+		}
+		info, statErr := os.Stat(file)
+		_, isLive := live[id]
+		if statErr != nil || isLive || info.ModTime().UnixMilli() >= since {
+			queue = append(queue, id)
+		}
+	}
+	for i := 0; i < len(queue); i++ {
+		id := queue[i]
+		file, ok := byID[id]
+		if !ok {
+			continue
+		}
+		if _, seen := selected[file]; seen {
+			continue
+		}
+		selected[file] = struct{}{}
+		queue = append(queue, children[id]...)
+	}
+	result := make([]string, 0, len(selected))
+	for _, file := range files {
+		if _, ok := selected[file]; ok {
+			result = append(result, file)
+		}
+	}
+	return result
 }

--- a/frontend/src/pages/coslash/CoslashPage.tsx
+++ b/frontend/src/pages/coslash/CoslashPage.tsx
@@ -181,7 +181,7 @@ function CoslashContent({
 export function CoslashPage() {
   const [vendor, setVendor] = useState<AgentVendor>('all');
   const [timeWindow, setTimeWindow] = useState<TimeWindow>('week');
-  const { sessions, isLoading, loadFailed, sessionsVersion, retrySessions } = useSessions();
+  const { sessions, isLoading, loadFailed, sessionsVersion, retrySessions } = useSessions(timeWindow);
   const [view, setView] = useState<ViewMode>('list');
   const [sortKey, setSortKey] = useState<SortKey>(SortKey.Recency);
   const [sortDir, setSortDir] = useState<SortDir>('desc');

--- a/frontend/src/pages/coslash/CoslashPage.tsx
+++ b/frontend/src/pages/coslash/CoslashPage.tsx
@@ -122,7 +122,7 @@ function CoslashContent({
   visibleSessions,
   hasSessions,
   searchTerm,
-  outsideWindowMatches,
+  timeWindow,
   view,
   onSelectSession,
 }: {
@@ -131,7 +131,7 @@ function CoslashContent({
   visibleSessions: Session[];
   hasSessions: boolean;
   searchTerm: string;
-  outsideWindowMatches: number;
+  timeWindow: TimeWindow;
   view: ViewMode;
   onSelectSession: (session: Session) => void;
 }) {
@@ -148,7 +148,7 @@ function CoslashContent({
     );
   }
   if (visibleSessions.length === 0) {
-    const emptyState = sessionsEmptyStateCopy({ hasSessions, searchTerm, outsideWindowMatches });
+    const emptyState = sessionsEmptyStateCopy({ hasSessions, searchTerm, timeWindow });
     return (
       <div role="status" className="grid h-full place-items-center bg-neutral-50 text-center">
         <div>
@@ -206,16 +206,6 @@ export function CoslashPage() {
     sortKey,
     sortDir,
   );
-  const outsideWindowMatches =
-    windowStart == null
-      ? 0
-      : sessions.filter(
-          (session) =>
-            session.status == null &&
-            session.mtime < windowStart &&
-            (vendor === 'all' || session.agent === vendor) &&
-            sessionMatchesSearchTerm(session, searchTerm),
-        ).length;
 
   return (
     <div className="flex h-svh flex-col">
@@ -251,7 +241,7 @@ export function CoslashPage() {
             visibleSessions={visibleSessions}
             hasSessions={sessions.length > 0}
             searchTerm={searchTerm}
-            outsideWindowMatches={outsideWindowMatches}
+            timeWindow={timeWindow}
             view={view}
             onSelectSession={(session) => setSelectedSessionId(session.id)}
           />

--- a/frontend/src/pages/coslash/hooks/use-sessions.ts
+++ b/frontend/src/pages/coslash/hooks/use-sessions.ts
@@ -1,13 +1,12 @@
 import { useEffect, useState } from 'react';
 import type { Session } from '@/pages/coslash/lib/session';
 import { MINUTE } from '@/pages/coslash/lib/time';
+import { timeWindowStart, type TimeWindow } from '@/pages/coslash/lib/time-window';
 
 // Background refresh keeps statuses and "ago" times current.
 const REFRESH_INTERVAL_MS = MINUTE;
 
-// Fetches every session; callers filter by time window client-side, so
-// changing the window never refetches.
-export function useSessions() {
+export function useSessions(timeWindow: TimeWindow) {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [loadFailed, setLoadFailed] = useState(false);
@@ -22,7 +21,9 @@ export function useSessions() {
         setIsLoading(true);
         setLoadFailed(false);
       }
-      fetch('/api/sessions', { signal: controller.signal })
+      const since = timeWindowStart(timeWindow);
+      const path = since == null ? '/api/sessions' : `/api/sessions?since=${since}`;
+      fetch(path, { signal: controller.signal })
         .then((response) => {
           if (!response.ok) {
             throw new Error(`Sessions request failed (${response.status})`);
@@ -54,7 +55,7 @@ export function useSessions() {
       clearInterval(refresh);
       controller.abort();
     };
-  }, [retryCount]);
+  }, [retryCount, timeWindow]);
 
   const retrySessions = () => {
     setIsLoading(true);

--- a/frontend/src/pages/coslash/lib/page-copy.ts
+++ b/frontend/src/pages/coslash/lib/page-copy.ts
@@ -1,22 +1,28 @@
+import type { TimeWindow } from '@/pages/coslash/lib/time-window';
+
 export function sessionsEmptyStateCopy({
   hasSessions,
   searchTerm,
-  outsideWindowMatches,
+  timeWindow,
 }: {
   hasSessions: boolean;
   searchTerm: string;
-  outsideWindowMatches: number;
+  timeWindow: TimeWindow;
 }): { title: string; detail?: string } {
-  if (!hasSessions) return { title: 'No sessions yet.' };
+  if (!hasSessions) {
+    return timeWindow === 'all'
+      ? { title: 'No sessions yet.' }
+      : {
+          title: 'No sessions in this window.',
+          detail: 'Select “All” to view older sessions.',
+        };
+  }
 
   const term = searchTerm.trim();
   if (term !== '') {
     return {
       title: `Nothing matches “${term}” in this window.`,
-      detail:
-        outsideWindowMatches > 0
-          ? `${outsideWindowMatches} matching ${outsideWindowMatches === 1 ? 'session' : 'sessions'} outside this window.`
-          : undefined,
+      detail: timeWindow === 'all' ? undefined : 'Select “All” to search older sessions.',
     };
   }
 


### PR DESCRIPTION
## Context

The session page parsed every historical transcript before applying client-side time filtering. This made bounded views pay the full-history collection cost and scaled poorly as transcript history grew.

## Changes

- Pass the active UI time window to `/api/sessions`, while keeping All unbounded.
- Prefilter Claude session groups and Codex descendant graphs before full parsing, preserving live sessions and complete subagent data.
- Read one extra day for fork context; forks whose parents fall outside that buffer retain conservative full usage.
- Use a bounded collection for the startup synthesis sweep.

## Test

- `cd collector && go build ./...` — passed
- `cd frontend && npx oxlint src/pages/coslash/CoslashPage.tsx src/pages/coslash/hooks/use-sessions.ts` — passed
- `cd frontend && npx vite build` — passed
- Manual: This Week returned 6 matching sessions in 291 ms versus 1.72 s for All, with zero record mismatches.
