### PR TITLE
Drop the synthesis.Home wrapper

### DIFF
--- a/collector/internal/synthesis/paths.go
+++ b/collector/internal/synthesis/paths.go
@@ -7,20 +7,16 @@ import (
 	"github.com/centauri-ai/coslash/collector/internal/settings"
 )
 
-func Home() string {
-	return settings.Home()
-}
-
 func SummariesDir() string {
-	return filepath.Join(Home(), "summaries")
+	return filepath.Join(settings.Home(), "summaries")
 }
 
 func SynthesisCwd() string {
-	return filepath.Join(Home(), "synthesis")
+	return filepath.Join(settings.Home(), "synthesis")
 }
 
 func EnsureDirs() error {
-	for _, directory := range []string{Home(), SummariesDir(), SynthesisCwd()} {
+	for _, directory := range []string{settings.Home(), SummariesDir(), SynthesisCwd()} {
 		if err := os.MkdirAll(directory, 0o700); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Context

`synthesis.Home` only returned `settings.Home`. Nothing outside the package called it, and inside the package it had three callers, so it added an exported name and one more hop without adding behavior.

## Changes

- Delete `synthesis.Home`; call `settings.Home` directly in `SummariesDir`,
  `SynthesisCwd`, and `EnsureDirs`.

`SummariesDir` and `SynthesisCwd` stay. Unlike `Home` they add a path segment,
and they have callers in `cache.go`, `runner.go`, and `collector.go`.

## Test

- `make -C collector check` — passed
- `make -C collector test` — passed
- `make -C collector release && make smoke` — passed
- Booted the binary under an empty `HOME` and confirmed the directory layout is
  unchanged:

  ```
  ~/.coslash
  ~/.coslash/summaries
  ~/.coslash/synthesis
  ```

  This is the behavior that would break if the wrapper had been resolving to a
  different root than `settings.Home`.