### PR TITLE
Publish tagged release artifacts and a Homebrew formula

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/homebrew/coslash.rb.erb
+++ b/.github/homebrew/coslash.rb.erb
@@ -1,7 +1,6 @@
 class Coslash < Formula
   desc "Attention layer for coding agents"
   homepage "https://github.com/centauri-ai/coslash"
-  version "<%= ENV.fetch("BREW_VERSION") %>"
   license "MIT"
 
   depends_on :macos

--- a/.github/homebrew/coslash.rb.erb
+++ b/.github/homebrew/coslash.rb.erb
@@ -1,0 +1,26 @@
+class Coslash < Formula
+  desc "Attention layer for coding agents"
+  homepage "https://github.com/centauri-ai/coslash"
+  version "<%= ENV.fetch("BREW_VERSION") %>"
+  license "MIT"
+
+  depends_on :macos
+
+  # `brew audit` rejects url/sha256 inside on_arm/on_intel, so the architecture
+  # is resolved here instead.
+  if Hardware::CPU.arm?
+    url "https://github.com/centauri-ai/coslash/releases/download/<%= ENV.fetch("RELEASE_TAG") %>/coslash_<%= ENV.fetch("RELEASE_TAG") %>_darwin_arm64.tar.gz"
+    sha256 "<%= ENV.fetch("ARM_SHA") %>"
+  else
+    url "https://github.com/centauri-ai/coslash/releases/download/<%= ENV.fetch("RELEASE_TAG") %>/coslash_<%= ENV.fetch("RELEASE_TAG") %>_darwin_amd64.tar.gz"
+    sha256 "<%= ENV.fetch("INTEL_SHA") %>"
+  end
+
+  def install
+    bin.install "coslash"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/coslash --version")
+  end
+end

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,8 +149,6 @@ jobs:
             fi
           fi
 
-          # Homebrew is the supported install path, so the notes lead with it
-          # rather than with the raw artifacts.
           notes=$(mktemp)
           cat >"$notes" <<'NOTES'
           ## Install
@@ -162,10 +160,23 @@ jobs:
 
           Already tapped? `brew upgrade coslash`.
 
-          The `.tar.gz` assets below are for manual installs. Verify them with
-          `shasum -a 256 -c checksums.txt`. The binaries are unsigned and
-          unnotarized, so macOS may warn about an archive downloaded through a
-          browser; the Homebrew install above is not affected.
+          The `.tar.gz` assets below are for manual installs:
+
+          ```sh
+          VERSION=v0.0.1
+          ARCH=arm64  # or amd64 on Intel
+          ASSET="coslash_${VERSION}_darwin_${ARCH}.tar.gz"
+          BASE_URL="https://github.com/centauri-ai/coslash/releases/download/${VERSION}"
+          curl -fLO "${BASE_URL}/${ASSET}"
+          curl -fLO "${BASE_URL}/checksums.txt"
+          grep -F "  ${ASSET}" checksums.txt | shasum -a 256 -c -
+          tar -xzf "${ASSET}"
+          "${ASSET%.tar.gz}/coslash"
+          ```
+
+          Substitute the release version and architecture. The binaries are
+          unsigned and unnotarized, so macOS may warn about an archive downloaded
+          through a browser; the Homebrew install above is not affected.
           NOTES
 
           if ! gh release view "$TAG" >/dev/null 2>&1; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,7 +254,7 @@ jobs:
           if [[ ! -f "$formula" ]]; then
             exit 0
           fi
