### PR TITLE
Share one GroupTotals in the session board

### DIFF
--- a/frontend/src/pages/coslash/components/SessionBoard.tsx
+++ b/frontend/src/pages/coslash/components/SessionBoard.tsx
@@ -31,19 +31,25 @@ function StatusColumnHeader({ status, sessions }: { status: Status; sessions: Se
   );
 }
 
-function RepoGroupHeader({ repo, sessions }: { repo: string; sessions: Session[] }) {
+function GroupTotals({ sessions }: { sessions: Session[] }) {
   const tokens = sessions.reduce((sum, session) => sum + getTotalTokens(session.tokens), 0);
   const cost = sessions.reduce((sum, session) => sum + getEstimatedCost(session.tokens), 0);
 
   return (
+    <span className="text-muted-foreground text-xs">
+      {sessions.length} {sessions.length === 1 ? 'session' : 'sessions'} · {formatTokens(tokens)} tok ·{' '}
+      <UnpricedModelWarning tokens={sessions.map((session) => session.tokens)}>
+        {formatEstimatedCost(cost)}
+      </UnpricedModelWarning>
+    </span>
+  );
+}
+
+function RepoGroupHeader({ repo, sessions }: { repo: string; sessions: Session[] }) {
+  return (
     <div className="bg-muted col-span-full flex items-center justify-between gap-2 border-b px-4 py-2">
       <span className="font-mono text-sm font-bold">{repo}/</span>
-      <span className="text-muted-foreground text-xs">
-        {sessions.length} {sessions.length === 1 ? 'session' : 'sessions'} · {formatTokens(tokens)} tok ·{' '}
-        <UnpricedModelWarning tokens={sessions.map((session) => session.tokens)}>
-          {formatEstimatedCost(cost)}
-        </UnpricedModelWarning>
-      </span>
+      <GroupTotals sessions={sessions} />
     </div>
   );
 }
@@ -84,19 +90,11 @@ function BranchRow({
   visibleStatuses: [string, Status][];
   onSelectSession: (session: Session) => void;
 }) {
-  const tokens = sessions.reduce((sum, session) => sum + getTotalTokens(session.tokens), 0);
-  const cost = sessions.reduce((sum, session) => sum + getEstimatedCost(session.tokens), 0);
-
   return (
     <>
       <div className="flex flex-col gap-1 border-b p-4">
         <span className="text-muted-foreground font-mono text-xs break-all">{branch}</span>
-        <span className="text-muted-foreground text-xs">
-          {sessions.length} {sessions.length === 1 ? 'session' : 'sessions'} · {formatTokens(tokens)} tok ·{' '}
-          <UnpricedModelWarning tokens={sessions.map((session) => session.tokens)}>
-            {formatEstimatedCost(cost)}
-          </UnpricedModelWarning>
-        </span>
+        <GroupTotals sessions={sessions} />
       </div>
       {visibleStatuses.map(([status]) => (
         <div


### PR DESCRIPTION
## Context

`RepoGroupHeader` and `BranchRow` each computed the same two totals and rendered the same "N sessions · X tok · $Y" span. Both copies were identical, down to the `UnpricedModelWarning` wrapper and the singular/plural switch.

## Changes

- Extract `GroupTotals` and call it from both. The two `reduce` pairs move into it, so group totals are summed in one place.

Setting expectations on size: this is 14 lines added against 16 removed, not the ~8-line saving I estimated when I first flagged it. The value is one definition rather than two — a change to how a group total reads no longer has to be made in two places, and the two cannot drift apart.

## Test

- `npx oxlint` — passed (two pre-existing Fast Refresh warnings, unchanged)
- `npx prettier --check .` — passed
- `npx vitest run` — passed (2 files, 7 tests)
- `npm run build` — passed
- Confirmed one remaining `getTotalTokens(session.tokens), 0` reduction in the file, down from two.

No rendered-output test here. Unlike the `TokenBreakdown` extraction, the span moves verbatim with only its surrounding `div` left in place, so the markup is unchanged by inspection. Worth a glance at the board view in review to confirm both the repo heading and the branch rows still read the same.