### PR TITLE
ci: add pull-request CI for the release codepath

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,115 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: frontend/.nvmrc
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install frontend dependencies
+        run: npm ci
+      - name: Lint frontend
+        run: npm run lint
+      - name: Check frontend formatting
+        run: npm run format:check
+      - name: Test frontend
+        run: npm test
+
+  collector:
+    name: Collector
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: collector
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: collector/go.mod
+          # This module has no dependencies or go.sum to cache.
+          cache: false
+      - name: Check collector
+        run: make check
+      - name: Test collector
+        run: make test
+
+  release:
+    name: Release
+    runs-on: macos-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: collector
+    steps:
+      - name: Check out repository with tags
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: frontend/.nvmrc
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: collector/go.mod
+          # This module has no dependencies or go.sum to cache.
+          cache: false
+      - name: Build release binary
+        run: make release
+      - name: Verify release leaves worktree clean
+        run: |
+          status=$(git status --porcelain)
+          if [[ -n "$status" ]]; then
+            echo "Release build dirtied the worktree:"
+            echo "$status"
+            exit 1
+          fi
+      - name: Smoke test embedded frontend
+        run: make smoke
+      - name: Preserve release binary
+        run: cp bin/coslash bin/coslash-release
+      - name: Build development binary
+        run: make build
+      - name: Smoke test development binary
+        run: make smoke-dev
+      - name: Upload release binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: coslash-macos
+          path: collector/bin/coslash-release
+          retention-days: 7
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.event_name == 'pull_request' && format('{0}-pr-{1}', github.workflow, github.event.pull_request.number) || format('{0}-{1}', github.workflow, github.run_id) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 defaults:
@@ -27,9 +27,9 @@ jobs:
         working-directory: frontend
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version-file: frontend/.nvmrc
           cache: npm
@@ -54,9 +54,9 @@ jobs:
         working-directory: collector
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: collector/go.mod
           # This module has no dependencies or go.sum to cache.
@@ -75,17 +75,17 @@ jobs:
         working-directory: collector
     steps:
       - name: Check out repository with tags
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version-file: frontend/.nvmrc
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: collector/go.mod
           # This module has no dependencies or go.sum to cache.
@@ -109,7 +109,7 @@ jobs:
       - name: Smoke test development binary
         run: make smoke-dev
       - name: Upload release binary
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coslash-macos
           path: collector/bin/coslash-release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
         run: npm run format:check
       - name: Test frontend
         run: npm test
+      - name: Build frontend
+        run: npm run build
 
   collector:
     name: Collector

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # coSlash
 
+[![CI](https://github.com/centauri-ai/coslash/actions/workflows/ci.yml/badge.svg)](https://github.com/centauri-ai/coslash/actions/workflows/ci.yml)
+
 The attention layer for coding agents. coSlash watches your local Claude Code and Codex sessions, reconstructs what each one was doing — goal, decisions, files, commits, next step — and shows which ones need you. Resume any session in its terminal, or copy a handoff brief and pick it up cold.
 
 ## Quick start

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -5,7 +5,7 @@ STAGED := internal/web/dist
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 ARGS :=
 
-.PHONY: build run test tidy clean release stage unstage
+.PHONY: build run test check tidy clean release stage unstage smoke smoke-dev
 
 release: stage
 	go build -ldflags '-X main.version=$(VERSION)' -o bin/$(BINARY) $(PKG)
@@ -36,6 +36,19 @@ run: unstage
 
 test:
 	go test ./...
+
+check:
+	@unformatted=$$(gofmt -l .); \
+		test -z "$$unformatted" || { echo "gofmt needed:"; echo "$$unformatted"; exit 1; }
+	go vet ./...
+
+# Checks the release binary over HTTP; run `make release` first.
+smoke:
+	./scripts/smoke.sh bin/$(BINARY) embedded
+
+# Checks that a dev binary embeds no frontend; run `make build` first.
+smoke-dev:
+	./scripts/smoke.sh bin/$(BINARY) bare
 
 tidy:
 	go mod tidy

--- a/collector/internal/vendors/claude/birthtime_darwin.go
+++ b/collector/internal/vendors/claude/birthtime_darwin.go
@@ -1,0 +1,16 @@
+package claude
+
+import (
+	"os"
+	"syscall"
+)
+
+// birthtime reports the file's creation time in Unix milliseconds. Only darwin
+// exposes it on Stat_t, so other platforms get the fallback in birthtime_other.go.
+func birthtime(info os.FileInfo) (int64, bool) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, false
+	}
+	return stat.Birthtimespec.Sec*1000 + stat.Birthtimespec.Nsec/1_000_000, true
+}

