### PR TITLE
Check the smoke JSON response one way

### DIFF
--- a/collector/scripts/smoke.sh
+++ b/collector/scripts/smoke.sh
@@ -137,15 +137,11 @@ if [[ "$mode" == "embedded" ]]; then
     exit 1
   fi
 
+  # The failure this guards against is /api/sessions falling through to the
+  # SPA document, so the opening bracket is the whole question.
   expect_status /api/sessions 200
-  if command -v jq >/dev/null 2>&1; then
-    if ! jq -e type "$response_body" >/dev/null; then
-      echo "error: /api/sessions did not return valid JSON" >&2
-      cat "$response_body" >&2
-      exit 1
-    fi
-  elif ! grep -Eq '^[[:space:]]*[\[{]' "$response_body"; then
-    echo "error: /api/sessions did not look like JSON" >&2
+  if ! grep -Eq '^[[:space:]]*[\[{]' "$response_body"; then
+    echo "error: /api/sessions did not return JSON" >&2
     cat "$response_body" >&2
     exit 1
   fi


### PR DESCRIPTION
## Context

`smoke.sh` validated `/api/sessions` two ways: `jq -e type` when jq was installed, and a `grep` for a leading bracket otherwise. The assertion a developer ran therefore depended on whether they had jq.

## Changes

- Keep the grep, drop the jq branch, so every machine runs the same check.

The failure this assertion exists for is `/api/sessions` falling through to the SPA document — a routing regression. The grep catches that, because an HTML body does not start with `[` or `{`. A full parse guards instead against the server emitting malformed JSON, which `encoding/json` does not do and which this test is not aimed at.

With #29 having removed `python3 -m json.tool` from `release.yml`, the repo now has one JSON check rather than three.

## Test

- `make -C collector release && make smoke` — passed
- `make -C collector build && make smoke-dev` — passed
- The check is not vacuous:

  | body | result |
  | --- | --- |
  | `<!doctype html>…<div id="root">` | **rejected** |
  | `[{"id":"x"}]` | accepted |
  | leading whitespace then `{"error":"x"}` | accepted |

  The first row is the regression the assertion is for.

Trade-off worth naming: this drops detection of a genuinely malformed JSON body on machines that had jq. I judged that out of scope for a smoke test against a Go handler that marshals a typed slice, but it is a real if narrow reduction, so flagging it rather than burying it.