### PR TITLE
Add global synthesis and terminal settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,18 @@ cd frontend && npm run dev
 ```
 
 The UI is at [http://localhost:5173](http://localhost:5173): Vite serves it and proxies `/api` to the Go server on port `8787`. `make run` embeds no frontend and opens no browser, so port `8787` serves the API alone.
+
+## Global settings
+
+coSlash stores machine-wide preferences in `~/.coslash/settings.json`. The file is optional: synthesis is off and Apple Terminal is used until you inspect a synthesis-eligible session and save a choice in the first-run Settings dialog. That dialog initially selects synthesis On, but synthesis remains off until you save. coSlash writes the directory with mode `0700` and the file with mode `0600`.
+
+Synthesis sends derived session facts through your selected CLI using its existing authentication and may consume account usage. Results are cached under `~/.coslash`; source transcripts are never modified. Do not put API keys, tokens, or other credentials in `settings.json`.
+
+Version 1 supports:
+
+- Synthesis backends: Claude Code (`claude-cli`) and Codex (`codex_exec`).
+- Claude models: `claude-haiku-4-5`, `claude-sonnet-5`, and `claude-opus-5`.
+- Codex models: `gpt-5.6-luna`, `gpt-5.6-terra`, and `gpt-5.6-sol`.
+- Terminal apps: Apple Terminal (`terminal`) and iTerm2 (`iterm2`).
+
+Use the top-right Settings dialog to apply synthesis and terminal changes immediately. The focused first-run dialog shown from an eligible session contains only synthesis consent and model choices. If you edit the JSON file directly, restart coSlash. The document must match [`settings.schema.json`](settings.schema.json); invalid or unsupported settings disable synthesis and block terminal launches until repaired rather than silently selecting another app.

--- a/collector/cmd/coslash/api.go
+++ b/collector/cmd/coslash/api.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os/exec"
 	"strconv"
 	"time"
 	"unicode/utf8"
@@ -13,6 +14,7 @@ import (
 	"github.com/centauri-ai/coslash/collector/internal/collector"
 	"github.com/centauri-ai/coslash/collector/internal/launch"
 	"github.com/centauri-ai/coslash/collector/internal/session"
+	"github.com/centauri-ai/coslash/collector/internal/settings"
 	"github.com/centauri-ai/coslash/collector/internal/synthesis"
 )
 
@@ -70,6 +72,7 @@ func handleSynthesis(w http.ResponseWriter, id string, mgr *synthesis.Manager) {
 	response := struct {
 		Synthesis        *session.SessionSynthesis `json:"synthesis"`
 		SynthesisPending bool                      `json:"synthesisPending"`
+		SynthesisError   string                    `json:"synthesisError,omitempty"`
 	}{}
 	mtime, err := synthesis.TranscriptMtime(found.LogPath)
 	if err == nil && mtime > 0 {
@@ -77,6 +80,9 @@ func handleSynthesis(w http.ResponseWriter, id string, mgr *synthesis.Manager) {
 		mgr.Ensure(found, mtime)
 		response.SynthesisPending = response.Synthesis == nil && synthesis.Eligible(found) &&
 			!mgr.InCooldown(found.ID, mtime)
+		if response.Synthesis == nil {
+			response.SynthesisError = mgr.Failure(found.ID, mtime)
+		}
 	}
 	writeJSON(w, response)
 	log.Printf("synthesis: %s", id)
@@ -93,7 +99,12 @@ func cleanupHandoffs() {
 	}
 }
 
-func handleLaunch(w http.ResponseWriter, r *http.Request) {
+func handleLaunch(w http.ResponseWriter, r *http.Request, settingsStore *settings.Store) {
+	state := settingsStore.State()
+	if !state.Valid {
+		http.Error(w, state.Error+"; open Settings to repair it", http.StatusConflict)
+		return
+	}
 	query := r.URL.Query()
 	found, err := collector.Get(query.Get("id"))
 	if err != nil {
@@ -112,13 +123,84 @@ func handleLaunch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	mode := query.Get("mode")
-	if err := launch.Terminal(found.Agent, found.WorkingDirectory, found.ID, mode, handoff); err != nil {
+	if err := launch.Terminal(state.Config.Launch.Terminal, found.Agent, found.WorkingDirectory, found.ID, mode, handoff); err != nil {
 		log.Printf("launch: %v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	log.Printf("launch %s: %s %s", mode, found.Agent, found.ID)
 	w.WriteHeader(http.StatusNoContent)
+}
+
+const maxSettingsBytes = 64 * 1024
+
+type availableBackend struct {
+	settings.BackendOption
+	Available bool `json:"available"`
+}
+
+type availableTerminal struct {
+	settings.TerminalOption
+	Available bool `json:"available"`
+}
+
+type settingsResponse struct {
+	Settings  settings.Config `json:"settings"`
+	Persisted bool            `json:"persisted"`
+	Valid     bool            `json:"valid"`
+	Error     string          `json:"error,omitempty"`
+	Options   struct {
+		SynthesisBackends []availableBackend  `json:"synthesisBackends"`
+		Terminals         []availableTerminal `json:"terminals"`
+	} `json:"options"`
+}
+
+func writeSettings(w http.ResponseWriter, state settings.State) {
+	response := settingsResponse{
+		Settings:  state.Config,
+		Persisted: state.Persisted,
+		Valid:     state.Valid,
+		Error:     state.Error,
+	}
+	for _, option := range settings.BackendOptions() {
+		_, err := exec.LookPath(settings.BackendExecutable(option.ID))
+		response.Options.SynthesisBackends = append(response.Options.SynthesisBackends, availableBackend{
+			BackendOption: option,
+			Available:     err == nil,
+		})
+	}
+	for _, option := range settings.TerminalOptions() {
+		response.Options.Terminals = append(response.Options.Terminals, availableTerminal{
+			TerminalOption: option,
+			Available:      launch.Available(option.ID),
+		})
+	}
+	writeJSON(w, response)
+}
+
+func handleSaveSettings(w http.ResponseWriter, r *http.Request, store *settings.Store, mgr *synthesis.Manager) {
+	data, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxSettingsBytes))
+	if err != nil {
+		http.Error(w, fmt.Sprintf("settings exceed %d bytes", maxSettingsBytes), http.StatusBadRequest)
+		return
+	}
+	config, err := settings.Decode(data)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	runner, err := synthesis.NewRunner(config.Synthesis)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := store.Save(config); err != nil {
+		log.Printf("save settings: %v", err)
+		http.Error(w, "could not save settings.json; check ~/.coslash permissions", http.StatusInternalServerError)
+		return
+	}
+	mgr.SetRunner(runner)
+	writeSettings(w, store.State())
 }
 
 func readHandoff(w http.ResponseWriter, r *http.Request) (string, error) {

--- a/collector/cmd/coslash/main.go
+++ b/collector/cmd/coslash/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/centauri-ai/coslash/collector/internal/collector"
 	"github.com/centauri-ai/coslash/collector/internal/session"
+	"github.com/centauri-ai/coslash/collector/internal/settings"
 	"github.com/centauri-ai/coslash/collector/internal/synthesis"
 	"github.com/centauri-ai/coslash/collector/internal/web"
 )
@@ -61,10 +62,18 @@ func main() {
 		return
 	}
 
-	mgr := synthesis.NewManager(synthesis.NewCLIRunner())
+	settingsStore := settings.Open()
+	settingsState := settingsStore.State()
+	var runner synthesis.Runner
+	if !settingsState.Valid {
+		log.Printf("settings: %s", settingsState.Error)
+	} else if settingsState.Persisted {
+		runner, _ = synthesis.NewRunner(settingsState.Config.Synthesis)
+	}
+	mgr := synthesis.NewManager(runner)
 	if err := synthesis.EnsureDirs(); err != nil {
 		log.Printf("initialize synthesis cache: %v", err)
-		mgr = synthesis.NewManager(nil)
+		mgr.SetRunner(nil)
 	}
 	go mgr.Run(context.Background(), func() ([]*session.Session, error) {
 		now := time.Now()
@@ -86,12 +95,12 @@ func main() {
 			log.Printf("could not open a browser (%v); open %s yourself", err, url)
 		}
 	}
-	if err := http.Serve(listener, routes(mgr)); err != nil {
+	if err := http.Serve(listener, routes(mgr, settingsStore)); err != nil {
 		log.Fatalf("coslash: %v", err)
 	}
 }
 
-func routes(mgr *synthesis.Manager) *http.ServeMux {
+func routes(mgr *synthesis.Manager, settingsStore *settings.Store) *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/sessions", func(w http.ResponseWriter, r *http.Request) {
 		handleList(w, r, mgr)
@@ -99,7 +108,15 @@ func routes(mgr *synthesis.Manager) *http.ServeMux {
 	mux.HandleFunc("GET /api/synthesis", func(w http.ResponseWriter, r *http.Request) {
 		handleSynthesis(w, r.URL.Query().Get("id"), mgr)
 	})
-	mux.HandleFunc("POST /api/launch", handleLaunch)
+	mux.HandleFunc("GET /api/settings", func(w http.ResponseWriter, _ *http.Request) {
+		writeSettings(w, settingsStore.State())
+	})
+	mux.HandleFunc("PUT /api/settings", func(w http.ResponseWriter, r *http.Request) {
+		handleSaveSettings(w, r, settingsStore, mgr)
+	})
+	mux.HandleFunc("POST /api/launch", func(w http.ResponseWriter, r *http.Request) {
+		handleLaunch(w, r, settingsStore)
+	})
 	// An unrouted /api path is a 404, never the frontend document.
 	mux.Handle("/api/", http.NotFoundHandler())
 

--- a/collector/internal/launch/launch.go
+++ b/collector/internal/launch/launch.go
@@ -14,7 +14,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/centauri-ai/coslash/collector/internal/synthesis"
+	"github.com/centauri-ai/coslash/collector/internal/settings"
 	"github.com/centauri-ai/coslash/collector/internal/vendors"
 )
 
@@ -40,29 +40,64 @@ var sessionIDPattern = regexp.MustCompile(
 	`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`,
 )
 
-func Terminal(agent, workingDirectory, sessionID, mode, handoff string) error {
+type terminalAdapter struct {
+	label     string
+	available func() error
+	open      func(string, string) error
+}
+
+func Terminal(terminal, agent, workingDirectory, sessionID, mode, handoff string) error {
 	if workingDirectory == "" {
 		return fmt.Errorf("launch: session has no working directory")
+	}
+	adapter, err := terminalFor(terminal)
+	if err != nil {
+		return err
+	}
+	if runtime.GOOS != "darwin" {
+		return fmt.Errorf("launch: opening a terminal is not supported on %s", runtime.GOOS)
+	}
+	if err := adapter.available(); err != nil {
+		return fmt.Errorf("launch: %s is not installed or available; choose another terminal in Settings", adapter.label)
 	}
 	command, handoffPath, err := cliCommand(agent, sessionID, mode, handoff)
 	if err != nil {
 		return err
 	}
-	if err := openTerminal(workingDirectory, command); err != nil {
+	if err := adapter.open(workingDirectory, command); err != nil {
 		if handoffPath != "" {
 			os.Remove(handoffPath)
 		}
-		return err
+		return fmt.Errorf("launch: open %s: %w", adapter.label, err)
 	}
 	return nil
 }
 
-func openTerminal(workingDirectory, command string) error {
-	switch runtime.GOOS {
-	case "darwin":
-		return openMacTerminal(workingDirectory, command)
+func Available(terminal string) bool {
+	if runtime.GOOS != "darwin" {
+		return false
 	}
-	return fmt.Errorf("launch: opening a terminal is not supported on %s", runtime.GOOS)
+	adapter, err := terminalFor(terminal)
+	return err == nil && adapter.available() == nil
+}
+
+func terminalFor(terminal string) (terminalAdapter, error) {
+	switch terminal {
+	case settings.TerminalApple:
+		return terminalAdapter{
+			label:     "Apple Terminal",
+			available: func() error { return macApplicationAvailable("Terminal") },
+			open:      openMacTerminal,
+		}, nil
+	case settings.TerminalITerm:
+		return terminalAdapter{
+			label:     "iTerm2",
+			available: func() error { return macApplicationAvailable("iTerm2") },
+			open:      openMacITerm,
+		}, nil
+	default:
+		return terminalAdapter{}, fmt.Errorf("launch: unsupported terminal %q", terminal)
+	}
 }
 
 func cliCommand(agent, sessionID, mode, handoff string) (string, string, error) {
@@ -117,7 +152,7 @@ func handoffCommand(agent, cli, handoff string) (string, string, error) {
 }
 
 func handoffDir() string {
-	return filepath.Join(synthesis.Home(), "sys-prompts")
+	return filepath.Join(settings.Home(), "sys-prompts")
 }
 
 func writeHandoffFile(contents string) (string, error) {

--- a/collector/internal/launch/launch_macos.go
+++ b/collector/internal/launch/launch_macos.go
@@ -1,19 +1,45 @@
 package launch
 
 import (
+	"fmt"
 	"os/exec"
 	"strings"
 )
 
+var runOSAScript = func(arguments ...string) error {
+	return exec.Command("osascript", arguments...).Run()
+}
+
+func macApplicationAvailable(name string) error {
+	if name != "Terminal" && name != "iTerm2" {
+		return fmt.Errorf("unknown application %q", name)
+	}
+	return runOSAScript("-e", `id of application "`+name+`"`)
+}
+
 func openMacTerminal(workingDirectory, command string) error {
 	script := "cd " + shellQuote(workingDirectory) + " && " + command
-	return exec.Command("osascript",
+	return runOSAScript(
 		"-e", "on run argv",
 		"-e", `tell application "Terminal" to do script (item 1 of argv)`,
 		"-e", `tell application "Terminal" to activate`,
 		"-e", "end run",
 		"--", script,
-	).Run()
+	)
+}
+
+func openMacITerm(workingDirectory, command string) error {
+	script := "cd " + shellQuote(workingDirectory) + " && " + command
+	return runOSAScript(
+		"-e", "on run argv",
+		"-e", `tell application "iTerm2"`,
+		"-e", `set newWindow to (create window with default profile)`,
+		"-e", `tell current session of newWindow to write text (item 1 of argv)`,
+		"-e", `activate`,
+		"-e", `end tell`,
+		"-e", "end run",
+		"--", script,
+	)
 }
 
 func shellJoin(arguments ...string) string {

--- a/collector/internal/settings/settings.go
+++ b/collector/internal/settings/settings.go
@@ -1,0 +1,316 @@
+package settings
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+const (
+	SchemaURL = "https://raw.githubusercontent.com/centauri-ai/coslash/main/settings.schema.json"
+	Version   = 1
+
+	BackendClaude = "claude-cli"
+	BackendCodex  = "codex_exec"
+
+	TerminalApple = "terminal"
+	TerminalITerm = "iterm2"
+)
+
+type Config struct {
+	Schema    string            `json:"$schema"`
+	Version   int               `json:"version"`
+	Synthesis SynthesisSettings `json:"synthesis"`
+	Launch    LaunchSettings    `json:"launch"`
+}
+
+type SynthesisSettings struct {
+	Enabled bool   `json:"enabled"`
+	Backend string `json:"backend"`
+	Model   string `json:"model"`
+}
+
+type LaunchSettings struct {
+	Terminal string `json:"terminal"`
+}
+
+type ModelOption struct {
+	ID      string `json:"id"`
+	Label   string `json:"label"`
+	Default bool   `json:"default"`
+}
+
+type BackendOption struct {
+	ID     string        `json:"id"`
+	Label  string        `json:"label"`
+	Models []ModelOption `json:"models"`
+}
+
+type TerminalOption struct {
+	ID    string `json:"id"`
+	Label string `json:"label"`
+}
+
+type State struct {
+	Config    Config
+	Persisted bool
+	Valid     bool
+	Error     string
+}
+
+type Store struct {
+	mu     sync.RWMutex
+	state  State
+	rename func(string, string) error
+}
+
+func Home() string {
+	if home := os.Getenv("COSLASH_HOME"); home != "" {
+		return home
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ".coslash"
+	}
+	return filepath.Join(home, ".coslash")
+}
+
+func Path() string {
+	return filepath.Join(Home(), "settings.json")
+}
+
+func Defaults() Config {
+	return Config{
+		Schema:  SchemaURL,
+		Version: Version,
+		Synthesis: SynthesisSettings{
+			Enabled: false,
+			Backend: BackendClaude,
+			Model:   "claude-haiku-4-5",
+		},
+		Launch: LaunchSettings{Terminal: TerminalApple},
+	}
+}
+
+func BackendOptions() []BackendOption {
+	return []BackendOption{
+		{
+			ID:    BackendClaude,
+			Label: "Claude Code CLI",
+			Models: []ModelOption{
+				{ID: "claude-haiku-4-5", Label: "Claude Haiku 4.5", Default: true},
+				{ID: "claude-sonnet-5", Label: "Claude Sonnet 5"},
+				{ID: "claude-opus-5", Label: "Claude Opus 5"},
+			},
+		},
+		{
+			ID:    BackendCodex,
+			Label: "Codex CLI",
+			Models: []ModelOption{
+				{ID: "gpt-5.6-luna", Label: "GPT-5.6 Luna", Default: true},
+				{ID: "gpt-5.6-terra", Label: "GPT-5.6 Terra"},
+				{ID: "gpt-5.6-sol", Label: "GPT-5.6 Sol"},
+			},
+		},
+	}
+}
+
+func TerminalOptions() []TerminalOption {
+	return []TerminalOption{
+		{ID: TerminalApple, Label: "Apple Terminal"},
+		{ID: TerminalITerm, Label: "iTerm2"},
+	}
+}
+
+func BackendExecutable(backend string) string {
+	switch backend {
+	case BackendClaude:
+		return "claude"
+	case BackendCodex:
+		return "codex"
+	default:
+		return ""
+	}
+}
+
+func Validate(config Config) error {
+	if config.Schema != SchemaURL {
+		return fmt.Errorf("$schema must be %q", SchemaURL)
+	}
+	if config.Version != Version {
+		return fmt.Errorf("unsupported settings version %d", config.Version)
+	}
+	var backend *BackendOption
+	for _, option := range BackendOptions() {
+		if option.ID == config.Synthesis.Backend {
+			selected := option
+			backend = &selected
+			break
+		}
+	}
+	if backend == nil {
+		return fmt.Errorf("unsupported synthesis backend %q", config.Synthesis.Backend)
+	}
+	modelSupported := false
+	for _, option := range backend.Models {
+		if option.ID == config.Synthesis.Model {
+			modelSupported = true
+			break
+		}
+	}
+	if !modelSupported {
+		return fmt.Errorf("model %q is not supported by %q", config.Synthesis.Model, backend.ID)
+	}
+	for _, option := range TerminalOptions() {
+		if option.ID == config.Launch.Terminal {
+			return nil
+		}
+	}
+	return fmt.Errorf("unsupported terminal %q", config.Launch.Terminal)
+}
+
+func Decode(data []byte) (Config, error) {
+	type synthesisDocument struct {
+		Enabled *bool   `json:"enabled"`
+		Backend *string `json:"backend"`
+		Model   *string `json:"model"`
+	}
+	type launchDocument struct {
+		Terminal *string `json:"terminal"`
+	}
+	type configDocument struct {
+		Schema    *string            `json:"$schema"`
+		Version   *int               `json:"version"`
+		Synthesis *synthesisDocument `json:"synthesis"`
+		Launch    *launchDocument    `json:"launch"`
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var document configDocument
+	if err := decoder.Decode(&document); err != nil {
+		return Config{}, fmt.Errorf("decode settings: %w", err)
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		return Config{}, err
+	}
+	if document.Schema == nil || document.Version == nil || document.Synthesis == nil ||
+		document.Synthesis.Enabled == nil || document.Synthesis.Backend == nil ||
+		document.Synthesis.Model == nil || document.Launch == nil || document.Launch.Terminal == nil {
+		return Config{}, errors.New("settings must include $schema, version, synthesis, and launch fields")
+	}
+	config := Config{
+		Schema:  *document.Schema,
+		Version: *document.Version,
+		Synthesis: SynthesisSettings{
+			Enabled: *document.Synthesis.Enabled,
+			Backend: *document.Synthesis.Backend,
+			Model:   *document.Synthesis.Model,
+		},
+		Launch: LaunchSettings{Terminal: *document.Launch.Terminal},
+	}
+	if err := Validate(config); err != nil {
+		return Config{}, err
+	}
+	return config, nil
+}
+
+func ensureJSONEOF(decoder *json.Decoder) error {
+	var extra any
+	if err := decoder.Decode(&extra); errors.Is(err, io.EOF) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("decode settings: %w", err)
+	}
+	return errors.New("decode settings: multiple JSON values")
+}
+
+func Open() *Store {
+	return &Store{state: load(), rename: os.Rename}
+}
+
+func load() State {
+	info, err := os.Lstat(Path())
+	if errors.Is(err, fs.ErrNotExist) {
+		return State{Config: Defaults(), Valid: true}
+	}
+	if err != nil {
+		return State{Config: Defaults(), Persisted: true, Error: "read settings.json: " + err.Error()}
+	}
+	if !info.Mode().IsRegular() {
+		return State{Config: Defaults(), Persisted: true, Error: "settings.json must be a regular file"}
+	}
+	if info.Mode().Perm() != 0o600 {
+		return State{Config: Defaults(), Persisted: true, Error: "settings.json permissions must be 0600"}
+	}
+	data, err := os.ReadFile(Path())
+	if err != nil {
+		return State{Config: Defaults(), Persisted: true, Error: "read settings.json: " + err.Error()}
+	}
+	config, err := Decode(data)
+	if err != nil {
+		return State{
+			Config:    Defaults(),
+			Persisted: true,
+			Error:     "settings.json is invalid: " + err.Error(),
+		}
+	}
+	return State{Config: config, Persisted: true, Valid: true}
+}
+
+func (store *Store) State() State {
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+	return store.state
+}
+
+func (store *Store) Save(config Config) error {
+	if err := Validate(config); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if err := os.MkdirAll(Home(), 0o700); err != nil {
+		return fmt.Errorf("create coSlash directory: %w", err)
+	}
+	if err := os.Chmod(Home(), 0o700); err != nil {
+		return fmt.Errorf("secure coSlash directory: %w", err)
+	}
+	temp, err := os.CreateTemp(Home(), ".settings-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create settings temporary file: %w", err)
+	}
+	tempPath := temp.Name()
+	defer os.Remove(tempPath)
+	if err := temp.Chmod(0o600); err != nil {
+		temp.Close()
+		return fmt.Errorf("secure settings temporary file: %w", err)
+	}
+	if _, err := temp.Write(data); err != nil {
+		temp.Close()
+		return fmt.Errorf("write settings temporary file: %w", err)
+	}
+	if err := temp.Sync(); err != nil {
+		temp.Close()
+		return fmt.Errorf("sync settings temporary file: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("close settings temporary file: %w", err)
+	}
+	if err := store.rename(tempPath, Path()); err != nil {
+		return fmt.Errorf("replace settings.json: %w", err)
+	}
+	store.mu.Lock()
+	store.state = State{Config: config, Persisted: true, Valid: true}
+	store.mu.Unlock()
+	return nil
+}

--- a/collector/internal/synthesis/manager.go
+++ b/collector/internal/synthesis/manager.go
@@ -26,7 +26,13 @@ type failureKey struct {
 	mtime int64
 }
 
+type failure struct {
+	at      time.Time
+	message string
+}
+
 type Manager struct {
+	runnerMu           sync.RWMutex
 	runner             Runner
 	cache              *Cache
 	slots              chan struct{}
@@ -54,14 +60,17 @@ func NewManager(runner Runner) *Manager {
 }
 
 func (m *Manager) Lookup(id string, mtime int64) *session.SessionSynthesis {
-	if m == nil || m.runner == nil {
+	if m == nil {
 		return nil
 	}
 	return m.cache.Lookup(id, mtime)
 }
 
 func (m *Manager) Ensure(s *session.Session, mtime int64) bool {
-	if m == nil || m.runner == nil || mtime <= 0 || !Eligible(s) {
+	if m == nil || mtime <= 0 || !Eligible(s) {
+		return false
+	}
+	if m.currentRunner() == nil {
 		return false
 	}
 	if m.Lookup(s.ID, mtime) != nil || m.InCooldown(s.ID, mtime) {
@@ -77,7 +86,11 @@ func (m *Manager) Ensure(s *session.Session, mtime int64) bool {
 		m.slots <- struct{}{}
 		defer func() { <-m.slots }()
 
-		result, err := m.runner.Run(context.Background(), input)
+		runner := m.currentRunner()
+		if runner == nil {
+			return
+		}
+		result, err := runner.Run(context.Background(), input)
 		if err != nil {
 			m.recordFailure(id, mtime, err)
 			log.Printf("synthesize session %s: %v", id, err)
@@ -86,7 +99,7 @@ func (m *Manager) Ensure(s *session.Session, mtime int64) bool {
 		record := Record{
 			SessionID:   id,
 			Mtime:       mtime,
-			Model:       runnerModel(m.runner),
+			Model:       runnerModel(runner),
 			GeneratedAt: m.now().UnixMilli(),
 			Synthesis:   result,
 		}
@@ -111,7 +124,11 @@ func buildInputWithDetailProbes(s *session.Session) string {
 }
 
 func (m *Manager) InCooldown(id string, mtime int64) bool {
-	if m == nil || m.runner == nil {
+	if m == nil {
+		return true
+	}
+	runner := m.currentRunner()
+	if runner == nil {
 		return true
 	}
 	now := m.now()
@@ -123,7 +140,7 @@ func (m *Manager) InCooldown(id string, mtime int64) bool {
 	if !ok {
 		return false
 	}
-	if now.Sub(value.(time.Time)) < m.failureCooldown {
+	if now.Sub(value.(failure).at) < m.failureCooldown {
 		return true
 	}
 	m.failures.Delete(key)
@@ -131,7 +148,7 @@ func (m *Manager) InCooldown(id string, mtime int64) bool {
 }
 
 func (m *Manager) Run(ctx context.Context, list func() ([]*session.Session, error)) {
-	if m == nil || m.runner == nil {
+	if m == nil {
 		return
 	}
 	m.sweep(list)
@@ -179,10 +196,46 @@ func (m *Manager) sweep(list func() ([]*session.Session, error)) {
 
 func (m *Manager) recordFailure(id string, mtime int64, err error) {
 	now := m.now()
-	m.failures.Store(failureKey{id: id, mtime: mtime}, now)
+	m.failures.Store(failureKey{id: id, mtime: mtime}, failure{at: now, message: err.Error()})
 	if errors.Is(err, exec.ErrNotFound) {
 		m.cliMissingUntil.Store(now.Add(m.cliMissingCooldown).UnixNano())
 	}
+}
+
+func (m *Manager) SetRunner(runner Runner) {
+	if m == nil {
+		return
+	}
+	m.runnerMu.Lock()
+	m.runner = runner
+	m.runnerMu.Unlock()
+	m.cliMissingUntil.Store(0)
+	m.failures.Range(func(key, _ any) bool {
+		m.failures.Delete(key)
+		return true
+	})
+}
+
+func (m *Manager) Failure(id string, mtime int64) string {
+	if m == nil {
+		return ""
+	}
+	value, ok := m.failures.Load(failureKey{id: id, mtime: mtime})
+	if !ok {
+		return ""
+	}
+	failed := value.(failure)
+	if m.now().Sub(failed.at) >= m.failureCooldown {
+		m.failures.Delete(failureKey{id: id, mtime: mtime})
+		return ""
+	}
+	return failed.message
+}
+
+func (m *Manager) currentRunner() Runner {
+	m.runnerMu.RLock()
+	defer m.runnerMu.RUnlock()
+	return m.runner
 }
 
 func runnerModel(runner Runner) string {

--- a/collector/internal/synthesis/paths.go
+++ b/collector/internal/synthesis/paths.go
@@ -3,17 +3,12 @@ package synthesis
 import (
 	"os"
 	"path/filepath"
+
+	"github.com/centauri-ai/coslash/collector/internal/settings"
 )
 
 func Home() string {
-	if home := os.Getenv("COSLASH_HOME"); home != "" {
-		return home
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ".coslash"
-	}
-	return filepath.Join(home, ".coslash")
+	return settings.Home()
 }
 
 func SummariesDir() string {
@@ -25,10 +20,15 @@ func SynthesisCwd() string {
 }
 
 func EnsureDirs() error {
-	if err := os.MkdirAll(SummariesDir(), 0o700); err != nil {
-		return err
+	for _, directory := range []string{Home(), SummariesDir(), SynthesisCwd()} {
+		if err := os.MkdirAll(directory, 0o700); err != nil {
+			return err
+		}
+		if err := os.Chmod(directory, 0o700); err != nil {
+			return err
+		}
 	}
-	return os.MkdirAll(SynthesisCwd(), 0o700)
+	return nil
 }
 
 func TranscriptMtime(logPath string) (int64, error) {

--- a/collector/internal/synthesis/runner.go
+++ b/collector/internal/synthesis/runner.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"unicode"
 
 	"github.com/centauri-ai/coslash/collector/internal/session"
+	"github.com/centauri-ai/coslash/collector/internal/settings"
 )
 
 const defaultModel = "claude-haiku-4-5"
@@ -22,18 +24,50 @@ type Runner interface {
 	Run(context.Context, string) (session.SessionSynthesis, error)
 }
 
+type commandSpec struct {
+	bin   string
+	args  []string
+	dir   string
+	stdin string
+}
+
+type commandExecutor func(context.Context, commandSpec) ([]byte, error)
+
+func executeCommand(ctx context.Context, spec commandSpec) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, spec.bin, spec.args...)
+	cmd.Dir = spec.dir
+	cmd.Stdin = strings.NewReader(spec.stdin)
+	return cmd.Output()
+}
+
 type CLIRunner struct {
+	Backend string
 	Bin     string
 	Model   string
 	Timeout time.Duration
+	exec    commandExecutor
 }
 
-func NewCLIRunner() *CLIRunner {
-	model := os.Getenv("COSLASH_SYNTHESIS_MODEL")
-	if model == "" {
-		model = defaultModel
+func NewClaudeRunner(model string) *CLIRunner {
+	return &CLIRunner{Backend: settings.BackendClaude, Bin: "claude", Model: model, Timeout: 90 * time.Second}
+}
+
+func NewCodexRunner(model string) *CLIRunner {
+	return &CLIRunner{Backend: settings.BackendCodex, Bin: "codex", Model: model, Timeout: 90 * time.Second}
+}
+
+func NewRunner(config settings.SynthesisSettings) (Runner, error) {
+	if !config.Enabled {
+		return nil, nil
 	}
-	return &CLIRunner{Bin: "claude", Model: model, Timeout: 90 * time.Second}
+	switch config.Backend {
+	case settings.BackendClaude:
+		return NewClaudeRunner(config.Model), nil
+	case settings.BackendCodex:
+		return NewCodexRunner(config.Model), nil
+	default:
+		return nil, fmt.Errorf("unsupported synthesis backend %q", config.Backend)
+	}
 }
 
 func (r *CLIRunner) ModelName() string {
@@ -42,12 +76,60 @@ func (r *CLIRunner) ModelName() string {
 
 func (r *CLIRunner) Run(ctx context.Context, input string) (session.SessionSynthesis, error) {
 	bin := r.Bin
-	if bin == "" {
-		bin = "claude"
-	}
 	model := r.Model
-	if model == "" {
-		model = defaultModel
+	var label string
+	var args []string
+	var parse func([]byte) (session.SessionSynthesis, error)
+	var schemaPath string
+	switch r.Backend {
+	case settings.BackendClaude:
+		label = "Claude Code"
+		parse = parseEnvelope
+		if bin == "" {
+			bin = "claude"
+		}
+		if model == "" {
+			model = defaultModel
+		}
+		args = []string{
+			"-p",
+			"--model", model,
+			"--output-format", "json",
+			"--json-schema", synthesisSchema,
+			"--system-prompt", systemPrompt,
+			"--tools", "",
+			"--safe-mode",
+			"--no-session-persistence",
+		}
+	case settings.BackendCodex:
+		label = "Codex"
+		parse = parseSynthesis
+		if bin == "" {
+			bin = "codex"
+		}
+		if model == "" {
+			model = "gpt-5.6-luna"
+		}
+		var err error
+		schemaPath, err = writeSchemaFile()
+		if err != nil {
+			return session.SessionSynthesis{}, err
+		}
+		defer os.Remove(schemaPath)
+		args = []string{
+			"exec",
+			"--ephemeral",
+			"--ignore-user-config",
+			"--ignore-rules",
+			"--skip-git-repo-check",
+			"--sandbox", "read-only",
+			"--model", model,
+			"--output-schema", schemaPath,
+			"--color", "never",
+			systemPrompt,
+		}
+	default:
+		return session.SessionSynthesis{}, fmt.Errorf("unsupported synthesis backend %q", r.Backend)
 	}
 	timeout := r.Timeout
 	if timeout <= 0 {
@@ -55,35 +137,63 @@ func (r *CLIRunner) Run(ctx context.Context, input string) (session.SessionSynth
 	}
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	cmd := exec.CommandContext(runCtx, bin,
-		"-p",
-		"--model", model,
-		"--output-format", "json",
-		"--json-schema", synthesisSchema,
-		"--system-prompt", systemPrompt,
-		"--tools", "",
-		"--safe-mode",
-		"--no-session-persistence",
-	)
-	cmd.Dir = SynthesisCwd()
-	cmd.Stdin = strings.NewReader(input)
-	output, err := cmd.Output()
+	executor := r.exec
+	if executor == nil {
+		executor = executeCommand
+	}
+	output, err := executor(runCtx, commandSpec{
+		bin:   bin,
+		args:  args,
+		dir:   SynthesisCwd(),
+		stdin: input,
+	})
 	if runCtx.Err() != nil {
-		return session.SessionSynthesis{}, runCtx.Err()
+		return session.SessionSynthesis{}, fmt.Errorf("%s synthesis timed out: %w", label, runCtx.Err())
 	}
 	if err != nil {
-		var exitErr *exec.ExitError
-		switch {
-		case errors.Is(err, exec.ErrNotFound):
-			return session.SessionSynthesis{}, fmt.Errorf("claude CLI not found: %w", err)
-		case errors.As(err, &exitErr):
-			return session.SessionSynthesis{}, fmt.Errorf("claude CLI exited: %w: %s", err,
-				strings.TrimSpace(string(exitErr.Stderr)))
-		default:
-			return session.SessionSynthesis{}, fmt.Errorf("run claude CLI: %w", err)
-		}
+		return session.SessionSynthesis{}, safeCommandError(label, err)
 	}
-	return parseEnvelope(output)
+	return parse(output)
+}
+
+func writeSchemaFile() (string, error) {
+	if err := os.MkdirAll(SynthesisCwd(), 0o700); err != nil {
+		return "", fmt.Errorf("create synthesis directory: %w", err)
+	}
+	file, err := os.CreateTemp(SynthesisCwd(), ".schema-*.json")
+	if err != nil {
+		return "", fmt.Errorf("create synthesis schema: %w", err)
+	}
+	path := file.Name()
+	remove := true
+	defer func() {
+		file.Close()
+		if remove {
+			os.Remove(path)
+		}
+	}()
+	if err := file.Chmod(0o600); err != nil {
+		return "", fmt.Errorf("secure synthesis schema: %w", err)
+	}
+	if _, err := io.WriteString(file, synthesisSchema); err != nil {
+		return "", fmt.Errorf("write synthesis schema: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return "", fmt.Errorf("close synthesis schema: %w", err)
+	}
+	remove = false
+	return path, nil
+}
+
+func safeCommandError(label string, err error) error {
+	if errors.Is(err, exec.ErrNotFound) {
+		return fmt.Errorf("%s CLI is not installed or not on PATH: %w", label, err)
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return fmt.Errorf("%s synthesis failed; verify CLI authentication and the selected model: %w", label, err)
+	}
+	return fmt.Errorf("run %s synthesis: %w", label, err)
 }
 
 func parseEnvelope(data []byte) (session.SessionSynthesis, error) {
@@ -101,7 +211,11 @@ func parseEnvelope(data []byte) (session.SessionSynthesis, error) {
 	if envelope.IsError {
 		return session.SessionSynthesis{}, errors.New("claude returned an error result")
 	}
-	result := stripJSONFence(envelope.Result)
+	return parseSynthesis([]byte(envelope.Result))
+}
+
+func parseSynthesis(data []byte) (session.SessionSynthesis, error) {
+	result := stripJSONFence(string(data))
 	var synthesis session.SessionSynthesis
 	if err := json.Unmarshal([]byte(result), &synthesis); err != nil {
 		return session.SessionSynthesis{}, fmt.Errorf("decode synthesis result: %w", err)

--- a/frontend/src/pages/coslash/CoslashPage.tsx
+++ b/frontend/src/pages/coslash/CoslashPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Search } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -12,6 +12,11 @@ import {
   sortSessions,
   type SortDir,
 } from '@/pages/coslash/components/SessionSortDropdownMenu';
+import {
+  SettingsButton,
+  SettingsDialog,
+  type SettingsDialogMode,
+} from '@/pages/coslash/components/SettingsDialog';
 import { UnpricedModelWarning } from '@/pages/coslash/components/UnpricedModelWarning';
 import {
   AgentVendorFilterTabMenu,
@@ -21,11 +26,13 @@ import {
   type ViewMode,
 } from '@/pages/coslash/CoslashTabMenus';
 import { useSessions } from '@/pages/coslash/hooks/use-sessions';
+import { useSettings } from '@/pages/coslash/hooks/use-settings';
 import { formatEstimatedCost } from '@/pages/coslash/lib/format';
 import { sessionsEmptyStateCopy } from '@/pages/coslash/lib/page-copy';
 import { getEstimatedCost } from '@/pages/coslash/lib/pricing';
 import { sessionMatchesSearchTerm } from '@/pages/coslash/lib/search';
 import { getStatus, type Session } from '@/pages/coslash/lib/session';
+import { shouldPromptForSynthesisConsent } from '@/pages/coslash/lib/settings';
 import { timeWindowStart, type TimeWindow } from '@/pages/coslash/lib/time-window';
 
 const WINDOW_ACTIVITY_LABELS: Record<TimeWindow, string> = {
@@ -36,11 +43,34 @@ const WINDOW_ACTIVITY_LABELS: Record<TimeWindow, string> = {
   'all': 'across all time',
 };
 
-function CoslashPageHeader() {
+function CoslashPageHeader({
+  onOpenSettings,
+  settingsError,
+}: {
+  onOpenSettings: () => void;
+  settingsError: boolean;
+}) {
   return (
-    <div className="flex items-center gap-2 px-4">
-      <img src="/brand/coslash-logo.svg" alt="coSlash" className="h-12" />
-      <span className="text-muted-foreground text-sm font-medium">Run more agents. Lose less context.</span>
+    <div className="flex items-center justify-between gap-4 px-4">
+      <div className="flex items-center gap-2">
+        <img src="/brand/coslash-logo.svg" alt="coSlash" className="h-12" />
+        <span className="text-muted-foreground text-sm font-medium">Run more agents. Lose less context.</span>
+      </div>
+      <SettingsButton onClick={onOpenSettings} hasError={settingsError} />
+    </div>
+  );
+}
+
+function SettingsErrorBanner({ message, onOpen }: { message: string; onOpen: () => void }) {
+  return (
+    <div
+      role="alert"
+      className="text-destructive flex items-center justify-between gap-4 border-y bg-neutral-50 px-4 py-2 text-sm"
+    >
+      <span>{message} Synthesis is off and terminal launches are blocked.</span>
+      <Button variant="outline" size="sm" onClick={onOpen}>
+        Repair settings
+      </Button>
     </div>
   );
 }
@@ -185,10 +215,27 @@ export function CoslashPage() {
   const [sortDir, setSortDir] = useState<SortDir>('desc');
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
+  const [settingsDialogMode, setSettingsDialogMode] = useState<SettingsDialogMode | null>(null);
+  const settingsState = useSettings();
+  const settingsHaveError = settingsState.loadError != null || settingsState.response?.valid === false;
   // Held by id, not by value: the inspector must render the freshest record
   // each refresh, and a stored object would freeze at click time. Looked up
   // from the unfiltered list so filters never close an open inspector.
   const selectedSession = sessions.find((session) => session.id === selectedSessionId) ?? null;
+  const synthesisSettingsKey = settingsState.response
+    ? [
+        settingsState.response.persisted,
+        settingsState.response.settings.synthesis.enabled,
+        settingsState.response.settings.synthesis.backend,
+        settingsState.response.settings.synthesis.model,
+      ].join(':')
+    : 'loading';
+
+  useEffect(() => {
+    if (shouldPromptForSynthesisConsent(selectedSession, settingsState.response)) {
+      setSettingsDialogMode((current) => current ?? 'synthesis-consent');
+    }
+  }, [selectedSession, settingsState.response]);
   // The API returns every session, so the window is applied here — switching it
   // never refetches. A live session shows regardless of how old its log is.
   const windowStart = timeWindowStart(timeWindow);
@@ -207,7 +254,16 @@ export function CoslashPage() {
 
   return (
     <div className="flex h-svh flex-col">
-      <CoslashPageHeader />
+      <CoslashPageHeader
+        onOpenSettings={() => setSettingsDialogMode('full-settings')}
+        settingsError={settingsHaveError}
+      />
+      {settingsState.response?.valid === false && (
+        <SettingsErrorBanner
+          message={settingsState.response.error ?? 'settings.json is invalid.'}
+          onOpen={() => setSettingsDialogMode('full-settings')}
+        />
+      )}
       <div className="bg-background flex flex-col gap-2 border-b px-4 pb-2">
         <div className="-m-1 flex items-center gap-2 overflow-x-auto p-1">
           <SessionSearch searchTerm={searchTerm} onSearchTermChange={setSearchTerm} />
@@ -248,7 +304,21 @@ export function CoslashPage() {
       <SessionInspector
         session={selectedSession}
         sessionsVersion={sessionsVersion}
+        synthesisSettingsKey={synthesisSettingsKey}
         onClose={() => setSelectedSessionId(null)}
+      />
+      <SettingsDialog
+        open={settingsDialogMode != null}
+        mode={settingsDialogMode ?? 'full-settings'}
+        onOpenChange={(open) => {
+          if (!open) setSettingsDialogMode(null);
+        }}
+        response={settingsState.response}
+        isLoading={settingsState.isLoading}
+        loadError={settingsState.loadError}
+        saveError={settingsState.saveError}
+        isSaving={settingsState.isSaving}
+        onSave={settingsState.save}
       />
     </div>
   );

--- a/frontend/src/pages/coslash/components/SessionInspector.tsx
+++ b/frontend/src/pages/coslash/components/SessionInspector.tsx
@@ -48,9 +48,14 @@ import { HOUR, MINUTE } from '@/pages/coslash/lib/time';
 type SynthesisResponse = {
   synthesis: SessionDetail['synthesis'];
   synthesisPending: boolean;
+  synthesisError?: string;
 };
 
-function useSessionDetail(session: Session | null, sessionsVersion: number): SessionDetail | null {
+function useSessionDetail(
+  session: Session | null,
+  sessionsVersion: number,
+  synthesisSettingsKey: string,
+): SessionDetail | null {
   const [loaded, setLoaded] = useState<({ sessionId: string } & SynthesisResponse) | null>(null);
   const pollDeadline = useRef<{ sessionId: string; deadline: number } | null>(null);
   const sessionId = session?.id ?? null;
@@ -94,11 +99,16 @@ function useSessionDetail(session: Session | null, sessionsVersion: number): Ses
       controller.abort();
       if (timer != null) clearTimeout(timer);
     };
-  }, [sessionId, sessionsVersion]);
+  }, [sessionId, sessionsVersion, synthesisSettingsKey]);
 
   if (session == null) return null;
   if (loaded?.sessionId !== session.id) return session;
-  return { ...session, synthesis: loaded.synthesis, synthesisPending: loaded.synthesisPending };
+  return {
+    ...session,
+    synthesis: loaded.synthesis,
+    synthesisPending: loaded.synthesisPending,
+    synthesisError: loaded.synthesisError,
+  };
 }
 
 function contextFillReadiness(detail: SessionDetail): { value: string; tone: string } | null {
@@ -384,7 +394,12 @@ function RecapSection({ detail }: { detail: SessionDetail }) {
     <div>
       <SectionLabel title="DEBRIEF" />
       <div className="rounded-lg border p-3">
-        <div className="flex items-center gap-2">
+        {detail.synthesisError && (
+          <div role="alert" className="bg-warning-bg text-warning-fg rounded-lg p-2 text-xs">
+            {detail.synthesisError} Using the transcript-derived debrief instead.
+          </div>
+        )}
+        <div className={cn('flex items-center gap-2', { 'pt-3': detail.synthesisError != null })}>
           <span className="text-muted-foreground text-xs">GOAL</span>
           <Badge variant="secondary" className="text-xs">
             {goalSourceLabel(goal.source)}
@@ -755,13 +770,15 @@ function InspectorFooter({ detail }: { detail: SessionDetail }) {
 export function SessionInspector({
   session,
   sessionsVersion,
+  synthesisSettingsKey,
   onClose,
 }: {
   session: Session | null;
   sessionsVersion: number;
+  synthesisSettingsKey: string;
   onClose: () => void;
 }) {
-  const detail = useSessionDetail(session, sessionsVersion);
+  const detail = useSessionDetail(session, sessionsVersion, synthesisSettingsKey);
   const contentRef = useRef<HTMLDivElement>(null);
   const isOpen = session != null;
 

--- a/frontend/src/pages/coslash/components/SettingsDialog.tsx
+++ b/frontend/src/pages/coslash/components/SettingsDialog.tsx
@@ -1,0 +1,443 @@
+import { useEffect, useState, type ReactNode } from 'react';
+import { Check, ChevronDown, ChevronRight, Settings, TriangleAlert } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { cn } from '@/lib/utils';
+import {
+  initialSettingsDraft,
+  modelForBackend,
+  requiresFirstRunConsent,
+  type BackendOption,
+  type CoslashSettings,
+  type SettingsResponse,
+} from '@/pages/coslash/lib/settings';
+
+function SectionLabel({ children }: { children: string }) {
+  return (
+    <div className="flex items-center gap-2 px-0.5">
+      <span className="text-muted-foreground text-[11px] font-semibold tracking-widest uppercase">
+        {children}
+      </span>
+      <span className="bg-border h-px flex-1" />
+    </div>
+  );
+}
+
+function SelectControl({
+  id,
+  label,
+  value,
+  onChange,
+  mono = false,
+  children,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  mono?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <div className="relative w-full sm:w-auto">
+      <select
+        id={id}
+        aria-label={label}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className={cn(
+          'border-border bg-background text-foreground focus-visible:border-ring focus-visible:ring-ring h-8 w-full cursor-pointer appearance-none rounded-lg border pr-8 pl-2.5 text-[13px] font-medium outline-none focus-visible:ring-3 sm:min-w-52',
+          { 'font-mono text-xs': mono },
+        )}
+      >
+        {children}
+      </select>
+      <ChevronDown
+        aria-hidden="true"
+        className="text-muted-foreground pointer-events-none absolute top-1/2 right-2.5 size-3.5 -translate-y-1/2"
+      />
+    </div>
+  );
+}
+
+function SynthesisPreference({
+  enabled,
+  onChange,
+}: {
+  enabled: boolean;
+  onChange: (enabled: boolean) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4 p-4">
+      <div className="flex min-w-0 flex-col gap-1">
+        <div className="text-sm font-semibold">AI synthesis</div>
+        <div className="text-muted-foreground text-xs text-pretty">
+          Summarize eligible session transcripts through a local CLI.
+        </div>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-label="AI synthesis"
+        aria-checked={enabled}
+        onClick={() => onChange(!enabled)}
+        className="bg-input focus-visible:border-ring focus-visible:ring-ring aria-checked:bg-primary relative inline-flex h-6 w-10 shrink-0 cursor-pointer items-center rounded-full p-0.5 transition-colors outline-none focus-visible:ring-3"
+      >
+        <span
+          className={cn(
+            'bg-background pointer-events-none size-5 rounded-full shadow-sm transition-transform',
+            {
+              'translate-x-4': enabled,
+              'translate-x-0': !enabled,
+            },
+          )}
+        />
+      </button>
+    </div>
+  );
+}
+
+function backendName(option: BackendOption): string {
+  return option.label.replace(/ CLI$/, '');
+}
+
+function BackendChoice({
+  option,
+  selected,
+  onSelect,
+}: {
+  option: BackendOption;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const name = backendName(option);
+  return (
+    <button
+      type="button"
+      disabled={!option.available}
+      aria-pressed={selected}
+      title={
+        option.available
+          ? name
+          : `The ${option.id === 'codex_exec' ? 'codex' : 'claude'} CLI was not found on PATH`
+      }
+      onClick={onSelect}
+      className={cn(
+        'border-border bg-background text-foreground focus-visible:ring-ring flex cursor-pointer items-center justify-between gap-2 rounded-xl border px-3 py-3 text-left transition-shadow outline-none focus-visible:ring-3',
+        {
+          'ring-foreground ring-2 ring-inset': selected,
+          'cursor-not-allowed opacity-50': !option.available,
+        },
+      )}
+    >
+      <span className="flex items-center gap-2">
+        <span
+          className={cn('size-2 rounded-full', {
+            'bg-claude': option.id === 'claude-cli',
+            'bg-codex': option.id === 'codex_exec',
+          })}
+        />
+        <span className="text-[13px] font-semibold">{name}</span>
+      </span>
+      {!option.available ? (
+        <span className="bg-warning-bg text-warning-fg inline-flex items-center gap-1 rounded-full px-2 py-1 text-[11px] font-semibold">
+          <span className="size-1 rounded-full bg-current" />
+          Not detected
+        </span>
+      ) : (
+        selected && <Check aria-hidden="true" className="size-3.5" strokeWidth={3} />
+      )}
+    </button>
+  );
+}
+
+function settingsEqual(left: CoslashSettings | null, right: CoslashSettings | null): boolean {
+  if (!left || !right) return left === right;
+  return (
+    left.$schema === right.$schema &&
+    left.version === right.version &&
+    left.synthesis.enabled === right.synthesis.enabled &&
+    left.synthesis.backend === right.synthesis.backend &&
+    left.synthesis.model === right.synthesis.model &&
+    left.launch.terminal === right.launch.terminal
+  );
+}
+
+export function SettingsButton({ onClick, hasError }: { onClick: () => void; hasError: boolean }) {
+  return (
+    <Button type="button" variant="outline" size="sm" className="relative" onClick={onClick}>
+      <Settings aria-hidden="true" />
+      Settings
+      {hasError && (
+        <span className="bg-destructive absolute -top-1 -right-1 size-2 rounded-full" aria-hidden="true" />
+      )}
+    </Button>
+  );
+}
+
+export type SettingsDialogMode = 'synthesis-consent' | 'full-settings';
+
+export function SettingsDialog({
+  open,
+  mode,
+  onOpenChange,
+  response,
+  isLoading,
+  loadError,
+  saveError,
+  isSaving,
+  onSave,
+}: {
+  open: boolean;
+  mode: SettingsDialogMode;
+  onOpenChange: (open: boolean) => void;
+  response: SettingsResponse | null;
+  isLoading: boolean;
+  loadError: string | null;
+  saveError: string | null;
+  isSaving: boolean;
+  onSave: (settings: CoslashSettings) => Promise<boolean>;
+}) {
+  const [draft, setDraft] = useState<CoslashSettings | null>(
+    response ? initialSettingsDraft(response) : null,
+  );
+  const [disclosureOpen, setDisclosureOpen] = useState(false);
+  const isFirstRun = requiresFirstRunConsent(response);
+  const requiresConsent = mode === 'synthesis-consent' && isFirstRun;
+  const showFullSettings = mode === 'full-settings';
+
+  useEffect(() => {
+    if (!open || !response) return;
+    setDraft(initialSettingsDraft(response));
+    setDisclosureOpen(false);
+  }, [open, response]);
+
+  const save = async () => {
+    if (!draft) return;
+    if (await onSave(draft)) onOpenChange(false);
+  };
+
+  const initialDraft = response ? initialSettingsDraft(response) : null;
+  const isDirty = !settingsEqual(draft, initialDraft);
+  const selectedBackend = response?.options.synthesisBackends.find(
+    (option) => option.id === draft?.synthesis.backend,
+  );
+  const selectedModel = selectedBackend?.models.find((option) => option.id === draft?.synthesis.model);
+  const selectedTerminal = response?.options.terminals.find((option) => option.id === draft?.launch.terminal);
+  const canSave = isFirstRun || response?.valid === false || isDirty;
+  const status = saveError
+    ? { label: 'Save failed', className: 'text-destructive' }
+    : isSaving
+      ? { label: 'Saving…', className: 'text-muted-foreground' }
+      : response?.valid === false
+        ? { label: 'Repair required', className: 'text-warning-fg' }
+        : isDirty
+          ? { label: 'Unsaved changes', className: 'text-warning-fg' }
+          : isFirstRun
+            ? { label: 'Not saved yet', className: 'text-warning-fg' }
+            : { label: 'No changes', className: 'text-muted-foreground' };
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => (!requiresConsent || next ? onOpenChange(next) : undefined)}>
+      <DialogContent
+        className="max-h-[calc(100svh-2rem)] gap-0 overflow-hidden p-0 shadow-2xl sm:max-w-xl"
+        showCloseButton={!requiresConsent}
+        onEscapeKeyDown={(event) => requiresConsent && event.preventDefault()}
+        onPointerDownOutside={(event) => requiresConsent && event.preventDefault()}
+      >
+        <DialogHeader className="gap-1.5 p-4 pr-12 pb-3">
+          <DialogTitle>{showFullSettings ? 'Settings' : 'Choose how coSlash handles synthesis'}</DialogTitle>
+          <DialogDescription className="flex items-center gap-1.5 text-xs">
+            <span>Machine-wide.</span>
+            <code className="bg-muted rounded-md px-1.5 py-0.5 font-mono text-[11px]">
+              ~/.coslash/settings.json
+            </code>
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="overflow-y-auto px-4 pt-1 pb-4">
+          {isLoading ? (
+            <div className="text-muted-foreground py-8 text-sm">Loading settings…</div>
+          ) : loadError ? (
+            <div role="alert" className="text-destructive py-4 text-sm">
+              Could not load settings: {loadError}
+            </div>
+          ) : response && draft ? (
+            <div className="flex flex-col gap-5">
+              {!response.valid && (
+                <div role="alert" className="text-destructive rounded-xl border p-3 text-sm">
+                  {response.error} Save valid settings below to repair the file.
+                </div>
+              )}
+
+              <div className="flex flex-col gap-2">
+                <SectionLabel>Synthesis</SectionLabel>
+                <div className="border-border bg-card overflow-hidden rounded-xl border">
+                  <SynthesisPreference
+                    enabled={draft.synthesis.enabled}
+                    onChange={(enabled) => setDraft({ ...draft, synthesis: { ...draft.synthesis, enabled } })}
+                  />
+
+                  {draft.synthesis.enabled ? (
+                    <div className="bg-muted flex flex-col gap-4 border-t p-4">
+                      <div className="flex flex-col gap-2">
+                        <div className="flex items-baseline justify-between gap-3">
+                          <div className="text-[13px] font-semibold">Backend</div>
+                          <div className="text-muted-foreground text-[11px]">
+                            Runs through your existing CLI account
+                          </div>
+                        </div>
+                        <div className="grid gap-2.5 sm:grid-cols-2">
+                          {response.options.synthesisBackends.map((option) => (
+                            <BackendChoice
+                              key={option.id}
+                              option={option}
+                              selected={option.id === draft.synthesis.backend}
+                              onSelect={() =>
+                                setDraft({
+                                  ...draft,
+                                  synthesis: {
+                                    ...draft.synthesis,
+                                    backend: option.id,
+                                    model: modelForBackend(response, option.id),
+                                  },
+                                })
+                              }
+                            />
+                          ))}
+                        </div>
+                      </div>
+
+                      <div className="border-border flex flex-col gap-3 border-t pt-3 sm:flex-row sm:items-center sm:justify-between">
+                        <div className="flex min-w-0 flex-col gap-1">
+                          <div className="text-[13px] font-semibold">Model</div>
+                          <div className="text-muted-foreground text-[11px]">
+                            {selectedBackend ? `${backendName(selectedBackend)} models` : 'Select a backend'}
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          {selectedModel?.default && (
+                            <span className="border-border bg-background text-muted-foreground inline-flex rounded-full border px-2 py-1 text-[11px] font-semibold">
+                              Default
+                            </span>
+                          )}
+                          <SelectControl
+                            id="synthesis-model"
+                            label="Synthesis model"
+                            value={draft.synthesis.model}
+                            mono
+                            onChange={(model) =>
+                              setDraft({ ...draft, synthesis: { ...draft.synthesis, model } })
+                            }
+                          >
+                            {selectedBackend?.models.map((option) => (
+                              <option key={option.id} value={option.id}>
+                                {option.id}
+                              </option>
+                            ))}
+                          </SelectControl>
+                        </div>
+                      </div>
+
+                      <div className="border-border border-t pt-3">
+                        <button
+                          type="button"
+                          aria-expanded={disclosureOpen}
+                          onClick={() => setDisclosureOpen((current) => !current)}
+                          className="text-muted-foreground flex cursor-pointer items-center gap-1.5 text-[11px] font-semibold"
+                        >
+                          <ChevronRight
+                            aria-hidden="true"
+                            className={cn('size-3 transition-transform', { 'rotate-90': disclosureOpen })}
+                            strokeWidth={2.5}
+                          />
+                          What synthesis sends
+                        </button>
+                        {disclosureOpen && (
+                          <div className="text-muted-foreground pt-2 text-[11px] leading-relaxed text-pretty">
+                            coSlash sends derived session facts through the selected CLI using your existing
+                            account. This may consume account usage. Results are cached under{' '}
+                            <code className="font-mono">~/.coslash</code>. Source transcripts are never
+                            modified, and coSlash does not store API keys or tokens in settings.
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="bg-muted text-muted-foreground border-t px-4 py-3 text-[11px]">
+                      Off — sessions get deterministic debriefs only. Nothing leaves this machine.
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {showFullSettings && (
+                <div className="flex flex-col gap-2">
+                  <SectionLabel>Launch</SectionLabel>
+                  <div className="border-border bg-card overflow-hidden rounded-xl border">
+                    <div className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
+                      <div className="flex min-w-0 flex-col gap-1">
+                        <div className="text-sm font-semibold">Terminal</div>
+                        <div className="text-muted-foreground text-xs">
+                          Opens new, resumed, and handoff sessions.
+                        </div>
+                      </div>
+                      <SelectControl
+                        id="launch-terminal"
+                        label="Terminal for new, resumed, and handoff sessions"
+                        value={draft.launch.terminal}
+                        onChange={(terminal) => setDraft({ ...draft, launch: { terminal } })}
+                      >
+                        {response.options.terminals.map((option) => (
+                          <option key={option.id} value={option.id} disabled={!option.available}>
+                            {option.label}
+                            {option.available ? '' : ' — not detected'}
+                          </option>
+                        ))}
+                      </SelectControl>
+                    </div>
+                    {selectedTerminal && !selectedTerminal.available && (
+                      <div
+                        role="alert"
+                        className="bg-muted text-warning-fg flex items-start gap-2 border-t px-4 py-3 text-[11px] text-pretty"
+                      >
+                        <TriangleAlert aria-hidden="true" className="mt-0.5 size-3.5 shrink-0" />
+                        <span>
+                          {selectedTerminal.label} is not available. Session launches will show an error
+                          rather than use a different terminal.
+                        </span>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {saveError && (
+                <div role="alert" className="text-destructive text-sm">
+                  {saveError}
+                </div>
+              )}
+            </div>
+          ) : null}
+        </div>
+
+        <div className="bg-muted flex items-center justify-between gap-4 border-t px-4 py-3">
+          <div className={cn('flex items-center gap-2 text-xs', status.className)}>
+            <span className="size-1.5 rounded-full bg-current" />
+            {status.label}
+          </div>
+          <div className="flex items-center gap-2">
+            {!requiresConsent && (
+              <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isSaving}>
+                Cancel
+              </Button>
+            )}
+            <Button onClick={() => void save()} disabled={!draft || isSaving || !canSave}>
+              {isFirstRun ? 'Save settings' : 'Save changes'}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/pages/coslash/components/SettingsDialog.tsx
+++ b/frontend/src/pages/coslash/components/SettingsDialog.tsx
@@ -212,11 +212,6 @@ export function SettingsDialog({
     setDisclosureOpen(false);
   }, [open, response]);
 
-  const save = async () => {
-    if (!draft) return;
-    if (await onSave(draft)) onOpenChange(false);
-  };
-
   const initialDraft = response ? initialSettingsDraft(response) : null;
   const isDirty = !settingsEqual(draft, initialDraft);
   const selectedBackend = response?.options.synthesisBackends.find(
@@ -224,18 +219,27 @@ export function SettingsDialog({
   );
   const selectedModel = selectedBackend?.models.find((option) => option.id === draft?.synthesis.model);
   const selectedTerminal = response?.options.terminals.find((option) => option.id === draft?.launch.terminal);
-  const canSave = isFirstRun || response?.valid === false || isDirty;
+  const synthesisBackendAvailable = draft?.synthesis.enabled !== true || selectedBackend?.available === true;
+  const canSave = (isFirstRun || response?.valid === false || isDirty) && synthesisBackendAvailable;
+
+  const save = async () => {
+    if (!draft || !synthesisBackendAvailable) return;
+    if (await onSave(draft)) onOpenChange(false);
+  };
+
   const status = saveError
     ? { label: 'Save failed', className: 'text-destructive' }
     : isSaving
       ? { label: 'Saving…', className: 'text-muted-foreground' }
-      : response?.valid === false
-        ? { label: 'Repair required', className: 'text-warning-fg' }
-        : isDirty
-          ? { label: 'Unsaved changes', className: 'text-warning-fg' }
-          : isFirstRun
-            ? { label: 'Not saved yet', className: 'text-warning-fg' }
-            : { label: 'No changes', className: 'text-muted-foreground' };
+      : !synthesisBackendAvailable
+        ? { label: 'Backend unavailable', className: 'text-warning-fg' }
+        : response?.valid === false
+          ? { label: 'Repair required', className: 'text-warning-fg' }
+          : isDirty
+            ? { label: 'Unsaved changes', className: 'text-warning-fg' }
+            : isFirstRun
+              ? { label: 'Not saved yet', className: 'text-warning-fg' }
+              : { label: 'No changes', className: 'text-muted-foreground' };
 
   return (
     <Dialog open={open} onOpenChange={(next) => (!requiresConsent || next ? onOpenChange(next) : undefined)}>

--- a/frontend/src/pages/coslash/hooks/use-settings.ts
+++ b/frontend/src/pages/coslash/hooks/use-settings.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+import type { CoslashSettings, SettingsResponse } from '@/pages/coslash/lib/settings';
+
+async function readError(response: Response): Promise<string> {
+  const message = (await response.text()).trim();
+  return message || `Settings request failed (${response.status})`;
+}
+
+export function useSettings() {
+  const [response, setResponse] = useState<SettingsResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetch('/api/settings', { signal: controller.signal })
+      .then(async (result) => {
+        if (!result.ok) throw new Error(await readError(result));
+        return result.json() as Promise<SettingsResponse>;
+      })
+      .then((loaded) => {
+        if (controller.signal.aborted) return;
+        setResponse(loaded);
+        setIsLoading(false);
+      })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) return;
+        setLoadError(error instanceof Error ? error.message : String(error));
+        setIsLoading(false);
+      });
+    return () => controller.abort();
+  }, []);
+
+  const save = async (settings: CoslashSettings): Promise<boolean> => {
+    setIsSaving(true);
+    setSaveError(null);
+    try {
+      const result = await fetch('/api/settings', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(settings),
+      });
+      if (!result.ok) throw new Error(await readError(result));
+      setResponse((await result.json()) as SettingsResponse);
+      setIsSaving(false);
+      return true;
+    } catch (error: unknown) {
+      setSaveError(error instanceof Error ? error.message : String(error));
+      setIsSaving(false);
+      return false;
+    }
+  };
+
+  return { response, isLoading, loadError, saveError, isSaving, save };
+}

--- a/frontend/src/pages/coslash/lib/session.ts
+++ b/frontend/src/pages/coslash/lib/session.ts
@@ -40,6 +40,7 @@ export type Session = {
   entrypoint: string | null;
   synthesis: SessionSynthesis | null;
   synthesisPending: boolean;
+  synthesisError?: string;
   declaredGoal: string | null;
   logPath: string;
   model: string | null;
@@ -81,6 +82,12 @@ export type DigestEntry = {
 export type SessionDetail = Session;
 
 export type GoalSource = 'declared' | 'inferred' | 'floor';
+
+export function isSynthesisEligible(
+  session: Pick<Session, 'turns' | 'compactions' | 'contextTokens'>,
+): boolean {
+  return session.turns > 5 || session.compactions > 0 || (session.contextTokens ?? 0) > 100_000;
+}
 
 export function goalSourceLabel(source: GoalSource): string {
   return source === 'floor' ? 'first prompt' : source;

--- a/frontend/src/pages/coslash/lib/settings.ts
+++ b/frontend/src/pages/coslash/lib/settings.ts
@@ -1,0 +1,71 @@
+import { isSynthesisEligible, type Session } from '@/pages/coslash/lib/session';
+
+export type SynthesisSettings = {
+  enabled: boolean;
+  backend: string;
+  model: string;
+};
+
+export type CoslashSettings = {
+  $schema: string;
+  version: number;
+  synthesis: SynthesisSettings;
+  launch: { terminal: string };
+};
+
+export type ModelOption = {
+  id: string;
+  label: string;
+  default: boolean;
+};
+
+export type BackendOption = {
+  id: string;
+  label: string;
+  models: ModelOption[];
+  available: boolean;
+};
+
+export type TerminalOption = {
+  id: string;
+  label: string;
+  available: boolean;
+};
+
+export type SettingsResponse = {
+  settings: CoslashSettings;
+  persisted: boolean;
+  valid: boolean;
+  error?: string;
+  options: {
+    synthesisBackends: BackendOption[];
+    terminals: TerminalOption[];
+  };
+};
+
+export function modelForBackend(response: SettingsResponse, backend: string): string {
+  const option = response.options.synthesisBackends.find((candidate) => candidate.id === backend);
+  return option?.models.find((model) => model.default)?.id ?? option?.models[0]?.id ?? '';
+}
+
+export function initialSettingsDraft(response: SettingsResponse): CoslashSettings {
+  return {
+    ...response.settings,
+    synthesis: {
+      ...response.settings.synthesis,
+      enabled: response.persisted ? response.settings.synthesis.enabled : true,
+    },
+    launch: { ...response.settings.launch },
+  };
+}
+
+export function requiresFirstRunConsent(response: SettingsResponse | null): boolean {
+  return response != null && !response.persisted;
+}
+
+export function shouldPromptForSynthesisConsent(
+  session: Pick<Session, 'turns' | 'compactions' | 'contextTokens'> | null,
+  response: SettingsResponse | null,
+): boolean {
+  return session != null && requiresFirstRunConsent(response) && isSynthesisEligible(session);
+}

--- a/frontend/src/pages/coslash/lib/settings.ts
+++ b/frontend/src/pages/coslash/lib/settings.ts
@@ -49,12 +49,20 @@ export function modelForBackend(response: SettingsResponse, backend: string): st
 }
 
 export function initialSettingsDraft(response: SettingsResponse): CoslashSettings {
+  const synthesis = { ...response.settings.synthesis };
+
+  if (!response.persisted) {
+    const availableBackend = response.options.synthesisBackends.find((option) => option.available);
+    synthesis.enabled = availableBackend != null;
+    if (availableBackend) {
+      synthesis.backend = availableBackend.id;
+      synthesis.model = modelForBackend(response, availableBackend.id);
+    }
+  }
+
   return {
     ...response.settings,
-    synthesis: {
-      ...response.settings.synthesis,
-      enabled: response.persisted ? response.settings.synthesis.enabled : true,
-    },
+    synthesis,
     launch: { ...response.settings.launch },
   };
 }

--- a/settings.schema.json
+++ b/settings.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/centauri-ai/coslash/main/settings.schema.json",
+  "title": "coSlash global settings",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["$schema", "version", "synthesis", "launch"],
+  "properties": {
+    "$schema": {
+      "const": "https://raw.githubusercontent.com/centauri-ai/coslash/main/settings.schema.json"
+    },
+    "version": { "const": 1 },
+    "synthesis": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled", "backend", "model"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "backend": { "enum": ["claude-cli", "codex_exec"] },
+        "model": {
+          "enum": [
+            "claude-haiku-4-5",
+            "claude-sonnet-5",
+            "claude-opus-5",
+            "gpt-5.6-luna",
+            "gpt-5.6-terra",
+            "gpt-5.6-sol"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "backend": { "const": "claude-cli" } } },
+          "then": {
+            "properties": {
+              "model": {
+                "enum": ["claude-haiku-4-5", "claude-sonnet-5", "claude-opus-5"]
+              }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "backend": { "const": "codex_exec" } } },
+          "then": {
+            "properties": {
+              "model": { "enum": ["gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol"] }
+            }
+          }
+        }
+      ]
+    },
+    "launch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["terminal"],
+      "properties": {
+        "terminal": { "enum": ["terminal", "iterm2"] }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Context

coSlash currently hard-codes its synthesis backend, model, and macOS terminal. This adds secure machine-wide settings with explicit synthesis consent, configurable runtime choices, and fail-closed handling for invalid configuration.

## Changes

- Add a versioned `~/.coslash/settings.json` schema and restricted atomic persistence.
- Add first-run synthesis consent and a full settings UI with availability and error states.
- Support Claude Code and Codex synthesis backends with selectable models.
- Support Apple Terminal and iTerm2 with availability checks and immediate runtime updates.

## Test

fresh start or delete `~/.coslash/settings.json`

### Screenshots

<img width="795" height="749" alt="Screenshot 2026-08-04 at 3 20 29 PM" src="https://github.com/user-attachments/assets/21d39c41-c54d-4dd8-adf6-d21165bdd82a" />
