### PR TITLE
Share one TokenBreakdown between card and inspector

### DIFF
--- a/frontend/src/pages/coslash/components/SessionCard.tsx
+++ b/frontend/src/pages/coslash/components/SessionCard.tsx
@@ -203,6 +203,22 @@ function SubagentStatusBadge({ status }: { status: Subagent['status'] }) {
   return <Badge className={cn('shrink-0 text-xs font-semibold', style.fg, style.bg)}>{style.label}</Badge>;
 }
 
+// Cache writes fold the 5-minute and 1-hour buckets into one figure.
+export function TokenBreakdown({ tokens }: { tokens: Session['tokens'] }) {
+  return (
+    <div className="text-muted-foreground pt-1">
+      in {formatTokens(sumTokens(tokens, 'input_tokens'))} · out{' '}
+      {formatTokens(sumTokens(tokens, 'output_tokens'))} · cache{' '}
+      {formatTokens(sumTokens(tokens, 'cache_read_input_tokens'))}r /{' '}
+      {formatTokens(
+        sumTokens(tokens, 'cache_creation_input_tokens') +
+          sumTokens(tokens, 'cache_creation_1h_input_tokens'),
+      )}
+      w
+    </div>
+  );
+}
+
 function SubagentTokenSummary({ subagent }: { subagent: Subagent }) {
   return (
     <div className="bg-muted rounded-lg border p-2 font-mono text-xs">
@@ -213,16 +229,7 @@ function SubagentTokenSummary({ subagent }: { subagent: Subagent }) {
         </span>
         <span className="font-bold">{formatEstimatedCost(getEstimatedCost(subagent.tokens))}</span>
       </div>
-      <div className="text-muted-foreground pt-1">
-        in {formatTokens(sumTokens(subagent.tokens, 'input_tokens'))} · out{' '}
-        {formatTokens(sumTokens(subagent.tokens, 'output_tokens'))} · cache{' '}
-        {formatTokens(sumTokens(subagent.tokens, 'cache_read_input_tokens'))}r /{' '}
-        {formatTokens(
-          sumTokens(subagent.tokens, 'cache_creation_input_tokens') +
-            sumTokens(subagent.tokens, 'cache_creation_1h_input_tokens'),
-        )}
-        w
-      </div>
+      <TokenBreakdown tokens={subagent.tokens} />
     </div>
   );
 }

--- a/frontend/src/pages/coslash/components/SessionInspector.tsx
+++ b/frontend/src/pages/coslash/components/SessionInspector.tsx
@@ -23,6 +23,7 @@ import {
   SessionVendorBadge,
   SubagentDialogContent,
   SubagentModelBadge,
+  TokenBreakdown,
 } from '@/pages/coslash/components/SessionCard';
 import { UnpricedModelWarning } from '@/pages/coslash/components/UnpricedModelWarning';
 import { useLaunchTerminal } from '@/pages/coslash/hooks/use-launch-terminal';
@@ -38,7 +39,6 @@ import {
   resolveGoal,
   STATUSES,
   SUBAGENT_STATUSES,
-  sumTokens,
   type DigestEntry,
   type Session,
   type SessionDetail,
@@ -239,16 +239,7 @@ function HeaderMeta({ detail }: { detail: SessionDetail }) {
           {formatDuration(detail.durationMs)} · {detail.turns} turns · {detail.toolUses} tools ·{' '}
           {detail.errors} errors
         </div>
-        <div className="text-muted-foreground pt-1">
-          in {formatTokens(sumTokens(detail.tokens, 'input_tokens'))} · out{' '}
-          {formatTokens(sumTokens(detail.tokens, 'output_tokens'))} · cache{' '}
-          {formatTokens(sumTokens(detail.tokens, 'cache_read_input_tokens'))}r /{' '}
-          {formatTokens(
-            sumTokens(detail.tokens, 'cache_creation_input_tokens') +
-              sumTokens(detail.tokens, 'cache_creation_1h_input_tokens'),
-          )}
-          w
-        </div>
+        <TokenBreakdown tokens={detail.tokens} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Context

`SessionCard` and `SessionInspector` rendered the same "in / out / cache r / w" line. The two blocks were identical apart from the object the tokens came from: `subagent.tokens` in one, `detail.tokens` in the other.

## Changes

- Export `TokenBreakdown` from `SessionCard`; use it in both places.
- `SessionInspector` no longer imports `sumTokens`.

It lives in `SessionCard` rather than a new file because `SessionInspector` already imports `SessionId`, `SessionName`, `SessionVendorBadge`, `SubagentModelBadge`, and `SubagentDialogContent` from there. This follows the arrangement already in place instead of starting a second one.

Also added a one-line comment recording what the block does that is not obvious: the cache-write figure folds the 5-minute and 1-hour buckets into one number.

## Test

- `npx oxlint` — passed (two pre-existing Fast Refresh warnings, unchanged)
- `npx prettier --check .` — passed
- `npx vitest run` — passed (2 files, 7 tests)
- `npm run build` — passed
- Rendered-output equivalence, with a throwaway test that kept a verbatim copy
  of the deleted block and compared `renderToStaticMarkup` of both across two
  models and all five token buckets:

  ```
  <div class="text-muted-foreground pt-1">in 1k · out 6k · cache 2Mr / 100kw</div>
  expect(after).toBe(before)  // passes
  ```
