### PR TITLE
Harden loopback server access with per-run tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ Running `coslash` starts one executable at
 [http://127.0.0.1:8787](http://127.0.0.1:8787) and opens a browser. There is no
 Node, Vite, or second process at runtime.
 
-| Flag | Effect |
-| --- | --- |
-| `--port N` | serve on port N (default `8787`) |
-| `--no-open` | do not open the browser |
-| `--version` | print the version and exit |
+| Flag        | Effect                           |
+| ----------- | -------------------------------- |
+| `--port N`  | serve on port N (default `8787`) |
+| `--no-open` | do not open the browser          |
+| `--version` | print the version and exit       |
 
 ## Build from source
 
@@ -63,6 +63,12 @@ That builds the frontend, embeds it into the binary, and leaves it at
 architectures into `collector/dist/` with a `checksums.txt`, which is what the
 release workflow publishes.
 
+On every start, coSlash prints and opens a URL containing a new access token.
+Use that URL rather than typing the address by hand. The token is delivered in
+the URL fragment, kept in browser session storage, and, when local storage is
+writable, saved to `~/.coslash/token` with owner-only permissions. An old link
+expires when the server restarts.
+
 ## Develop
 
 In two terminals:
@@ -72,7 +78,23 @@ cd collector && make run
 cd frontend && npm run dev
 ```
 
-The UI is at [http://localhost:5173](http://localhost:5173): Vite serves it and proxies `/api` to the Go server on port `8787`. `make run` embeds no frontend and opens no browser, so port `8787` serves the API alone.
+The UI is at [http://127.0.0.1:5173](http://127.0.0.1:5173): Vite serves it and
+proxies `/api` to the Go server on port `8787`, reading the current development
+token automatically. If port `5173` is occupied, use the fallback URL Vite
+prints. `make run` embeds no frontend and opens no browser, so port `8787`
+serves the API alone.
+
+The production server binds only to IPv4 loopback and rejects unexpected Host,
+Origin, and cross-site browser requests. Direct API calls must include the
+current token. This form keeps the token out of `curl`'s process arguments:
+
+```sh
+sed 's/^/header = "X-Coslash-Token: /; s/$/"/' ~/.coslash/token \
+  | curl --config - http://127.0.0.1:8787/api/sessions
+```
+
+coSlash does not enable CORS. New HTTP routes must remain behind the same
+loopback request guard.
 
 ## Global settings
 
@@ -91,7 +113,7 @@ Use the top-right Settings dialog to apply synthesis and terminal changes immedi
 
 After installing coSlash, run `coslash doctor` to check detected session sources, CLIs, and local storage.
 
-| Command | Effect |
-| --- | --- |
-| `coslash doctor` | Print checks and local diagnostic facts; exits non-zero when a check fails. |
-| `coslash doctor --json` | Print the same diagnostic snapshot as JSON. |
+| Command                 | Effect                                                                      |
+| ----------------------- | --------------------------------------------------------------------------- |
+| `coslash doctor`        | Print checks and local diagnostic facts; exits non-zero when a check fails. |
+| `coslash doctor --json` | Print the same diagnostic snapshot as JSON.                                 |

--- a/collector/CLAUDE.md
+++ b/collector/CLAUDE.md
@@ -1,0 +1,11 @@
+# Collector HTTP security
+
+All routes, including the embedded frontend, must be served through
+`internal/httpsec.Guard`. New routes must not bypass the guard or emit CORS
+headers. API routes require the per-run token and must use method-qualified
+`http.ServeMux` patterns. Frontend requests to `/api/` must use `apiFetch` so
+the per-run token is attached. Keep internal errors in server logs and return
+fixed, non-sensitive messages to clients.
+
+The token prevents requests from other browser origins; it does not protect
+against local processes running as the same user, which can read the token file.

--- a/collector/cmd/coslash/api.go
+++ b/collector/cmd/coslash/api.go
@@ -29,7 +29,7 @@ func handleList(w http.ResponseWriter, r *http.Request, mgr *synthesis.Manager) 
 	sessions, err := collector.List(since)
 	if err != nil {
 		log.Printf("list sessions: %v", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, "could not list sessions", http.StatusInternalServerError)
 		return
 	}
 	for _, session := range sessions {
@@ -62,7 +62,7 @@ func handleSynthesis(w http.ResponseWriter, id string, mgr *synthesis.Manager) {
 	found, err := collector.Get(id)
 	if err != nil {
 		log.Printf("synthesis: %v", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, "could not load synthesis", http.StatusInternalServerError)
 		return
 	}
 	if found == nil {
@@ -109,7 +109,7 @@ func handleLaunch(w http.ResponseWriter, r *http.Request, settingsStore *setting
 	found, err := collector.Get(query.Get("id"))
 	if err != nil {
 		log.Printf("launch: %v", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, "could not load session", http.StatusInternalServerError)
 		return
 	}
 	if found == nil {
@@ -125,7 +125,7 @@ func handleLaunch(w http.ResponseWriter, r *http.Request, settingsStore *setting
 	mode := query.Get("mode")
 	if err := launch.Terminal(state.Config.Launch.Terminal, found.Agent, found.WorkingDirectory, found.ID, mode, handoff); err != nil {
 		log.Printf("launch: %v", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, "could not launch terminal", http.StatusInternalServerError)
 		return
 	}
 	log.Printf("launch %s: %s %s", mode, found.Agent, found.ID)

--- a/collector/cmd/coslash/main.go
+++ b/collector/cmd/coslash/main.go
@@ -3,6 +3,8 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"errors"
 	"flag"
 	"fmt"
@@ -10,11 +12,13 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"syscall"
 	"time"
 
 	"github.com/centauri-ai/coslash/collector/internal/collector"
 	"github.com/centauri-ai/coslash/collector/internal/diagnostics"
+	"github.com/centauri-ai/coslash/collector/internal/httpsec"
 	"github.com/centauri-ai/coslash/collector/internal/session"
 	"github.com/centauri-ai/coslash/collector/internal/settings"
 	"github.com/centauri-ai/coslash/collector/internal/synthesis"
@@ -94,22 +98,44 @@ func main() {
 	if err != nil {
 		log.Fatalf("coslash: %v", err)
 	}
-	url := "http://" + listener.Addr().String()
-	log.Printf("listening on %s", url)
+	token, err := newToken()
+	if err != nil {
+		log.Fatalf("coslash: generate API token: %v", err)
+	}
+	if err := writeToken(token); err != nil {
+		log.Printf("write API token: %v", err)
+	}
+	baseURL := "http://" + listener.Addr().String()
+	accessURL := baseURL + "/#t=" + token
+	log.Printf("listening on %s", baseURL)
+	log.Printf("open %s", accessURL)
 	if !opts.noOpen {
-		if err := openBrowser(url); err != nil {
-			log.Printf("could not open a browser (%v); open %s yourself", err, url)
+		if err := openBrowser(accessURL); err != nil {
+			log.Printf("could not open a browser (%v); use the URL above", err)
 		}
 	}
-	if err := http.Serve(listener, routes(mgr, settingsStore)); err != nil {
+	guard := httpsec.Guard{Addr: listener.Addr().String(), Token: token}
+	server := newServer(guard, mgr, settingsStore)
+	if err := server.Serve(listener); err != nil {
 		log.Fatalf("coslash: %v", err)
+	}
+}
+
+func newServer(guard httpsec.Guard, mgr *synthesis.Manager, settingsStore *settings.Store) *http.Server {
+	return &http.Server{
+		Handler:           guard.Wrap(routes(mgr, settingsStore)),
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      3 * time.Minute,
+		IdleTimeout:       60 * time.Second,
+		MaxHeaderBytes:    1 << 16,
 	}
 }
 
 func routes(mgr *synthesis.Manager, settingsStore *settings.Store) *http.ServeMux {
 	mux := http.NewServeMux()
 	api := http.NewServeMux()
-	api.HandleFunc("/api/sessions", func(w http.ResponseWriter, r *http.Request) {
+	api.HandleFunc("GET /api/sessions", func(w http.ResponseWriter, r *http.Request) {
 		handleList(w, r, mgr)
 	})
 	api.HandleFunc("GET /api/synthesis", func(w http.ResponseWriter, r *http.Request) {
@@ -127,30 +153,18 @@ func routes(mgr *synthesis.Manager, settingsStore *settings.Store) *http.ServeMu
 	api.HandleFunc("GET /api/diagnostics", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, diagnostics.Collect(r.Context(), version, false))
 	})
-	apiHandler := sameOriginAPI(api)
-	mux.Handle("/api", apiHandler)
-	mux.Handle("/api/", apiHandler)
+	mux.Handle("/api", api)
+	mux.Handle("/api/", api)
 
 	frontend, err := web.Handler()
 	if err != nil {
 		// A `make build` binary has no staged assets; keep its API usable for
 		// `npm run dev` instead of failing to start.
-		log.Printf("coslash: %v", err)
-		frontend = unavailable(err)
+		log.Printf("coslash: frontend unavailable: %v", err)
+		frontend = unavailable()
 	}
 	mux.Handle("/", frontend)
 	return mux
-}
-
-func sameOriginAPI(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		site := r.Header.Get("Sec-Fetch-Site")
-		if site != "" && site != "same-origin" && site != "none" {
-			http.Error(w, "cross-origin API requests are not allowed", http.StatusForbidden)
-			return
-		}
-		next.ServeHTTP(w, r)
-	})
 }
 
 func listen(port int) (net.Listener, error) {
@@ -165,8 +179,38 @@ func listen(port int) (net.Listener, error) {
 	return listener, nil
 }
 
-func unavailable(err error) http.Handler {
+func unavailable() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		http.Error(w, "frontend unavailable", http.StatusServiceUnavailable)
 	})
+}
+
+func newToken() (string, error) {
+	random := make([]byte, 32)
+	if _, err := rand.Read(random); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(random), nil
+}
+
+func writeToken(token string) error {
+	home := settings.Home()
+	if err := os.MkdirAll(home, 0o700); err != nil {
+		return err
+	}
+	path := filepath.Join(home, "token")
+	temporary, err := os.CreateTemp(home, ".token-*")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	if _, err := temporary.WriteString(token + "\n"); err != nil {
+		temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	return os.Rename(temporaryPath, path)
 }

--- a/collector/cmd/coslash/main_test.go
+++ b/collector/cmd/coslash/main_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"encoding/base64"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/centauri-ai/coslash/collector/internal/httpsec"
+	"github.com/centauri-ai/coslash/collector/internal/settings"
+	"github.com/centauri-ai/coslash/collector/internal/synthesis"
+)
+
+func TestListenBindsIPv4Loopback(t *testing.T) {
+	listener, err := listen(0)
+	if err != nil {
+		if errors.Is(err, syscall.EPERM) || errors.Is(err, syscall.EACCES) {
+			t.Skipf("sandbox does not permit opening a loopback listener: %v", err)
+		}
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	host, _, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if host != "127.0.0.1" {
+		t.Fatalf("listener host = %q, want 127.0.0.1", host)
+	}
+}
+
+func TestAPIRoutesRejectUnsupportedMethods(t *testing.T) {
+	t.Setenv("COSLASH_HOME", t.TempDir())
+	handler := routes(synthesis.NewManager(nil), settings.Open())
+	for _, test := range []struct {
+		method string
+		path   string
+	}{
+		{method: http.MethodPost, path: "/api/sessions"},
+		{method: http.MethodPost, path: "/api/synthesis"},
+		{method: http.MethodGet, path: "/api/launch"},
+		{method: http.MethodPost, path: "/api/diagnostics"},
+	} {
+		t.Run(test.method+" "+test.path, func(t *testing.T) {
+			request := httptest.NewRequest(test.method, "http://127.0.0.1"+test.path, nil)
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, request)
+			if response.Code != http.StatusMethodNotAllowed {
+				t.Fatalf("status = %d, want %d", response.Code, http.StatusMethodNotAllowed)
+			}
+		})
+	}
+}
+
+func TestServerWrapsRoutesWithGuard(t *testing.T) {
+	t.Setenv("COSLASH_HOME", t.TempDir())
+	server := newServer(
+		httpsec.Guard{Addr: "127.0.0.1:8787", Token: "secret"},
+		synthesis.NewManager(nil),
+		settings.Open(),
+	)
+	request := httptest.NewRequest(http.MethodGet, "http://evil.example:8787/", nil)
+	response := httptest.NewRecorder()
+	server.Handler.ServeHTTP(response, request)
+	if response.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusForbidden)
+	}
+}
+
+func TestTokenLifecycle(t *testing.T) {
+	token, err := newToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		t.Fatalf("decode token: %v", err)
+	}
+	if len(decoded) != 32 {
+		t.Fatalf("token contains %d bytes, want 32", len(decoded))
+	}
+
+	home := filepath.Join(t.TempDir(), "coslash")
+	t.Setenv("COSLASH_HOME", home)
+	if err := writeToken(token); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(home, "token")
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(contents)) != token {
+		t.Fatal("token file does not contain generated token")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("token mode = %o, want 600", info.Mode().Perm())
+	}
+}
+
+func TestWriteTokenPreservesHomePermissions(t *testing.T) {
+	home := t.TempDir()
+	if err := os.Chmod(home, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("COSLASH_HOME", home)
+
+	if err := writeToken("secret"); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o750 {
+		t.Fatalf("home mode = %o, want 750", info.Mode().Perm())
+	}
+}

--- a/collector/internal/httpsec/httpsec.go
+++ b/collector/internal/httpsec/httpsec.go
@@ -1,0 +1,95 @@
+// Package httpsec guards the loopback server against browser-borne attacks.
+// A page in the user's browser can reach 127.0.0.1 even though a remote host
+// cannot, so loopback binding alone is not an authorization boundary.
+package httpsec
+
+import (
+	"crypto/subtle"
+	"log"
+	"net"
+	"net/http"
+	"strings"
+)
+
+const documentPolicy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'; object-src 'none'"
+
+// Guard restricts requests to the loopback listener and its browser origin.
+type Guard struct {
+	Addr  string
+	Token string
+}
+
+// Wrap applies loopback request validation and security response headers.
+func (g Guard) Wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		setSecurityHeaders(w.Header(), r.URL.Path)
+
+		if !g.allowedHost(r.Host) {
+			log.Printf("http security: rejected unexpected host %q", r.Host)
+			http.Error(w, "request rejected", http.StatusForbidden)
+			return
+		}
+
+		if site := r.Header.Get("Sec-Fetch-Site"); site != "" {
+			navigation := strings.EqualFold(r.Header.Get("Sec-Fetch-Mode"), "navigate") &&
+				strings.EqualFold(r.Header.Get("Sec-Fetch-Dest"), "document")
+			if !navigation && !strings.EqualFold(site, "same-origin") && !strings.EqualFold(site, "none") {
+				log.Printf("http security: rejected cross-site request")
+				http.Error(w, "request rejected", http.StatusForbidden)
+				return
+			}
+		} else if origin := r.Header.Get("Origin"); origin != "" && origin != "http://"+g.Addr {
+			log.Printf("http security: rejected unexpected origin %q", origin)
+			http.Error(w, "request rejected", http.StatusForbidden)
+			return
+		}
+
+		if strings.HasPrefix(r.URL.Path, "/api/") && !g.allowedToken(r) {
+			log.Printf("http security: rejected unauthenticated API request")
+			http.Error(w, "authentication required", http.StatusUnauthorized)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (g Guard) allowedHost(requestHost string) bool {
+	if requestHost == g.Addr {
+		return true
+	}
+	_, listenerPort, err := net.SplitHostPort(g.Addr)
+	if err != nil {
+		return false
+	}
+	host, port, err := net.SplitHostPort(requestHost)
+	if err != nil || port != listenerPort {
+		return false
+	}
+	return strings.EqualFold(host, "localhost") || host == "::1"
+}
+
+func (g Guard) allowedToken(r *http.Request) bool {
+	if g.Token == "" {
+		return false
+	}
+	provided := r.Header.Get("X-Coslash-Token")
+	if provided == "" {
+		if bearer, ok := strings.CutPrefix(r.Header.Get("Authorization"), "Bearer "); ok {
+			provided = bearer
+		}
+	}
+	return subtle.ConstantTimeCompare([]byte(provided), []byte(g.Token)) == 1
+}
+
+func setSecurityHeaders(header http.Header, requestPath string) {
+	header.Set("X-Content-Type-Options", "nosniff")
+	header.Set("Referrer-Policy", "no-referrer")
+	header.Set("Cross-Origin-Resource-Policy", "same-origin")
+	header.Set("Cross-Origin-Opener-Policy", "same-origin")
+	if strings.HasPrefix(requestPath, "/api/") {
+		header.Set("Cache-Control", "no-store")
+		return
+	}
+	header.Set("Content-Security-Policy", documentPolicy)
+}

--- a/collector/internal/httpsec/httpsec_test.go
+++ b/collector/internal/httpsec/httpsec_test.go
@@ -1,0 +1,130 @@
+package httpsec
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGuardRequests(t *testing.T) {
+	tests := []struct {
+		name      string
+		guardAddr string
+		path      string
+		method    string
+		host      string
+		origin    string
+		fetchSite string
+		fetchMode string
+		fetchDest string
+		token     string
+		auth      string
+		want      int
+	}{
+		{name: "API by address", path: "/api/sessions", host: "127.0.0.1:8787", token: "secret", want: http.StatusOK},
+		{name: "localhost navigation", path: "/api/sessions", host: "localhost:8787", fetchSite: "none", token: "secret", want: http.StatusOK},
+		{name: "bearer token", path: "/api/sessions", host: "127.0.0.1:8787", auth: "Bearer secret", want: http.StatusOK},
+		{name: "rebound host", path: "/api/sessions", host: "a.evil.com:8787", token: "secret", want: http.StatusForbidden},
+		{name: "listener port mismatch", guardAddr: "127.0.0.1:9999", path: "/api/sessions", host: "127.0.0.1:8787", token: "secret", want: http.StatusForbidden},
+		{name: "evil origin", path: "/api/sessions", host: "127.0.0.1:8787", origin: "http://evil.com", token: "secret", want: http.StatusForbidden},
+		{name: "cross-site read", path: "/api/sessions", host: "127.0.0.1:8787", fetchSite: "cross-site", token: "secret", want: http.StatusForbidden},
+		{name: "same-site read", path: "/api/sessions", host: "127.0.0.1:8787", fetchSite: "same-site", token: "secret", want: http.StatusForbidden},
+		{name: "cross-site document navigation", path: "/", host: "127.0.0.1:8787", fetchSite: "cross-site", fetchMode: "navigate", fetchDest: "document", want: http.StatusOK},
+		{name: "cross-site subresource", path: "/", host: "127.0.0.1:8787", fetchSite: "cross-site", fetchMode: "cors", fetchDest: "empty", want: http.StatusForbidden},
+		{name: "wrong token", path: "/api/sessions", host: "127.0.0.1:8787", token: "wrong", want: http.StatusUnauthorized},
+		{name: "missing token", path: "/api/sessions", host: "127.0.0.1:8787", want: http.StatusUnauthorized},
+		{name: "document needs no token", path: "/", host: "127.0.0.1:8787", want: http.StatusOK},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			called := false
+			next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				called = true
+				w.WriteHeader(http.StatusOK)
+			})
+			guardAddr := test.guardAddr
+			if guardAddr == "" {
+				guardAddr = "127.0.0.1:8787"
+			}
+			method := test.method
+			if method == "" {
+				method = http.MethodGet
+			}
+			request := httptest.NewRequest(method, "http://127.0.0.1:8787"+test.path, nil)
+			request.Host = test.host
+			for name, value := range map[string]string{
+				"Origin":          test.origin,
+				"Sec-Fetch-Site":  test.fetchSite,
+				"Sec-Fetch-Mode":  test.fetchMode,
+				"Sec-Fetch-Dest":  test.fetchDest,
+				"X-Coslash-Token": test.token,
+				"Authorization":   test.auth,
+			} {
+				if value != "" {
+					request.Header.Set(name, value)
+				}
+			}
+			response := httptest.NewRecorder()
+
+			Guard{Addr: guardAddr, Token: "secret"}.Wrap(next).ServeHTTP(response, request)
+
+			if response.Code != test.want {
+				t.Fatalf("status = %d, want %d", response.Code, test.want)
+			}
+			if called != (test.want == http.StatusOK) {
+				t.Fatalf("downstream called = %t", called)
+			}
+			if response.Header().Get("Access-Control-Allow-Origin") != "" {
+				t.Fatal("guard emitted Access-Control-Allow-Origin")
+			}
+		})
+	}
+}
+
+func TestGuardEmptyTokenFailsClosed(t *testing.T) {
+	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("unauthenticated request reached downstream handler")
+	})
+	request := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:8787/api/sessions", nil)
+	response := httptest.NewRecorder()
+
+	Guard{Addr: "127.0.0.1:8787"}.Wrap(next).ServeHTTP(response, request)
+
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestGuardSecurityHeaders(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	guard := Guard{Addr: "127.0.0.1:8787", Token: "secret"}.Wrap(next)
+
+	apiRequest := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:8787/api/sessions", nil)
+	apiRequest.Header.Set("X-Coslash-Token", "secret")
+	apiResponse := httptest.NewRecorder()
+	guard.ServeHTTP(apiResponse, apiRequest)
+	if got := apiResponse.Header().Get("Cache-Control"); got != "no-store" {
+		t.Errorf("API Cache-Control = %q", got)
+	}
+
+	documentRequest := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:8787/", nil)
+	documentResponse := httptest.NewRecorder()
+	guard.ServeHTTP(documentResponse, documentRequest)
+	if got := documentResponse.Header().Get("Content-Security-Policy"); !strings.Contains(got, "frame-ancestors 'none'") {
+		t.Errorf("document Content-Security-Policy = %q", got)
+	}
+	for _, name := range []string{
+		"X-Content-Type-Options",
+		"Referrer-Policy",
+		"Cross-Origin-Resource-Policy",
+		"Cross-Origin-Opener-Policy",
+	} {
+		if got := documentResponse.Header().Get(name); got == "" {
+			t.Errorf("document missing %s", name)
+		}
+	}
+}

--- a/collector/internal/web/web.go
+++ b/collector/internal/web/web.go
@@ -36,6 +36,10 @@ func handler(assets fs.FS) (http.Handler, error) {
 	}
 	files := http.FileServerFS(assets)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if hasTraversal(r.URL.Path) {
+			http.NotFound(w, r)
+			return
+		}
 		name := path.Clean(r.URL.Path)
 		switch {
 		case isFile(assets, name):
@@ -48,6 +52,15 @@ func handler(assets fs.FS) (http.Handler, error) {
 			http.ServeContent(w, r, "index.html", time.Time{}, bytes.NewReader(document))
 		}
 	}), nil
+}
+
+func hasTraversal(requestPath string) bool {
+	for _, part := range strings.Split(requestPath, "/") {
+		if part == ".." {
+			return true
+		}
+	}
+	return false
 }
 
 // isFile reports whether name is a regular file in assets. A directory fails

--- a/collector/internal/web/web_test.go
+++ b/collector/internal/web/web_test.go
@@ -1,0 +1,32 @@
+package web
+
+import (
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+)
+
+func TestHandlerRejectsTraversalAndMissingAssets(t *testing.T) {
+	assets := fstest.MapFS{
+		"index.html":    &fstest.MapFile{Data: []byte("document")},
+		"assets/app.js": &fstest.MapFile{Data: []byte("script")},
+	}
+	handler, err := handler(fs.FS(assets))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, requestPath := range []string{"/assets/../../etc/passwd", "/assets/missing.js"} {
+		t.Run(requestPath, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, "http://coslash.test/", nil)
+			request.URL.Path = requestPath
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, request)
+			if response.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, want %d", response.Code, http.StatusNotFound)
+			}
+		})
+	}
+}

--- a/collector/scripts/smoke.sh
+++ b/collector/scripts/smoke.sh
@@ -49,6 +49,7 @@ env HOME="$smoke_home" "$binary" --no-open --port 0 >"$server_log" 2>&1 &
 server_pid=$!
 
 base_url=
+token=
 for ((attempt = 1; attempt <= 40; attempt++)); do
   if ! kill -0 "$server_pid" 2>/dev/null; then
     echo "error: server exited during startup" >&2
@@ -56,7 +57,12 @@ for ((attempt = 1; attempt <= 40; attempt++)); do
     exit 1
   fi
   base_url=$(sed -n 's|.*listening on \(http://127\.0\.0\.1:[0-9]\{1,\}\).*|\1|p' "$server_log" | head -1)
-  if [[ -n "$base_url" ]] && curl -fs -o /dev/null "$base_url$readiness_path"; then
+  if [[ -f "$smoke_home/.coslash/token" ]]; then
+    IFS= read -r token <"$smoke_home/.coslash/token"
+  fi
+  if [[ -n "$base_url" && -n "$token" ]] &&
+    printf 'header = "X-Coslash-Token: %s"\n' "$token" |
+      curl --config - -fs -o /dev/null "$base_url$readiness_path"; then
     break
   fi
   base_url=
@@ -76,7 +82,10 @@ expect_status() {
   local actual
 
   echo "GET $path -> expecting $expected"
-  if ! actual=$(curl -sS -o "$response_body" -w '%{http_code}' "$base_url$path"); then
+  if ! actual=$(
+    printf 'header = "X-Coslash-Token: %s"\n' "$token" |
+      curl --config - -sS -o "$response_body" -w '%{http_code}' "$base_url$path"
+  ); then
     echo "error: GET $path failed" >&2
     exit 1
   fi

--- a/frontend/src/pages/coslash/CoslashPage.tsx
+++ b/frontend/src/pages/coslash/CoslashPage.tsx
@@ -149,7 +149,7 @@ function SessionsStats({
 }
 
 function CoslashContent({
-  loadFailed,
+  loadError,
   onRetry,
   visibleSessions,
   hasSessions,
@@ -162,7 +162,7 @@ function CoslashContent({
   diagnosticsLoadFailed,
   onRefreshDiagnostics,
 }: {
-  loadFailed: boolean;
+  loadError: string | null;
   onRetry: () => void;
   visibleSessions: Session[];
   hasSessions: boolean;
@@ -175,11 +175,11 @@ function CoslashContent({
   diagnosticsLoadFailed: boolean;
   onRefreshDiagnostics: () => void;
 }) {
-  if (loadFailed) {
+  if (loadError != null) {
     return (
       <div role="alert" className="text-destructive grid h-full place-items-center bg-neutral-50 text-sm">
         <div className="flex flex-col items-center gap-3">
-          <div>CoSlash couldn’t load sessions from the API.</div>
+          <div>{loadError}</div>
           <Button variant="outline" size="sm" onClick={onRetry}>
             Try again
           </Button>
@@ -234,9 +234,9 @@ function CoslashContent({
 export function CoslashPage() {
   const [vendor, setVendor] = useState<AgentVendor>('all');
   const [timeWindow, setTimeWindow] = useState<TimeWindow>('week');
-  const { sessions, isLoading, loadFailed, sessionsVersion, retrySessions } = useSessions(timeWindow);
+  const { sessions, isLoading, loadError, sessionsVersion, retrySessions } = useSessions(timeWindow);
   const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
-  const diagnosticsEnabled = diagnosticsOpen || (!isLoading && !loadFailed && sessions.length === 0);
+  const diagnosticsEnabled = diagnosticsOpen || (!isLoading && loadError == null && sessions.length === 0);
   const {
     diagnostics,
     isLoading: diagnosticsLoading,
@@ -322,7 +322,11 @@ export function CoslashPage() {
           <div className="flex w-full items-center justify-between gap-3">
             <div className="min-w-0 flex-1">
               <LoadingSpinner isLoading={isLoading}>
-                <SessionsStats sessions={sessionsForVendor} loadFailed={loadFailed} timeWindow={timeWindow} />
+                <SessionsStats
+                  sessions={sessionsForVendor}
+                  loadFailed={loadError != null}
+                  timeWindow={timeWindow}
+                />
               </LoadingSpinner>
             </div>
             <DiagnosticsDialog
@@ -340,7 +344,7 @@ export function CoslashPage() {
         <div className="min-h-0 flex-1 overflow-hidden">
           <LoadingSpinner isLoading={isLoading && sessions.length === 0}>
             <CoslashContent
-              loadFailed={loadFailed}
+              loadError={loadError}
               onRetry={retrySessions}
               visibleSessions={visibleSessions}
               hasSessions={sessions.length > 0}

--- a/frontend/src/pages/coslash/components/SessionInspector.tsx
+++ b/frontend/src/pages/coslash/components/SessionInspector.tsx
@@ -27,6 +27,7 @@ import {
 } from '@/pages/coslash/components/SessionCard';
 import { UnpricedModelWarning } from '@/pages/coslash/components/UnpricedModelWarning';
 import { useLaunchTerminal } from '@/pages/coslash/hooks/use-launch-terminal';
+import { ApiAuthenticationError, apiFetch } from '@/pages/coslash/lib/api';
 import { formatDuration, formatEstimatedCost, formatTimeAgo, formatTokens } from '@/pages/coslash/lib/format';
 import { handoffBrief } from '@/pages/coslash/lib/handoff';
 import { getEstimatedCost } from '@/pages/coslash/lib/pricing';
@@ -55,13 +56,15 @@ function useSessionDetail(
   session: Session | null,
   sessionsVersion: number,
   synthesisSettingsKey: string,
-): SessionDetail | null {
+): { detail: SessionDetail | null; loadError: string | null } {
   const [loaded, setLoaded] = useState<({ sessionId: string } & SynthesisResponse) | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const pollDeadline = useRef<{ sessionId: string; deadline: number } | null>(null);
   const sessionId = session?.id ?? null;
 
   useEffect(() => {
     setLoaded((current) => (current?.sessionId === sessionId ? current : null));
+    setLoadError(null);
     if (sessionId == null) {
       pollDeadline.current = null;
       return;
@@ -73,7 +76,7 @@ function useSessionDetail(
     let timer: ReturnType<typeof setTimeout> | undefined;
     const load = async () => {
       try {
-        const res = await fetch(`/api/synthesis?id=${sessionId}`, {
+        const res = await apiFetch(`/api/synthesis?id=${sessionId}`, {
           signal: controller.signal,
         });
         if (!res.ok) return;
@@ -90,8 +93,10 @@ function useSessionDetail(
           pollDeadline.current = null;
           setLoaded({ sessionId, ...result });
         }
-      } catch {
-        // aborted by a newer selection or panel close
+      } catch (error: unknown) {
+        if (!controller.signal.aborted && error instanceof ApiAuthenticationError) {
+          setLoadError(error.message);
+        }
       }
     };
     void load();
@@ -101,13 +106,16 @@ function useSessionDetail(
     };
   }, [sessionId, sessionsVersion, synthesisSettingsKey]);
 
-  if (session == null) return null;
-  if (loaded?.sessionId !== session.id) return session;
+  if (session == null) return { detail: null, loadError };
+  if (loaded?.sessionId !== session.id) return { detail: session, loadError };
   return {
-    ...session,
-    synthesis: loaded.synthesis,
-    synthesisPending: loaded.synthesisPending,
-    synthesisError: loaded.synthesisError,
+    detail: {
+      ...session,
+      synthesis: loaded.synthesis,
+      synthesisPending: loaded.synthesisPending,
+      synthesisError: loaded.synthesisError,
+    },
+    loadError,
   };
 }
 
@@ -769,7 +777,7 @@ export function SessionInspector({
   synthesisSettingsKey: string;
   onClose: () => void;
 }) {
-  const detail = useSessionDetail(session, sessionsVersion, synthesisSettingsKey);
+  const { detail, loadError } = useSessionDetail(session, sessionsVersion, synthesisSettingsKey);
   const contentRef = useRef<HTMLDivElement>(null);
   const isOpen = session != null;
 
@@ -805,6 +813,11 @@ export function SessionInspector({
                 <div className="border-b p-1" />
               </div>
             </SheetHeader>
+            {loadError != null && (
+              <div role="alert" className="text-destructive px-4 pb-2 text-xs">
+                {loadError}
+              </div>
+            )}
             <InspectorBody detail={detail} />
             <InspectorFooter detail={detail} />
           </>

--- a/frontend/src/pages/coslash/hooks/use-diagnostics.ts
+++ b/frontend/src/pages/coslash/hooks/use-diagnostics.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { apiFetch } from '@/pages/coslash/lib/api';
 import type { Diagnostics } from '@/pages/coslash/lib/diagnostics';
 
 export function useDiagnostics(enabled: boolean) {
@@ -12,7 +13,7 @@ export function useDiagnostics(enabled: boolean) {
     const controller = new AbortController();
     setIsLoading(true);
     setLoadFailed(false);
-    fetch('/api/diagnostics', { signal: controller.signal })
+    apiFetch('/api/diagnostics', { signal: controller.signal })
       .then((response) => {
         if (!response.ok) throw new Error(`Diagnostics request failed (${response.status})`);
         return response.json() as Promise<Diagnostics>;

--- a/frontend/src/pages/coslash/hooks/use-launch-terminal.ts
+++ b/frontend/src/pages/coslash/hooks/use-launch-terminal.ts
@@ -1,9 +1,10 @@
 import { useState } from 'react';
+import { apiFetch } from '@/pages/coslash/lib/api';
 
 export type LaunchMode = 'resume' | 'new';
 
 async function launchTerminal(sessionId: string, mode: LaunchMode, handoff?: string): Promise<void> {
-  const response = await fetch(`/api/launch?id=${sessionId}&mode=${mode}`, {
+  const response = await apiFetch(`/api/launch?id=${sessionId}&mode=${mode}`, {
     method: 'POST',
     body: handoff,
   });

--- a/frontend/src/pages/coslash/hooks/use-sessions.ts
+++ b/frontend/src/pages/coslash/hooks/use-sessions.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { ApiAuthenticationError, apiFetch } from '@/pages/coslash/lib/api';
 import type { Session } from '@/pages/coslash/lib/session';
 import { MINUTE } from '@/pages/coslash/lib/time';
 import { timeWindowStart, type TimeWindow } from '@/pages/coslash/lib/time-window';
@@ -9,7 +10,7 @@ const REFRESH_INTERVAL_MS = MINUTE;
 export function useSessions(timeWindow: TimeWindow) {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [loadFailed, setLoadFailed] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [retryCount, setRetryCount] = useState(0);
   const [sessionsVersion, setSessionsVersion] = useState(0);
 
@@ -19,11 +20,11 @@ export function useSessions(timeWindow: TimeWindow) {
     const load = (background: boolean) => {
       if (!background) {
         setIsLoading(true);
-        setLoadFailed(false);
+        setLoadError(null);
       }
       const since = timeWindowStart(timeWindow);
       const path = since == null ? '/api/sessions' : `/api/sessions?since=${since}`;
-      fetch(path, { signal: controller.signal })
+      apiFetch(path, { signal: controller.signal })
         .then((response) => {
           if (!response.ok) {
             throw new Error(`Sessions request failed (${response.status})`);
@@ -35,15 +36,19 @@ export function useSessions(timeWindow: TimeWindow) {
           setSessions(loadedSessions);
           setSessionsVersion((version) => version + 1);
           setIsLoading(false);
-          setLoadFailed(false);
+          setLoadError(null);
         })
         .catch((error: unknown) => {
           if (controller.signal.aborted) return;
-          // keep showing the last good list when a background refresh fails
-          if (!background) {
+          const authenticationFailed = error instanceof ApiAuthenticationError;
+          // Keep showing the last good list when an ordinary background
+          // refresh fails. Authentication failures invalidate that private data.
+          if (!background || authenticationFailed) {
             setSessions([]);
             setIsLoading(false);
-            setLoadFailed(true);
+            setLoadError(
+              authenticationFailed ? error.message : 'CoSlash couldn’t load sessions from the API.',
+            );
           }
           console.error('Failed to load sessions', error);
         });
@@ -59,9 +64,15 @@ export function useSessions(timeWindow: TimeWindow) {
 
   const retrySessions = () => {
     setIsLoading(true);
-    setLoadFailed(false);
+    setLoadError(null);
     setRetryCount((key) => key + 1);
   };
 
-  return { sessions, isLoading, loadFailed, sessionsVersion, retrySessions };
+  return {
+    sessions,
+    isLoading,
+    loadError,
+    sessionsVersion,
+    retrySessions,
+  };
 }

--- a/frontend/src/pages/coslash/hooks/use-settings.ts
+++ b/frontend/src/pages/coslash/hooks/use-settings.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { apiFetch } from '@/pages/coslash/lib/api';
 import type { CoslashSettings, SettingsResponse } from '@/pages/coslash/lib/settings';
 
 async function readError(response: Response): Promise<string> {
@@ -15,7 +16,7 @@ export function useSettings() {
 
   useEffect(() => {
     const controller = new AbortController();
-    fetch('/api/settings', { signal: controller.signal })
+    apiFetch('/api/settings', { signal: controller.signal })
       .then(async (result) => {
         if (!result.ok) throw new Error(await readError(result));
         return result.json() as Promise<SettingsResponse>;
@@ -37,7 +38,7 @@ export function useSettings() {
     setIsSaving(true);
     setSaveError(null);
     try {
-      const result = await fetch('/api/settings', {
+      const result = await apiFetch('/api/settings', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(settings),

--- a/frontend/src/pages/coslash/lib/api.test.ts
+++ b/frontend/src/pages/coslash/lib/api.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ApiAuthenticationError, apiFetch } from './api';
+
+describe('apiFetch', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('uses a new token fragment that arrives after the module is loaded', async () => {
+    const stored = new Map<string, string>();
+    const location = { hash: '#t=old-token', pathname: '/', search: '' };
+    const replaceState = vi.fn(() => {
+      location.hash = '';
+    });
+    vi.stubGlobal('window', {
+      location,
+      history: { state: null, replaceState },
+      sessionStorage: {
+        getItem: (key: string) => stored.get(key) ?? null,
+        setItem: (key: string, value: string) => stored.set(key, value),
+      },
+    });
+
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiFetch('/api/sessions');
+    location.hash = '#t=new-token';
+    await apiFetch('/api/sessions');
+
+    const secondRequest = fetchMock.mock.calls[1]?.[1] as RequestInit;
+    expect(new Headers(secondRequest.headers).get('X-Coslash-Token')).toBe('new-token');
+    expect(stored.get('coslash-api-token')).toBe('new-token');
+    expect(replaceState).toHaveBeenCalledTimes(2);
+  });
+
+  it('maps a 401 response to ApiAuthenticationError', async () => {
+    vi.stubGlobal('window', {
+      location: { hash: '', pathname: '/', search: '' },
+      history: { state: null, replaceState: vi.fn() },
+      sessionStorage: { getItem: vi.fn(() => null), setItem: vi.fn() },
+    });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 401 })));
+
+    await expect(apiFetch('/api/sessions')).rejects.toBeInstanceOf(ApiAuthenticationError);
+  });
+});

--- a/frontend/src/pages/coslash/lib/api.ts
+++ b/frontend/src/pages/coslash/lib/api.ts
@@ -1,0 +1,34 @@
+export const API_AUTHENTICATION_MESSAGE = 'This link expired — reopen the URL printed in your terminal.';
+
+const TOKEN_STORAGE_KEY = 'coslash-api-token';
+
+export class ApiAuthenticationError extends Error {
+  constructor() {
+    super(API_AUTHENTICATION_MESSAGE);
+    this.name = 'ApiAuthenticationError';
+  }
+}
+
+function loadToken(): string | null {
+  const fragment = new URLSearchParams(window.location.hash.slice(1));
+  const suppliedToken = fragment.get('t');
+  if (suppliedToken != null && suppliedToken !== '') {
+    window.sessionStorage.setItem(TOKEN_STORAGE_KEY, suppliedToken);
+    window.history.replaceState(
+      window.history.state,
+      '',
+      `${window.location.pathname}${window.location.search}`,
+    );
+    return suppliedToken;
+  }
+  return window.sessionStorage.getItem(TOKEN_STORAGE_KEY);
+}
+
+export async function apiFetch(path: string, init: RequestInit = {}): Promise<Response> {
+  const token = loadToken();
+  const headers = new Headers(init.headers);
+  if (token != null) headers.set('X-Coslash-Token', token);
+  const response = await fetch(path, { ...init, headers });
+  if (response.status === 401) throw new ApiAuthenticationError();
+  return response;
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
@@ -6,7 +8,31 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
-    proxy: { '/api': 'http://127.0.0.1:8787' },
+    host: '127.0.0.1',
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://127.0.0.1:8787',
+        changeOrigin: true,
+        configure: (proxy) => {
+          let warnedAboutMissingToken = false;
+          proxy.on('proxyReq', (proxyRequest) => {
+            proxyRequest.removeHeader('origin');
+            const home = process.env.COSLASH_HOME ?? path.join(os.homedir(), '.coslash');
+            try {
+              const token = fs.readFileSync(path.join(home, 'token'), 'utf8').trim();
+              if (token !== '') proxyRequest.setHeader('x-coslash-token', token);
+              warnedAboutMissingToken = false;
+            } catch {
+              if (!warnedAboutMissingToken) {
+                console.warn('coSlash API token is unavailable; start the Go server before using Vite.');
+                warnedAboutMissingToken = true;
+              }
+            }
+          });
+        },
+      },
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Context

Protect private local transcript data from unrelated browser tabs. 

## Changes

- Guard loopback Host, Origin, and fetch metadata; require a per-run API token and add security headers.
- Deliver the token through the URL fragment/session storage and inject it through the Vite proxy.
- Resolve the token per request so a new restart URL recovers an existing tab.
- Add a frontend regression test for token refresh after restart.

## Test

- `go test ./...` — packages compile; no Go test files
- `npm test` — passed
- `npm run lint` — passed with two existing warnings
- `npm run build` — passed
- Manual: verified token mode/rotation, 401/200/403 API guards, headers, and Vite proxy on fallback port 5174.