### PR TITLE
truncate the subagent title

### DIFF
--- a/frontend/src/pages/coslash/components/SessionCard.tsx
+++ b/frontend/src/pages/coslash/components/SessionCard.tsx
@@ -289,9 +289,11 @@ export function SubagentDialogContent({
   return (
     <DialogContent className="sm:max-w-2xl">
       <DialogHeader className="min-w-0">
-        <div className="flex min-w-0 flex-wrap items-center gap-2">
+        <div className="flex min-w-0 items-center gap-2 pr-8">
           <SubagentBadge />
-          <DialogTitle className="min-w-0 text-base">{subagent.name}</DialogTitle>
+          <DialogTitle className="min-w-0 flex-1 truncate text-base">
+            {subagent.name}
+          </DialogTitle>
         </div>
         <DialogDescription asChild>
           <div className="flex flex-col gap-2 pt-1">


### PR DESCRIPTION
## Context

Truncate subagent title, especially for Codex permission check subagents

## Changes

Truncate in the frontend

## Test
before
<img width="1187" height="1391" alt="Codex Image Aug 6, 2026, 02_31_34 PM" src="https://github.com/user-attachments/assets/09fafa3a-308c-4be9-8c8b-3275cf37a04a" />


after
<img width="990" height="611" alt="Screenshot 2026-08-06 at 2 32 26 PM" src="https://github.com/user-attachments/assets/ea3a0bdd-9760-4f6a-84fc-53c97278b20d" />
