### PR TITLE
leftover synthesis.Home wrapper removal

### DIFF
--- a/collector/internal/diagnostics/snapshot.go
+++ b/collector/internal/diagnostics/snapshot.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/centauri-ai/coslash/collector/internal/collector"
 	"github.com/centauri-ai/coslash/collector/internal/settings"
-	"github.com/centauri-ai/coslash/collector/internal/synthesis"
 	"github.com/centauri-ai/coslash/collector/internal/vendors"
 	"github.com/centauri-ai/coslash/collector/internal/vendors/claude"
 	"github.com/centauri-ai/coslash/collector/internal/vendors/codex"
@@ -119,7 +118,7 @@ func Collect(ctx context.Context, version string, includeVersions bool) *Snapsho
 		snapshot.homeError = userHomeErr.Error()
 	}
 
-	storageHome := synthesis.Home()
+	storageHome := settings.Home()
 	snapshot.Storage = probeStorage(storageHome)
 	snapshot.Storage.Home = displayPath(userHome, storageHome)
 	snapshot.Storage.Error = displayError(userHome, snapshot.Storage.Error)


### PR DESCRIPTION
## Context

https://github.com/centauri-ai/coslash/actions/runs/31048787818

follow up to https://github.com/centauri-ai/coslash/pull/37
- forgot to update call site for one spot

<!--
Explain the problem or motivation in one or two sentences.
Link a public issue with "Fixes #123" when applicable.
-->

## Changes

<!-- Focus on user-visible behavior and non-obvious product or implementation choices. -->

- remove leftover `synthesis.Home` wrapper in `snapshot.go`

## Test

<!-- List only checks that actually ran. Include a manual scenario when relevant. -->

- cd collector && go vet ./...