### PR TITLE
Read commit messages from the -F and -am commit forms

### DIFF
--- a/collector/internal/session/commits.go
+++ b/collector/internal/session/commits.go
@@ -11,8 +11,8 @@ var gitCommitCommand = regexp.MustCompile(`(?:^|[\n;&|])\s*git\s+commit(?:$|[\s;
 // -m, --message, or a combined short flag such as -am, single or double-quoted
 var commitMessage = regexp.MustCompile(`(?:--message|-[a-zA-Z]*m)[=\s]*(?:"([^"]+)"|'([^']+)')`)
 
-// -F or --file, which read the message from a file instead of the command line
-var commitFileFlag = regexp.MustCompile(`(?:--file|-[a-zA-Z]*F)[=\s]`)
+// -F or --file with its operand, which name the file the message comes from
+var commitFileFlag = regexp.MustCompile(`(?:--file|-[a-zA-Z]*F)[=\s]+(\S+)`)
 
 var commitAmend = regexp.MustCompile(`--amend\b`)
 
@@ -37,9 +37,12 @@ func CommitMessage(command string) (string, bool) {
 
 func commitSubject(command string) string {
 	flag := commitMessage.FindStringIndex(command)
-	file := commitFileFlag.FindStringIndex(command)
+	file := commitFileFlag.FindStringSubmatchIndex(command)
 	if file != nil && (flag == nil || file[0] < flag[0]) {
-		body, _ := unwrapMultilineMessage(command) // `-F -` takes stdin
+		if command[file[2]:file[3]] != "-" {
+			return "" // a named file, whose contents the transcript does not hold
+		}
+		body, _ := unwrapMultilineMessage(command) // `-F -` reads stdin
 		return firstLine(body)
 	}
 	if flag == nil {

--- a/collector/internal/session/commits.go
+++ b/collector/internal/session/commits.go
@@ -8,8 +8,13 @@ import (
 // git commit as a complete command word, excludes plumbing commands (i.e.  commit-tree)
 var gitCommitCommand = regexp.MustCompile(`(?:^|[\n;&|])\s*git\s+commit(?:$|[\s;&|])`)
 
-// single or double-quoted
-var commitMessage = regexp.MustCompile(`-m\s+(?:"([^"]+)"|'([^']+)')`)
+// -m, --message, or a combined short flag such as -am, single or double-quoted
+var commitMessage = regexp.MustCompile(`(?:--message|-[a-zA-Z]*m)[=\s]*(?:"([^"]+)"|'([^']+)')`)
+
+// -F or --file, which read the message from a file instead of the command line
+var commitFileFlag = regexp.MustCompile(`(?:--file|-[a-zA-Z]*F)[=\s]`)
+
+var commitAmend = regexp.MustCompile(`--amend\b`)
 
 // multilineBlockOpener matches the start of a shell here-document (<<EOF, <<'EOF', <<"EOF", <<-EOF)
 var multilineBlockOpener = regexp.MustCompile(`<<-?\s*['"]?(\w+)['"]?`)
@@ -20,19 +25,40 @@ func CommitMessage(command string) (string, bool) {
 		return "", false
 	}
 	// only match after git commit command, discard everything before
-	matchStart := matchIndices[0]
-	match := commitMessage.FindStringSubmatch(command[matchStart:])
-	if match == nil {
-		return "(commit)", true
+	tail := command[matchIndices[0]:]
+	if subject := commitSubject(tail); subject != "" {
+		return subject, true
 	}
+	if commitAmend.MatchString(tail) {
+		return "", false
+	}
+	return "(commit)", true
+}
+
+func commitSubject(command string) string {
+	flag := commitMessage.FindStringIndex(command)
+	file := commitFileFlag.FindStringIndex(command)
+	if file != nil && (flag == nil || file[0] < flag[0]) {
+		body, _ := unwrapMultilineMessage(command) // `-F -` takes stdin
+		return firstLine(body)
+	}
+	if flag == nil {
+		return ""
+	}
+	match := commitMessage.FindStringSubmatch(command)
 	message := match[1] // double quote message
 	if message == "" {
 		message = match[2] // single quote message
 	}
 	if body, ok := unwrapMultilineMessage(message); ok {
-		return body, true
+		message = body
 	}
-	return message, true
+	return firstLine(message)
+}
+
+func firstLine(text string) string {
+	line, _, _ := strings.Cut(strings.TrimSpace(text), "\n")
+	return strings.TrimSpace(line)
 }
 
 // unwrapMultilineMessage extracts  body of a `-m "$(cat <<'EOF' … EOF)"` commit message

--- a/collector/internal/session/commits.go
+++ b/collector/internal/session/commits.go
@@ -29,7 +29,14 @@ func CommitMessage(command string) (string, bool) {
 	if subject := commitSubject(tail); subject != "" {
 		return subject, true
 	}
-	if commitAmend.MatchString(tail) {
+	// the flags of this invocation alone, so that a later `git commit --amend` in
+	// the same script cannot suppress the commit that this one creates. The match
+	// ends on the separator or space after `commit`, so keep that byte.
+	flags := command[matchIndices[1]-1:]
+	if end := strings.IndexAny(flags, ";&|\n"); end >= 0 {
+		flags = flags[:end]
+	}
+	if commitAmend.MatchString(flags) {
 		return "", false
 	}
 	return "(commit)", true

--- a/frontend/src/pages/coslash/CoslashPage.tsx
+++ b/frontend/src/pages/coslash/CoslashPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Search } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { setTheme } from '@/lib/theme';
 import { DiagnosticsDialog } from '@/pages/coslash/components/DiagnosticsDialog';
 import { FirstRunOnboarding } from '@/pages/coslash/components/FirstRunOnboarding';
 import { LoadingSpinner } from '@/pages/coslash/components/LoadingSpinner';
@@ -30,7 +31,6 @@ import {
 import { useDiagnostics } from '@/pages/coslash/hooks/use-diagnostics';
 import { useSessions } from '@/pages/coslash/hooks/use-sessions';
 import { useSettings } from '@/pages/coslash/hooks/use-settings';
-import { setTheme } from '@/lib/theme';
 import type { Diagnostics } from '@/pages/coslash/lib/diagnostics';
 import { formatEstimatedCost } from '@/pages/coslash/lib/format';
 import { sessionsEmptyStateCopy } from '@/pages/coslash/lib/page-copy';

--- a/frontend/src/pages/coslash/components/SessionCard.tsx
+++ b/frontend/src/pages/coslash/components/SessionCard.tsx
@@ -291,9 +291,7 @@ export function SubagentDialogContent({
       <DialogHeader className="min-w-0">
         <div className="flex min-w-0 items-center gap-2 pr-8">
           <SubagentBadge />
-          <DialogTitle className="min-w-0 flex-1 truncate text-base">
-            {subagent.name}
-          </DialogTitle>
+          <DialogTitle className="min-w-0 flex-1 truncate text-base">{subagent.name}</DialogTitle>
         </div>
         <DialogDescription asChild>
           <div className="flex flex-col gap-2 pt-1">


### PR DESCRIPTION
## Context

The session inspector showed `(commit)` for every commit in session 5088f0d6. `CommitMessage` read only `-m "…"`. Every commit in that session used `git commit -F -`, which reads the message from stdin.

## Changes

- When `-F` comes before any `-m`, read the message from the here-document.
- Accept `--message=`, `-am`, and `-m` with no space before the quote.
- List the subject line only, so no body and no trailer reaches the inspector, the handoff, or the synthesis prompt.
- Do not count `git commit --amend` with no message as a new commit.
- Add `commits_test.go` with the 14 command forms found in real transcripts.

Note: a `grep` pattern that contains `|git commit -m` still registers as a commit. One occurrence in 194 sessions. A regex cannot separate that case.

## Test

- `make check` — passed
- `make test` — passed
- Manual: 194 local sessions through `/api/sessions`. Placeholder rows fell from 22 to 1 of 60. Session 5088f0d6 lists all 11 subjects.

### Screenshots

before
<img width="1161" height="1362" alt="Screenshot 2026-08-05 at 17 57 30" src="https://github.com/user-attachments/assets/b6627135-6101-4a0c-bef0-be686d5de5e7" />
after
<img width="1159" height="1364" alt="Screenshot 2026-08-05 at 17 57 49" src="https://github.com/user-attachments/assets/ac9d04f6-d0ff-4025-ba83-8ffa242e0039" />