-          current_version="$(ruby -ne 'if $_ =~ /^\s*version "([^"]+)"/; puts $1; exit; end' "$formula")"
+          current_version="$(ruby -ne 'if $_ =~ %r{/releases/download/v([^/]+)/}; puts $1; exit; end' "$formula")"
           if [[ -z "$current_version" ]]; then
             echo "error: could not read the current tap version" >&2
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,19 +13,15 @@ permissions:
   contents: read
 
 jobs:
-  release:
+  build:
     runs-on: macos-15
-    permissions:
-      contents: write
     steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: collector/go.mod
           cache: false
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: frontend/.nvmrc
           cache: npm
@@ -44,7 +40,7 @@ jobs:
         env:
           VERSION: ${{ inputs.version || github.ref_name }}
         run: make -C collector dist VERSION="$VERSION"
-      - name: Smoke-test packaged binaries
+      - name: Smoke-test Apple silicon package
         env:
           VERSION: ${{ inputs.version || github.ref_name }}
         run: |
@@ -75,21 +71,82 @@ jobs:
           wait "$server_pid" 2>/dev/null || true
           server_pid=
 
-          intel_stem="coslash_${VERSION}_darwin_amd64"
-          tar -xzf "collector/dist/${intel_stem}.tar.gz" -C "$smoke_dir"
-          file "$smoke_dir/$intel_stem/coslash" | grep -q 'Mach-O 64-bit executable x86_64'
           (cd collector/dist && shasum -a 256 -c checksums.txt)
+      - name: Save release artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-artifacts
+          path: |
+            collector/dist/*.tar.gz
+            collector/dist/checksums.txt
+          if-no-files-found: error
+          retention-days: 1
+
+  smoke-intel:
+    needs: build
+    runs-on: macos-15-intel
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: release-artifacts
+          path: dist
+      - name: Smoke-test Intel package
+        env:
+          VERSION: ${{ inputs.version || github.ref_name }}
+        run: |
+          set -euo pipefail
+          smoke_dir="$(mktemp -d)"
+          server_pid=
+          cleanup() {
+            if [[ -n "$server_pid" ]]; then
+              kill "$server_pid" 2>/dev/null || true
+              wait "$server_pid" 2>/dev/null || true
+            fi
+            rm -rf "$smoke_dir"
+          }
+          trap cleanup EXIT
+
+          intel_stem="coslash_${VERSION}_darwin_amd64"
+          tar -xzf "dist/${intel_stem}.tar.gz" -C "$smoke_dir"
+          intel_binary="$smoke_dir/$intel_stem/coslash"
+          [[ "$("$intel_binary" --version)" == "$VERSION" ]]
+
+          "$intel_binary" --no-open --port 8787 >"$smoke_dir/server.log" 2>&1 &
+          server_pid=$!
+          curl --retry 20 --retry-delay 1 --retry-connrefused -sf \
+            http://127.0.0.1:8787/ -o "$smoke_dir/index.html"
+          grep -q '<div id="root"' "$smoke_dir/index.html"
+          curl -sf http://127.0.0.1:8787/api/sessions | python3 -m json.tool >/dev/null
+          kill "$server_pid"
+          wait "$server_pid" 2>/dev/null || true
+          server_pid=
+          (cd dist && shasum -a 256 -c checksums.txt)
+
+  publish:
+    needs: [build, smoke-intel]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    runs-on: macos-15
+    permissions:
+      contents: write
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: release-artifacts
+          path: dist
       - name: Publish
-        if: startsWith(github.ref, 'refs/tags/')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          assets=(collector/dist/*.tar.gz collector/dist/checksums.txt)
+          assets=(dist/*.tar.gz dist/checksums.txt)
           if gh release view "$TAG" >/dev/null 2>&1; then
-            gh release upload "$TAG" "${assets[@]}" --clobber
-            exit 0
+            if [[ "$(gh release view "$TAG" --json isDraft --jq .isDraft)" != true ]]; then
+              echo "error: release $TAG is already public; refusing to replace its assets" >&2
+              exit 1
+            fi
           fi
 
           # Homebrew is the supported install path, so the notes lead with it
@@ -111,40 +168,59 @@ jobs:
           browser; the Homebrew install above is not affected.
           NOTES
 
-          create=(gh release create "$TAG" "${assets[@]}"
-            --title "$TAG" --notes-file "$notes" --generate-notes)
-          if [[ "$TAG" == *-* ]]; then
-            create+=(--prerelease)
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            create=(gh release create "$TAG" --draft
+              --title "$TAG" --notes-file "$notes" --generate-notes)
+            if [[ "$TAG" == *-* ]]; then
+              create+=(--prerelease)
+            fi
+            "${create[@]}"
           fi
-          "${create[@]}"
+
+          existing_dir="$(mktemp -d)"
+          for asset in "${assets[@]}"; do
+            name="${asset##*/}"
+            if gh release view "$TAG" --json assets --jq '.assets[].name' | grep -Fxq "$name"; then
+              gh release download "$TAG" --pattern "$name" --dir "$existing_dir"
+              if ! cmp -s "$asset" "$existing_dir/$name"; then
+                echo "error: draft already contains a different $name" >&2
+                exit 1
+              fi
+            else
+              gh release upload "$TAG" "$asset"
+            fi
+          done
+
+          verify_dir="$(mktemp -d)"
+          gh release download "$TAG" --pattern '*.tar.gz' --pattern checksums.txt --dir "$verify_dir"
+          for asset in "${assets[@]}"; do
+            cmp "$asset" "$verify_dir/${asset##*/}"
+          done
+          (cd "$verify_dir" && shasum -a 256 -c checksums.txt)
+          gh release edit "$TAG" --draft=false
 
   bump-homebrew:
-    needs: release
+    needs: publish
     if: >-
+      github.event_name == 'push' &&
       startsWith(github.ref, 'refs/tags/') &&
       !contains(github.ref_name, '-')
     runs-on: macos-15
+    concurrency:
+      group: homebrew-tap-coslash
+      cancel-in-progress: false
     steps:
       - name: Check out coSlash
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           path: coslash
       - name: Check out Homebrew tap
-        uses: actions/checkout@v5
-        with:
-          repository: centauri-ai/homebrew-tap
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          path: tap
+        run: git clone --depth 1 https://github.com/centauri-ai/homebrew-tap.git tap
       - name: Download and verify release assets
         env:
           TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "error: Homebrew bumps require a stable semver tag" >&2
-            exit 1
-          fi
-
           mkdir downloads
           base_url="https://github.com/centauri-ai/coslash/releases/download/$TAG"
           arm_asset="coslash_${TAG}_darwin_arm64.tar.gz"
@@ -160,10 +236,34 @@ jobs:
             echo "ARM_SHA=$(shasum -a 256 "downloads/$arm_asset" | awk '{print $1}')"
             echo "INTEL_SHA=$(shasum -a 256 "downloads/$intel_asset" | awk '{print $1}')"
           } >> "$GITHUB_ENV"
