### PR TITLE
fix: give the publish job a repository context

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,9 @@ jobs:
       - name: Publish
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This job never checks out, so `gh` has no git remote to infer the
+          # repository from and would fail with "not a git repository".
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
Bug fix for #10.

The `publish` job never checks out, so `gh` has no git remote to infer the repo from and fails with `fatal: not a git repository` — blocking every tagged release before `bump-homebrew` can run. Setting `GH_REPO` avoids adding a checkout just to give `gh` a remote to read.

Not yet verified in CI: `publish` only runs on a tag push, so it needs a tag after merge.
