### PR TITLE
Bind the smoke server to an ephemeral port

### DIFF
--- a/collector/cmd/coslash/main.go
+++ b/collector/cmd/coslash/main.go
@@ -34,14 +34,15 @@ type options struct {
 func parseOptions(arguments []string) (options, error) {
 	flags := flag.NewFlagSet("coslash", flag.ContinueOnError)
 	var opts options
-	flags.IntVar(&opts.port, "port", defaultPort, "port to serve on, loopback only")
+	flags.IntVar(&opts.port, "port", defaultPort, "port to serve on, loopback only; 0 picks any free port")
 	flags.BoolVar(&opts.noOpen, "no-open", false, "do not open a browser on startup")
 	flags.BoolVar(&opts.showVersion, "version", false, "print the version and exit")
 	if err := flags.Parse(arguments); err != nil {
 		return options{}, err
 	}
-	if opts.port < 1 || opts.port > 65535 {
-		return options{}, fmt.Errorf("--port must be between 1 and 65535, got %d", opts.port)
+	// 0 asks the kernel for a free port; the bound one is logged at startup.
+	if opts.port < 0 || opts.port > 65535 {
+		return options{}, fmt.Errorf("--port must be between 0 and 65535, got %d", opts.port)
 	}
 	if extra := flags.Args(); len(extra) > 0 {
 		return options{}, fmt.Errorf("unexpected argument %q", extra[0])

--- a/collector/scripts/smoke.sh
+++ b/collector/scripts/smoke.sh
@@ -43,47 +43,32 @@ if [[ "$mode" == "bare" ]]; then
   readiness_path=/api/sessions
 fi
 
+# --port 0 lets the kernel pick a free port, so this cannot collide with
+# whatever else is listening. The server logs the port it actually bound.
+env HOME="$smoke_home" "$binary" --no-open --port 0 >"$server_log" 2>&1 &
+server_pid=$!
+
 base_url=
-for port in 18787 18788 18789; do
-  : >"$server_log"
-  env HOME="$smoke_home" "$binary" --no-open --port "$port" >"$server_log" 2>&1 &
-  server_pid=$!
-
-  ready=false
-  for ((attempt = 1; attempt <= 40; attempt++)); do
-    if ! kill -0 "$server_pid" 2>/dev/null; then
-      break
-    fi
-    if grep -Fq "listening on http://127.0.0.1:$port" "$server_log" &&
-      curl -fs -o /dev/null "http://127.0.0.1:$port$readiness_path" &&
-      kill -0 "$server_pid" 2>/dev/null; then
-      ready=true
-      break
-    fi
-    sleep 0.25
-  done
-
-  if [[ "$ready" == "true" ]]; then
-    base_url="http://127.0.0.1:$port"
-    echo "server ready on $base_url ($mode mode)"
-    break
-  fi
-
-  if kill -0 "$server_pid" 2>/dev/null; then
-    echo "error: server did not become ready on port $port" >&2
+for ((attempt = 1; attempt <= 40; attempt++)); do
+  if ! kill -0 "$server_pid" 2>/dev/null; then
+    echo "error: server exited during startup" >&2
     cat "$server_log" >&2
     exit 1
   fi
-
-  wait "$server_pid" 2>/dev/null || true
-  server_pid=
+  base_url=$(sed -n 's|.*listening on \(http://127\.0\.0\.1:[0-9]\{1,\}\).*|\1|p' "$server_log" | head -1)
+  if [[ -n "$base_url" ]] && curl -fs -o /dev/null "$base_url$readiness_path"; then
+    break
+  fi
+  base_url=
+  sleep 0.25
 done
 
 if [[ -z "$base_url" ]]; then
-  echo "error: server failed to start on candidate ports 18787, 18788, and 18789" >&2
+  echo "error: server did not become ready" >&2
   cat "$server_log" >&2
   exit 1
 fi
+echo "server ready on $base_url ($mode mode)"
 
 expect_status() {
   local path=$1


### PR DESCRIPTION
## Context

`smoke.sh` tried ports 18787, 18788, and 18789 in turn, with the whole startup and readiness sequence wrapped in that loop, plus a separate error path for "all three were taken". The loop existed because a hardcoded port can already
be in use.

## Changes

- `main.go` accepts `--port 0`, which asks the kernel for a free port. It previously rejected 0 and accepted 1 to 65535.
- `smoke.sh` starts the server once on `--port 0` and reads the bound address out of the `listening on http://127.0.0.1:PORT` line the server already logs.

This removes the collision instead of retrying it. A server that fails to start is now always a real error, so the script reports it rather than trying the next candidate.

`--port 0` is not a test-only affordance — "give me any free port" is a reasonable thing to ask of a local tool, and the startup log already prints where it landed. It is documented in `--port` help.

## Test

- `make -C collector check` — passed
- `make -C collector test` — passed
- `make -C collector release && make smoke` — passed on an ephemeral port
  (`server ready on http://127.0.0.1:63008`), all seven assertions
- `make -C collector build && make smoke-dev` — passed, bare mode still gets
  503 on `/` and 200 on `/api/sessions`
- Port validation at the new boundary:

  | flag | result |
  | --- | --- |
  | `--port -1` | `--port must be between 0 and 65535, got -1` |
  | `--port 0` | accepted |
  | `--port 65536` | `--port must be between 0 and 65535, got 65536` |

- **The case the loop existed for.** Occupied 18787 with another listener and ran `make smoke`: it bound 63118 and exited 0. On `main` this is the run that would have consumed the first fallback.