--- a/collector/internal/vendors/claude/birthtime_other.go
+++ b/collector/internal/vendors/claude/birthtime_other.go
@@ -1,0 +1,12 @@
+//go:build !darwin
+
+package claude
+
+import "os"
+
+// birthtime has no portable source outside darwin, so callers fall back to the
+// modification time. Fork ordering only needs birthtime to break ties, and the
+// collector ships for macOS.
+func birthtime(os.FileInfo) (int64, bool) {
+	return 0, false
+}

--- a/collector/internal/vendors/claude/fork.go
+++ b/collector/internal/vendors/claude/fork.go
@@ -3,7 +3,6 @@ package claude
 import (
 	"log"
 	"os"
-	"syscall"
 
 	"github.com/centauri-ai/coslash/collector/internal/vendors"
 )
@@ -127,9 +126,8 @@ func fileCreationTime(path string) int64 {
 		log.Printf("%s: stat for fork ordering failed: %v", path, err)
 		return 0
 	}
-	stat, ok := info.Sys().(*syscall.Stat_t)
-	if !ok {
-		return info.ModTime().UnixMilli()
+	if created, ok := birthtime(info); ok {
+		return created
 	}
-	return stat.Birthtimespec.Sec*1000 + stat.Birthtimespec.Nsec/1_000_000
+	return info.ModTime().UnixMilli()
 }

