### PR TITLE
Group board sessions with Map.groupBy

### DIFF
--- a/frontend/src/pages/coslash/components/SessionBoard.tsx
+++ b/frontend/src/pages/coslash/components/SessionBoard.tsx
@@ -6,21 +6,6 @@ import { formatEstimatedCost, formatTokens } from '@/pages/coslash/lib/format';
 import { getEstimatedCost } from '@/pages/coslash/lib/pricing';
 import { getStatus, getTotalTokens, STATUSES, type Session, type Status } from '@/pages/coslash/lib/session';
 
-// Preserves insertion order, so sorted input yields groups ordered by their top session.
-function groupBy(sessions: Session[], keyOf: (session: Session) => string): [string, Session[]][] {
-  const groups = new Map<string, Session[]>();
-  for (const session of sessions) {
-    const key = keyOf(session);
-    let group = groups.get(key);
-    if (!group) {
-      groups.set(key, [session]);
-      continue;
-    }
-    group.push(session);
-  }
-  return [...groups.entries()];
-}
-
 function StatusColumnHeader({ status, sessions }: { status: Status; sessions: Session[] }) {
   return (
     <div className="sticky top-0 z-10 flex items-center gap-2 border-b border-l border-l-neutral-100 bg-neutral-50 px-3 py-2">
@@ -135,18 +120,21 @@ export function SessionBoard({
           sessions={sessions.filter((session) => getStatus(session.status) === key)}
         />
       ))}
-      {groupBy(sessions, (session) => session.repo ?? '(no repo)').map(([repo, repoSessions]) => (
+      {/* Map keeps insertion order, so sorted input groups by its top session. */}
+      {[...Map.groupBy(sessions, (session) => session.repo ?? '(no repo)')].map(([repo, repoSessions]) => (
         <Fragment key={repo}>
           <RepoGroupHeader repo={repo} sessions={repoSessions} />
-          {groupBy(repoSessions, (session) => session.branch ?? '—').map(([branch, branchSessions]) => (
-            <BranchRow
-              key={branch}
-              branch={branch}
-              sessions={branchSessions}
-              visibleStatuses={visibleStatuses}
-              onSelectSession={onSelectSession}
-            />
-          ))}
+          {[...Map.groupBy(repoSessions, (session) => session.branch ?? '—')].map(
+            ([branch, branchSessions]) => (
+              <BranchRow
+                key={branch}
+                branch={branch}
+                sessions={branchSessions}
+                visibleStatuses={visibleStatuses}
+                onSelectSession={onSelectSession}
+              />
+            ),
+          )}
         </Fragment>
       ))}
     </div>

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "es2023",
-    "lib": ["ES2023", "DOM"],
+    // ES2024 for Map.groupBy. Baseline: Chrome 117, Safari 17.4, Firefox 119.
+    "lib": ["ES2024", "DOM"],
     "module": "esnext",
     "types": ["vite/client"],
     "allowArbitraryExtensions": true,


### PR DESCRIPTION
## Context

`SessionBoard` carried a 13-line `groupBy` that built a `Map` and spread its entries. `Map.groupBy` does exactly that.

## Changes

- Delete `groupBy`; call `Map.groupBy` at both call sites.
- `lib: ES2024` in `tsconfig.app.json` for the type definitions.

The wrapper only spread the result, so inlining removes the indirection rather than renaming it. Its comment documented insertion order — now a language guarantee rather than a local implementation detail — so it moves to the grouping site as a one-line note.

`target` stays at `es2023`. `Map.groupBy` is a built-in, not syntax, so only the library definitions need bumping and esbuild's output is unchanged.

**Reviewer call: this sets a browser floor.** `Map.groupBy` needs Chrome 117, Safari 17.4, or Firefox 119 — roughly early 2024. Vite transpiles syntax but does not polyfill built-ins, so an older browser gets a runtime `TypeError` with no build-time warning. coSlash opens the user's default browser on macOS, and Safari 17.4 requires Monterey or newer.

## Test

- `npx oxlint` — passed (two pre-existing Fast Refresh warnings, unchanged)
- `npx prettier --check .` — passed
- `npx vitest run` — passed (2 files, 7 tests)
- `npm run build` — passed, so `tsc -b` accepts `Map.groupBy` under the new lib
- Equivalence check against the deleted function, including group order:

  ```
  rows: b, a, b, null, a  →  b:2 a:2 (no repo):1
  assert.deepStrictEqual(old(rows, key), [...Map.groupBy(rows, key)])  // passes
  ```
Covers the `?? '(no repo)'` fallback key and confirms groups stay ordered by first appearance, which is what keeps the board sorted.