+      - name: Reject stale tap update
+        run: |
+          set -euo pipefail
+          formula=tap/Formula/coslash.rb
+          if [[ ! -f "$formula" ]]; then
+            exit 0
+          fi
+          current_version="$(ruby -ne 'if $_ =~ /^\s*version "([^"]+)"/; puts $1; exit; end' "$formula")"
+          if [[ -z "$current_version" ]]; then
+            echo "error: could not read the current tap version" >&2
+            exit 1
+          fi
+          if ruby -rrubygems -e 'exit(Gem::Version.new(ARGV[0]) < Gem::Version.new(ARGV[1]) ? 0 : 1)' "$BREW_VERSION" "$current_version"; then
+            echo "error: refusing to replace $current_version with older version $BREW_VERSION" >&2
+            exit 1
+          fi
       - name: Render formula
         run: |
           mkdir -p tap/Formula
           ruby -rerb -e 'File.write(ARGV[1], ERB.new(File.read(ARGV[0]), trim_mode: "-").result)' coslash/.github/homebrew/coslash.rb.erb tap/Formula/coslash.rb
+      - name: Validate formula
+        working-directory: tap
+        run: |
+          tap_dir="$(brew --repository)/Library/Taps/centauri-ai/homebrew-tap"
+          mkdir -p "${tap_dir%/*}"
+          ln -s "$GITHUB_WORKSPACE/tap" "$tap_dir"
+          brew style --formula centauri-ai/tap/coslash
+          brew audit --strict centauri-ai/tap/coslash
       - name: Commit formula
         working-directory: tap
         env:
@@ -178,4 +278,8 @@ jobs:
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git commit -m "coslash $TAG"
-          git push
+      - name: Push formula
+        working-directory: tap
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: git push "https://x-access-token:${TAP_TOKEN}@github.com/centauri-ai/homebrew-tap.git" HEAD:main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,181 @@
+name: release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to build and smoke-test without publishing, e.g. v0.0.1-test"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: macos-15
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: collector/go.mod
+          cache: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: frontend/.nvmrc
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Validate version
+        env:
+          VERSION: ${{ inputs.version || github.ref_name }}
+        run: |
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            echo "error: version must be a tag such as v0.0.1 or v0.0.1-rc.1" >&2
+            exit 1
+          fi
+      - name: Test
+        run: make -C collector test
+      - name: Package
+        env:
+          VERSION: ${{ inputs.version || github.ref_name }}
+        run: make -C collector dist VERSION="$VERSION"
+      - name: Smoke-test packaged binaries
+        env:
+          VERSION: ${{ inputs.version || github.ref_name }}
+        run: |
+          set -euo pipefail
+          smoke_dir="$(mktemp -d)"
+          server_pid=
+          cleanup() {
+            if [[ -n "$server_pid" ]]; then
+              kill "$server_pid" 2>/dev/null || true
+              wait "$server_pid" 2>/dev/null || true
+            fi
+            rm -rf "$smoke_dir"
+          }
+          trap cleanup EXIT
+
+          arm_stem="coslash_${VERSION}_darwin_arm64"
+          tar -xzf "collector/dist/${arm_stem}.tar.gz" -C "$smoke_dir"
+          arm_binary="$smoke_dir/$arm_stem/coslash"
+          [[ "$("$arm_binary" --version)" == "$VERSION" ]]
+
+          "$arm_binary" --no-open --port 8787 >"$smoke_dir/server.log" 2>&1 &
+          server_pid=$!
+          curl --retry 20 --retry-delay 1 --retry-connrefused -sf \
+            http://127.0.0.1:8787/ -o "$smoke_dir/index.html"
+          grep -q '<div id="root"' "$smoke_dir/index.html"
+          curl -sf http://127.0.0.1:8787/api/sessions | python3 -m json.tool >/dev/null
+          kill "$server_pid"
+          wait "$server_pid" 2>/dev/null || true
+          server_pid=
+
+          intel_stem="coslash_${VERSION}_darwin_amd64"
+          tar -xzf "collector/dist/${intel_stem}.tar.gz" -C "$smoke_dir"
+          file "$smoke_dir/$intel_stem/coslash" | grep -q 'Mach-O 64-bit executable x86_64'
+          (cd collector/dist && shasum -a 256 -c checksums.txt)
+      - name: Publish
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          assets=(collector/dist/*.tar.gz collector/dist/checksums.txt)
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release upload "$TAG" "${assets[@]}" --clobber
+            exit 0
+          fi
+
+          # Homebrew is the supported install path, so the notes lead with it
+          # rather than with the raw artifacts.
+          notes=$(mktemp)
+          cat >"$notes" <<'NOTES'
+          ## Install
+
+          ```sh
+          brew install centauri-ai/tap/coslash
+          coslash
+          ```
+
+          Already tapped? `brew upgrade coslash`.
+
+          The `.tar.gz` assets below are for manual installs. Verify them with
+          `shasum -a 256 -c checksums.txt`. The binaries are unsigned and
+          unnotarized, so macOS may warn about an archive downloaded through a
+          browser; the Homebrew install above is not affected.
+          NOTES
+
+          create=(gh release create "$TAG" "${assets[@]}"
+            --title "$TAG" --notes-file "$notes" --generate-notes)
+          if [[ "$TAG" == *-* ]]; then
+            create+=(--prerelease)
+          fi
+          "${create[@]}"
+
+  bump-homebrew:
+    needs: release
+    if: >-
+      startsWith(github.ref, 'refs/tags/') &&
+      !contains(github.ref_name, '-')
+    runs-on: macos-15
+    steps:
+      - name: Check out coSlash
+        uses: actions/checkout@v5
+        with:
+          path: coslash
+      - name: Check out Homebrew tap
+        uses: actions/checkout@v5
+        with:
+          repository: centauri-ai/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap
+      - name: Download and verify release assets
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "error: Homebrew bumps require a stable semver tag" >&2
+            exit 1
+          fi
+
+          mkdir downloads
+          base_url="https://github.com/centauri-ai/coslash/releases/download/$TAG"
+          arm_asset="coslash_${TAG}_darwin_arm64.tar.gz"
+          intel_asset="coslash_${TAG}_darwin_amd64.tar.gz"
+          curl -fL "$base_url/$arm_asset" -o "downloads/$arm_asset"
+          curl -fL "$base_url/$intel_asset" -o "downloads/$intel_asset"
+          curl -fL "$base_url/checksums.txt" -o downloads/checksums.txt
+          (cd downloads && shasum -a 256 -c checksums.txt)
+
+          {
+            echo "BREW_VERSION=${TAG#v}"
+            echo "RELEASE_TAG=$TAG"
+            echo "ARM_SHA=$(shasum -a 256 "downloads/$arm_asset" | awk '{print $1}')"
+            echo "INTEL_SHA=$(shasum -a 256 "downloads/$intel_asset" | awk '{print $1}')"
+          } >> "$GITHUB_ENV"
+      - name: Render formula
+        run: |
+          mkdir -p tap/Formula
+          ruby -rerb -e 'File.write(ARGV[1], ERB.new(File.read(ARGV[0]), trim_mode: "-").result)' coslash/.github/homebrew/coslash.rb.erb tap/Formula/coslash.rb
+      - name: Commit formula
+        working-directory: tap
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          git add Formula/coslash.rb
+          if git diff --cached --quiet; then
+            echo "Formula already matches $TAG"
+            exit 0
+          fi
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git commit -m "coslash $TAG"
+          git push

--- a/README.md
+++ b/README.md
@@ -21,15 +21,18 @@ you want:
 ```sh
 VERSION=v0.0.1
 ARCH=arm64  # or amd64 on Intel
-curl -LO "https://github.com/centauri-ai/coslash/releases/download/${VERSION}/coslash_${VERSION}_darwin_${ARCH}.tar.gz"
-tar -xzf "coslash_${VERSION}_darwin_${ARCH}.tar.gz"
-"coslash_${VERSION}_darwin_${ARCH}/coslash"
+ASSET="coslash_${VERSION}_darwin_${ARCH}.tar.gz"
+BASE_URL="https://github.com/centauri-ai/coslash/releases/download/${VERSION}"
+curl -fLO "${BASE_URL}/${ASSET}"
+curl -fLO "${BASE_URL}/checksums.txt"
+grep -F "  ${ASSET}" checksums.txt | shasum -a 256 -c -
+tar -xzf "${ASSET}"
+"${ASSET%.tar.gz}/coslash"
 ```
 
-Every release publishes a `checksums.txt`; verify with
-`shasum -a 256 -c checksums.txt`. The binaries are unsigned, so macOS may warn
-about an archive you downloaded through a browser — the Homebrew install above
-is the supported path and is not affected.
+The binaries are unsigned, so macOS may warn about an archive you downloaded
+through a browser — the Homebrew install above is the supported path and is not
+affected.
 
 Running `coslash` starts one executable at
 [http://127.0.0.1:8787](http://127.0.0.1:8787) and opens a browser. There is no

--- a/README.md
+++ b/README.md
@@ -4,7 +4,44 @@
 
 The attention layer for coding agents. coSlash watches your local Claude Code and Codex sessions, reconstructs what each one was doing — goal, decisions, files, commits, next step — and shows which ones need you. Resume any session in its terminal, or copy a handoff brief and pick it up cold.
 
-## Quick start
+## Install
+
+coSlash ships prebuilt binaries for macOS on Apple silicon and Intel.
+
+```sh
+brew install centauri-ai/tap/coslash
+coslash
+```
+
+`brew upgrade coslash` moves to a newer release; `brew uninstall coslash` removes it.
+
+Or download a release archive directly, substituting the version and architecture
+you want:
+
+```sh
+VERSION=v0.0.1
+ARCH=arm64  # or amd64 on Intel
+curl -LO "https://github.com/centauri-ai/coslash/releases/download/${VERSION}/coslash_${VERSION}_darwin_${ARCH}.tar.gz"
+tar -xzf "coslash_${VERSION}_darwin_${ARCH}.tar.gz"
+"coslash_${VERSION}_darwin_${ARCH}/coslash"
+```
+
+Every release publishes a `checksums.txt`; verify with
+`shasum -a 256 -c checksums.txt`. The binaries are unsigned, so macOS may warn
+about an archive you downloaded through a browser — the Homebrew install above
+is the supported path and is not affected.
+
+Running `coslash` starts one executable at
+[http://127.0.0.1:8787](http://127.0.0.1:8787) and opens a browser. There is no
+Node, Vite, or second process at runtime.
+
+| Flag | Effect |
+| --- | --- |
+| `--port N` | serve on port N (default `8787`) |
+| `--no-open` | do not open the browser |
+| `--version` | print the version and exit |
+
+## Build from source
 
 **Prerequisites:** Go 1.26+ and Node 24+ (Node is only needed to build).
 
@@ -14,13 +51,10 @@ make release
 ./bin/coslash
 ```
 
-That builds the frontend, embeds it, and starts one executable at [http://127.0.0.1:8787](http://127.0.0.1:8787). No Node, Vite, or second process at runtime — the browser should open on its own.
-
-| Flag | Effect |
-| --- | --- |
-| `--port N` | serve on port N (default `8787`) |
-| `--no-open` | do not open the browser |
-| `--version` | print the version and exit |
+That builds the frontend, embeds it into the binary, and leaves it at
+`collector/bin/coslash`. `make dist` instead cross-compiles both macOS
+architectures into `collector/dist/` with a `checksums.txt`, which is what the
+release workflow publishes.
 
 ## Develop
 

--- a/collector/.gitignore
+++ b/collector/.gitignore
@@ -1,4 +1,5 @@
 /bin/
+/dist/
 .DS_Store
 
 # Frontend assets staged for go:embed by `make release`.

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -2,10 +2,12 @@ BINARY := coslash
 PKG := ./cmd/coslash
 FRONTEND := ../frontend
 STAGED := internal/web/dist
-VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+DIST := dist
+PLATFORMS := darwin/arm64 darwin/amd64
 ARGS :=
 
-.PHONY: build run test check tidy clean release stage unstage smoke smoke-dev
+.PHONY: build run test check tidy clean release stage unstage smoke smoke-dev dist
 
 release: stage
 	go build -ldflags '-X main.version=$(VERSION)' -o bin/$(BINARY) $(PKG)
@@ -21,6 +23,26 @@ stage:
 	mkdir -p $(STAGED)
 	cp -R $(FRONTEND)/dist/. $(STAGED)/
 	touch $(STAGED)/.gitkeep
+
+# Cross-compile every shipped platform from one staged frontend build.
+dist: stage
+	@test -f $(STAGED)/index.html || { \
+		echo "error: $(STAGED)/index.html is missing; refusing to package a binary with no frontend"; exit 1; }
+	rm -rf $(DIST)
+	mkdir -p $(DIST)
+	@for platform in $(PLATFORMS); do \
+		goos=$${platform%/*}; goarch=$${platform#*/}; \
+		stem=$(BINARY)_$(VERSION)_$${goos}_$${goarch}; \
+		mkdir -p $(DIST)/$$stem; \
+		CGO_ENABLED=0 GOOS=$$goos GOARCH=$$goarch \
+			go build -trimpath -ldflags '-s -w -X main.version=$(VERSION)' \
+			-o $(DIST)/$$stem/$(BINARY) $(PKG) || exit 1; \
+		cp ../LICENSE ../README.md $(DIST)/$$stem/; \
+		tar -czf $(DIST)/$$stem.tar.gz -C $(DIST) $$stem; \
+		rm -rf $(DIST)/$$stem; \
+		echo "packaged $(DIST)/$$stem.tar.gz"; \
+	done
+	cd $(DIST) && shasum -a 256 *.tar.gz > checksums.txt
 
 # Without this a build after `make release` would embed that release's frontend.
 unstage:
@@ -54,4 +76,4 @@ tidy:
 	go mod tidy
 
 clean: unstage
-	rm -rf bin
+	rm -rf bin $(DIST)

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -38,7 +38,8 @@ dist: stage
 			go build -trimpath -ldflags '-s -w -X main.version=$(VERSION)' \
 			-o $(DIST)/$$stem/$(BINARY) $(PKG) || exit 1; \
 		cp ../LICENSE ../README.md $(DIST)/$$stem/; \
-		tar -czf $(DIST)/$$stem.tar.gz -C $(DIST) $$stem; \
+		find $(DIST)/$$stem -exec touch -t 198001010000 {} +; \
+		COPYFILE_DISABLE=1 tar --format ustar -cf - -C $(DIST) $$stem | gzip -n > $(DIST)/$$stem.tar.gz; \
 		rm -rf $(DIST)/$$stem; \
 		echo "packaged $(DIST)/$$stem.tar.gz"; \
 	done


### PR DESCRIPTION
## Context

coSlash has no published binaries, so the only way to get it is to clone the
repository and build it with Go and Node. This adds a tagged release path that
produces macOS binaries and a Homebrew formula, making install and upgrade a
single command. Binaries ship unsigned and unnotarized for the first release,
with Homebrew rather than direct download as the supported install path.

Depends on #8, which adds `--version` and the embedded frontend. This branch
builds and packages on its own, but the packaged binary is only complete once
#8 lands, so do not cut a tag before then. The two branches touch the same
Makefile and README sections with identical content, so the second merge will
need a trivial conflict resolution.

## Changes

- A `v*` tag builds macOS arm64 and amd64 binaries, publishes SHA-256
  checksums, and creates the GitHub release. Release notes lead with the
  Homebrew install command rather than the raw artifacts.
- A second job renders the formula for the tag, re-verifies the published
  checksums, and commits it to the tap repository. It runs only for stable
  semver tags, so prereleases publish artifacts without moving the tap.
- Before publishing, the workflow extracts the packaged binary and checks
  `--version`, the embedded UI, and the API, so a build that produces a broken
  binary cannot become a release.
- `make dist` cross-compiles both architectures from a single frontend build
  and writes `checksums.txt`. `make release` still builds one local binary.
- The formula resolves architecture with `Hardware::CPU` rather than
  `on_arm`/`on_intel` blocks, which `brew audit` rejects for `url` and `sha256`.
- `workflow_dispatch` builds and smoke-tests without publishing, so the
  pipeline can be exercised without spending a tag.

Publishing requires the tap repository to exist and a token secret with write
access to it; without both, the formula job fails after the release succeeds.

## Test

Validated against #8 merged in locally, since the packaged binary needs it.

- `make -C collector test` — passed
- `make -C collector dist VERSION=v1.2.3-test` — passed; two archives plus
  `checksums.txt`, verified with `shasum -a 256 -c`
- Manual: extracted the packaged arm64 binary and confirmed `--version`, the
  embedded UI at `/`, and `/api/sessions`
- Manual: rendered the formula into a local tap — `brew style` and
  `brew audit` clean, then install, `brew test`, upgrade to a newer version,
  and uninstall all succeeded
- Manual: confirmed the installed binary carries no `com.apple.quarantine`
  attribute and launches with no Gatekeeper override

Not covered: Intel install (no Intel hardware available), the HTTPS download
path (local testing used `file://`), and the tap-publish job.