--- a/collector/scripts/smoke.sh
+++ b/collector/scripts/smoke.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  echo "usage: scripts/smoke.sh <binary> <embedded|bare>" >&2
+}
+
+if [[ $# -ne 2 ]]; then
+  usage
+  exit 2
+fi
+
+binary=$1
+mode=$2
+if [[ ! -x "$binary" ]]; then
+  echo "error: binary is not executable: $binary" >&2
+  exit 1
+fi
+if [[ "$mode" != "embedded" && "$mode" != "bare" ]]; then
+  usage
+  exit 2
+fi
+
+smoke_home=$(mktemp -d)
+server_pid=
+
+cleanup() {
+  if [[ -n "$server_pid" ]] && kill -0 "$server_pid" 2>/dev/null; then
+    kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+  fi
+  rm -rf -- "$smoke_home"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+response_body="$smoke_home/response-body"
+server_log="$smoke_home/server.log"
+readiness_path=/
+if [[ "$mode" == "bare" ]]; then
+  readiness_path=/api/sessions
+fi
+
+base_url=
+for port in 18787 18788 18789; do
+  : >"$server_log"
+  env HOME="$smoke_home" "$binary" --no-open --port "$port" >"$server_log" 2>&1 &
+  server_pid=$!
+
+  ready=false
+  for ((attempt = 1; attempt <= 40; attempt++)); do
+    if ! kill -0 "$server_pid" 2>/dev/null; then
+      break
+    fi
+    if grep -Fq "listening on http://127.0.0.1:$port" "$server_log" &&
+      curl -fs -o /dev/null "http://127.0.0.1:$port$readiness_path" &&
+      kill -0 "$server_pid" 2>/dev/null; then
+      ready=true
+      break
+    fi
+    sleep 0.25
+  done
+
+  if [[ "$ready" == "true" ]]; then
+    base_url="http://127.0.0.1:$port"
+    echo "server ready on $base_url ($mode mode)"
+    break
+  fi
+
+  if kill -0 "$server_pid" 2>/dev/null; then
+    echo "error: server did not become ready on port $port" >&2
+    cat "$server_log" >&2
+    exit 1
+  fi
+
+  wait "$server_pid" 2>/dev/null || true
+  server_pid=
+done
+
+if [[ -z "$base_url" ]]; then
+  echo "error: server failed to start on candidate ports 18787, 18788, and 18789" >&2
+  cat "$server_log" >&2
+  exit 1
+fi
+
+expect_status() {
+  local path=$1
+  local expected=$2
+  local actual
+
+  echo "GET $path -> expecting $expected"
+  if ! actual=$(curl -sS -o "$response_body" -w '%{http_code}' "$base_url$path"); then
+    echo "error: GET $path failed" >&2
+    exit 1
+  fi
+  if [[ "$actual" != "$expected" ]]; then
+    echo "error: GET $path: expected $expected, got $actual" >&2
+    cat "$response_body" >&2
+    exit 1
+  fi
+}
+
+assert_contains() {
+  local value=$1
+  local description=$2
+  if ! grep -Fq "$value" "$response_body"; then
+    echo "error: response did not contain $description" >&2
+    cat "$response_body" >&2
+    exit 1
+  fi
+}
+
+if [[ "$mode" == "embedded" ]]; then
+  expect_status / 200
+  assert_contains '<div id="root"' 'the application root'
+  assert_contains '<title>coSlash' 'the application title'
+
+  asset=$(grep -Eo '/assets/[^\"]*\.js' "$response_body" | sed -n '1p' || true)
+  if [[ -z "$asset" ]]; then
+    echo "error: application document did not reference a JavaScript asset" >&2
+    cat "$response_body" >&2
+    exit 1
+  fi
+  expect_status "$asset" 200
+
+  expect_status /coslash 200
+  assert_contains '<div id="root"' 'the application root'
+
+  expect_status /assets/does-not-exist.js 404
+
+  expect_status /api/nope 404
+  if grep -Fq '<div id="root"' "$response_body"; then
+    echo "error: unrouted API path returned the application document" >&2
+    cat "$response_body" >&2
+    exit 1
+  fi
+
+  expect_status /api/sessions 200
+  if command -v jq >/dev/null 2>&1; then
+    if ! jq -e type "$response_body" >/dev/null; then
+      echo "error: /api/sessions did not return valid JSON" >&2
+      cat "$response_body" >&2
+      exit 1
+    fi
+  elif ! grep -Eq '^[[:space:]]*[\[{]' "$response_body"; then
+    echo "error: /api/sessions did not look like JSON" >&2
+    cat "$response_body" >&2
+    exit 1
+  fi
+
+  version=$("$binary" --version)
+  echo "version -> $version"
+  if [[ -z "$version" || "$version" == "dev" ]]; then
+    echo "error: release binary has an invalid version: ${version:-<empty>}" >&2
+    exit 1
+  fi
+else
+  expect_status / 503
+  expect_status /api/sessions 200
+fi
+
+echo "smoke test passed ($mode mode)"

--- a/frontend/src/pages/coslash/CoslashPage.tsx
+++ b/frontend/src/pages/coslash/CoslashPage.tsx
@@ -38,11 +38,9 @@ const WINDOW_ACTIVITY_LABELS: Record<TimeWindow, string> = {
 
 function CoslashPageHeader() {
   return (
-      <div className="flex items-center gap-2 px-4">
-        <img src="/brand/coslash-logo.svg" alt="coSlash" className="h-12" />
-        <span className="text-muted-foreground text-sm font-medium">
-        Run more agents. Lose less context.
-      </span>
+    <div className="flex items-center gap-2 px-4">
+      <img src="/brand/coslash-logo.svg" alt="coSlash" className="h-12" />
+      <span className="text-muted-foreground text-sm font-medium">Run more agents. Lose less context.</span>
     </div>
   );
 }
@@ -85,7 +83,7 @@ function SessionsStats({
     <div className="flex w-full min-w-0 items-center justify-between gap-3">
       <div className="text-muted-foreground flex min-w-0 items-center gap-2 text-sm">
         <span className="truncate">
-          <span className="font-semibold text-foreground">
+          <span className="text-foreground font-semibold">
             {sessions.length} {sessions.length === 1 ? 'session' : 'sessions'}
           </span>{' '}
           {WINDOW_ACTIVITY_LABELS[timeWindow]} ·{' '}
@@ -210,7 +208,7 @@ export function CoslashPage() {
   return (
     <div className="flex h-svh flex-col">
       <CoslashPageHeader />
-      <div className="bg-background flex flex-col border-b px-4 gap-2 pb-2">
+      <div className="bg-background flex flex-col gap-2 border-b px-4 pb-2">
         <div className="-m-1 flex items-center gap-2 overflow-x-auto p-1">
           <SessionSearch searchTerm={searchTerm} onSearchTermChange={setSearchTerm} />
           <div className="flex shrink-0 items-center gap-2">


### PR DESCRIPTION
## Context

The repository had no CI. Nothing checked a pull request, and nothing verified that the release build — the one that embeds the built frontend into the Go binary via `go:embed` — still produced a working executable. A broken release was only discoverable by hand.

This adds both, with the release path exercised the same way a person would run it rather than approximated by a separate set of steps.

## Changes

**`.github/workflows/ci.yml` — three jobs**, on every pull request, on pushes to `main`, and on manual dispatch. In-progress runs are cancelled for pull requests but not for `main`.

| Job | Runner | What it does |
| --- | --- | --- |
| `Frontend` | ubuntu | `npm ci`, lint, format check, tests, production build |
| `Collector` | ubuntu | `make check` (gofmt + `go vet`), `make test` |
| `Release` | macOS | `make release`, worktree-clean check, smoke test, dev build, dev smoke test, artifact upload |

The `Release` job is the point of the change. It runs the same `make release` a human release uses, then boots the resulting binary and asserts its behavior over HTTP. Step order matters: the embedded binary is copied aside *before* `make build` overwrites `bin/coslash`, so the uploaded artifact is the embedded one and not the bare development build.

**`collector/scripts/smoke.sh`** boots a built binary under an empty `HOME` and checks its HTTP contract in two modes.

- *Embedded* — `/` serves the application document; a `/assets/*.js` file referenced by that document resolves; `/coslash` survives a direct hit rather than 404ing; a missing asset returns **404 rather than falling back to the SPA document**; an unrouted `/api` path returns 404 rather than the application document; `/api/sessions` returns JSON; `--version` is not `dev`.
- *Bare* — `/` returns 503 and `/api/sessions` still answers.

The 404 and 503 assertions lock in the behavior from `0cb5405`, which was previously only verifiable by hand.

**`make check`, `make smoke`, `make smoke-dev`** give CI stable entry points instead of shell inlined into YAML, and stay usable locally.

**The collector now builds on non-darwin platforms.** The new Linux job caught this immediately: `Birthtimespec` exists only on darwin's `syscall.Stat_t`, so `internal/vendors/claude/fork.go` had never compiled anywhere else — nothing had ever tried. `fileCreationTime` already fell back to `ModTime()` when the `Stat_t` type assertion failed, so the intent was present; it simply could not compile where the field is absent. The darwin-only read now sits behind a build-tagged `birthtime` helper. No behavior change on darwin — the expression is unchanged — and fork ordering only uses birthtime to break ties between transcripts.

**`CoslashPage.tsx` reformatted** so the new formatting gate is not red on its first run. Whitespace and Tailwind class ordering only; nothing renders differently.

Plus a CI badge in the README.

## Test

All three jobs pass: `Frontend` 23s, `Collector` 23s, `Release` 48s.

**The uploaded artifact is the embedded binary** — the one failure mode that could ship behind a green check. Downloaded `coslash-macos` (10.1 MB), `--version` printed a real commit SHA rather than `dev`, and booting it under an empty `HOME` gave `/` → 200 with `<title>coSlash` and one `id="root"` div, `/api/sessions` → 200. A 503 there would have meant the wrong binary was uploaded.

**The frontend build step earns its slot.** With a deliberate type error present, `npm run lint`, `npm run format:check`, `vitest run`, and `vite build` all exit 0; only `npm run build` fails, with `TS2322`. `vite build` passing on its own confirms why — esbuild strips types without checking them, so `tsc -b` is doing the work. It uses the same script the release path invokes, so both check the identical build.

**Every CI step also replayed locally**, in the workflow's order, on darwin-arm64 / Node 23.5.0 / Go 1.26.5: `make check`, `make test`, `make release` (worktree clean afterwards), `make smoke`, `make build`, `make smoke-dev`, and the full frontend sequence from a cold `node_modules`. `GOOS=linux go build ./...` and `go vet ./...` pass on amd64 and arm64 after the portability fix.

Not yet done: deliberately breaking each gate to watch it go red — though the gofmt/vet gate proved itself for real via the Linux bug above, and the formatting gate was genuinely red before the `CoslashPage.tsx` fix — and the smoke script's port-fallback and argument-validation edge cases.

## Note for reviewers

`go test ./...` currently has no test files, so that step passes vacuously. The wiring is correct and picks up tests as soon as they exist, and `smoke.sh` is doing the real behavioral verification in the meantime, but a green `Collector` check should not be read as coverage. `internal/web`'s routing rules are pure functions of an `fs.FS` and are the obvious first candidate.
