### PR TITLE
Drop the client-side time-window filter

### DIFF
--- a/frontend/src/pages/coslash/CoslashPage.tsx
+++ b/frontend/src/pages/coslash/CoslashPage.tsx
@@ -33,7 +33,7 @@ import { getEstimatedCost } from '@/pages/coslash/lib/pricing';
 import { sessionMatchesSearchTerm } from '@/pages/coslash/lib/search';
 import { getStatus, type Session } from '@/pages/coslash/lib/session';
 import { shouldPromptForSynthesisConsent } from '@/pages/coslash/lib/settings';
-import { timeWindowStart, type TimeWindow } from '@/pages/coslash/lib/time-window';
+import { type TimeWindow } from '@/pages/coslash/lib/time-window';
 
 const WINDOW_ACTIVITY_LABELS: Record<TimeWindow, string> = {
   'week': 'active this week',
@@ -236,16 +236,9 @@ export function CoslashPage() {
       setSettingsDialogMode((current) => current ?? 'synthesis-consent');
     }
   }, [selectedSession, settingsState.response]);
-  // The API returns every session, so the window is applied here — switching it
-  // never refetches. A live session shows regardless of how old its log is.
-  const windowStart = timeWindowStart(timeWindow);
-  const sessionsInWindow =
-    windowStart == null
-      ? sessions
-      : sessions.filter((session) => session.status != null || session.mtime >= windowStart);
-  const sessionsForVendor = sessionsInWindow.filter(
-    (session) => vendor === 'all' || session.agent === vendor,
-  );
+  // useSessions refetches on every window change and the API applies the
+  // window before parsing, so sessions already holds exactly this window.
+  const sessionsForVendor = sessions.filter((session) => vendor === 'all' || session.agent === vendor);
   const visibleSessions = sortSessions(
     sessionsForVendor.filter((session) => sessionMatchesSearchTerm(session, searchTerm)),
     sortKey,
@@ -288,7 +281,7 @@ export function CoslashPage() {
         </div>
       </div>
       <div className="relative flex-1 overflow-hidden">
-        <LoadingSpinner isLoading={isLoading && sessions.length === 0}>
+        <LoadingSpinner isLoading={isLoading}>
           <CoslashContent
             loadFailed={loadFailed}
             onRetry={retrySessions}


### PR DESCRIPTION
## Context

PR #9 moved windowing to the server: `useSessions` sends `?since=` and refetches
whenever the window changes, and `collector.List` drops any root that is not
live and older than `since`. `CoslashPage` kept applying the same predicate —
`status != null || mtime >= windowStart` — to rows that already came back
filtered.

The comment above it said "The API returns every session, so the window is
applied here — switching it never refetches." That stopped being true in #9.

## Changes

- Delete the client-side window filter; `sessions` already holds exactly the
  window. Drop the now-unused `timeWindowStart` import.
- Gate the content spinner on `isLoading` instead of `isLoading &&
  sessions.length === 0`.

That second change is not incidental. The old guard never fires when switching
windows, because `sessions` still holds the previous window's rows, so the page
rendered stale data and leaned on the filter to make it look right. Removing
the filter without this would flash the full list when narrowing from "All" to
"This week". The stats row directly above already used plain `isLoading`; the
two loading states now agree.

Also worth recording: the filter recomputed `timeWindowStart` at render time,
so on the sliding `7d` and `30d` windows its boundary sat later than the one
the fetch used, and a row inside that band vanished until the next refetch. The
band is at most the 60s refresh interval wide, so this was a latent
inconsistency rather than something users hit often. Redundancy is the reason
to delete it; this is a bonus.

## Test

- `npx oxlint` — passed (two pre-existing Fast Refresh warnings, unchanged)
- `npx prettier --check .` — passed
- `npx vitest run` — passed (2 files, 7 tests)
- `npm run build` — passed
- Measured against a real 186-session history on a release binary:

  | request | rows | rows the deleted filter would drop |
  | --- | --- | --- |
  | `/api/sessions` | 186 | 179 |
  | `/api/sessions?since=<start of week>` | 7 | **0** |

  The server is already applying the exact predicate the client repeated.
- Probed the sliding-window drift the same way: with `since=now-7d`, the
  closest non-live row sat 30.2 min past the boundary, so nothing was being
  dropped in practice at the time of measurement — consistent with calling this
  latent rather than active.

Not covered: no component test for the spinner change. The frontend suite has
no React testing library, and adding one to cover a deletion did not seem
worth the dependency. The narrowing case is worth a manual click in review:
switch "All" → "This week" and confirm you get a spinner rather than a flash
of the full list.