### PR TITLE
Compare settings drafts with JSON.stringify

### DIFF
--- a/frontend/src/pages/coslash/components/SettingsDialog.tsx
+++ b/frontend/src/pages/coslash/components/SettingsDialog.tsx
@@ -151,18 +151,6 @@ function BackendChoice({
   );
 }
 
-function settingsEqual(left: CoslashSettings | null, right: CoslashSettings | null): boolean {
-  if (!left || !right) return left === right;
-  return (
-    left.$schema === right.$schema &&
-    left.version === right.version &&
-    left.synthesis.enabled === right.synthesis.enabled &&
-    left.synthesis.backend === right.synthesis.backend &&
-    left.synthesis.model === right.synthesis.model &&
-    left.launch.terminal === right.launch.terminal
-  );
-}
-
 export function SettingsButton({ onClick, hasError }: { onClick: () => void; hasError: boolean }) {
   return (
     <Button type="button" variant="outline" size="sm" className="relative" onClick={onClick}>
@@ -213,7 +201,8 @@ export function SettingsDialog({
   }, [open, response]);
 
   const initialDraft = response ? initialSettingsDraft(response) : null;
-  const isDirty = !settingsEqual(draft, initialDraft);
+  // Both sides are spreads of the same response.settings, so key order matches.
+  const isDirty = JSON.stringify(draft) !== JSON.stringify(initialDraft);
   const selectedBackend = response?.options.synthesisBackends.find(
     (option) => option.id === draft?.synthesis.backend,
   );


### PR DESCRIPTION
## Context

`settingsEqual` listed all six fields of `CoslashSettings` by hand to decide
whether the Save button is enabled.

Both sides of that comparison come from `initialSettingsDraft(response)`, and
every draft update in the dialog is a spread of that same object
(`{ ...draft, synthesis: { ...draft.synthesis, enabled } }`). Spreads preserve
insertion order, and the server marshals the struct in a fixed field order, so
the two sides always share a key order. `JSON.stringify` compares them
directly.

## Changes

- Delete `settingsEqual`; compare with `JSON.stringify` at its one call site.

Stringify also covers the null cases the function's guard handled: two nulls
stringify alike, and a null and an object do not.

This removes a way to get the check wrong. A field added to `CoslashSettings`
is now compared automatically, where the hand-written list would ignore it
until someone remembered to add a line.

Worth stating the failure direction, since key-order comparison is
order-sensitive: if the orders ever diverged, stringify would report *unequal*
for identical settings. That shows "Unsaved changes" and permits a redundant
save. It cannot report equal for settings that differ, so the Save button
cannot be wrongly disabled.

## Test

- `npx oxlint` — passed (two pre-existing Fast Refresh warnings, unchanged)
- `npx prettier --check .` — passed
- `npx vitest run` — passed (2 files, 7 tests)
- `npm run build` — passed

No unit test: the comparison is now an inline expression, and extracting it to
test would restore the function this PR removes. The frontend suite has no
React testing library and adding one for a two-line change did not seem worth
the dependency. Manual check for review: open Settings, toggle a value and back,
confirm the status text returns to "No changes" and Save disables.