### PR TITLE
Preserve Codex question and answer history

### DIFF
--- a/collector/internal/session/accumulators.go
+++ b/collector/internal/session/accumulators.go
@@ -29,6 +29,11 @@ func (log *DigestLog) Push(turn int, category, description string) {
 	})
 }
 
+func (log *DigestLog) PushQuestion(turn int, description, answer string) {
+	log.Push(turn, DigestQuestion, description)
+	log.entries[len(log.entries)-1].Answer = Truncate(answer, TruncateTextLimit)
+}
+
 func (log *DigestLog) PushSubagent(turn int, spawnKey string) {
 	log.entries = append(log.entries, DigestEntry{
 		Turn:     max(turn, 1),

--- a/collector/internal/session/session.go
+++ b/collector/internal/session/session.go
@@ -68,6 +68,7 @@ type DigestEntry struct {
 	Turn        int    `json:"turn"`
 	Category    string `json:"category"`
 	Description string `json:"description"`
+	Answer      string `json:"answer,omitempty"`
 	SubagentID  string `json:"subagentId,omitempty"`
 	SpawnKey    string `json:"-"`
 }

--- a/collector/internal/vendors/claude/parse.go
+++ b/collector/internal/vendors/claude/parse.go
@@ -331,14 +331,10 @@ func analyzeClaudeSession(file string) (*claudeSessionAnalysis, error) {
 			}
 			if result != nil && result.Answers != nil {
 				for _, question := range result.Questions {
-					description := question.Question
-					if answer := result.Answers[question.Question].String(); answer != "" {
-						description = question.Question + " ↳ " + answer
-					}
-					analysis.digest.Push(
+					analysis.digest.PushQuestion(
 						analysis.userPromptCount,
-						session.DigestQuestion,
-						description,
+						question.Question,
+						result.Answers[question.Question].String(),
 					)
 				}
 			}

--- a/collector/internal/vendors/codex/parse.go
+++ b/collector/internal/vendors/codex/parse.go
@@ -240,8 +240,10 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 						analysis.pullRequests++
 					}
 				}
-				if question, ok := questionFrom(row.Payload); ok {
-					analysis.digest.Push(analysis.prompts, session.DigestQuestion, question)
+				if questions, ok := questionsFrom(row.Payload); ok {
+					for _, question := range questions {
+						analysis.digest.Push(analysis.prompts, session.DigestQuestion, question)
+					}
 				}
 				analysis.notePlan(row.Payload)
 			case "function_call_output":
@@ -472,7 +474,6 @@ func unifiedDiffStat(diff string) (additions, deletions int) {
 var execCmdPattern = regexp.MustCompile(
 	`(?:^|[{,]\s*)(?:"cmd"|cmd)\s*:\s*("(?:[^"\\]|\\.)*")`,
 )
-var questionPattern = regexp.MustCompile(`"question"\s*:\s*("(?:[^"\\]|\\.)*")`)
 var planStepPattern = regexp.MustCompile(
 	`"?step"?\s*:\s*("(?:[^"\\]|\\.)*")\s*,\s*"?status"?\s*:\s*"(\w+)"`,
 )
@@ -508,23 +509,31 @@ func (analysis *codexSessionAnalysis) notePlan(payload codexPayload) {
 	analysis.plan = steps
 }
 
-func questionFrom(payload codexPayload) (string, bool) {
-	text := payload.Input
+func questionsFrom(payload codexPayload) ([]string, bool) {
+	if payload.Name != "request_user_input" {
+		return nil, false
+	}
+	text := string(payload.Arguments)
 	if text == "" {
-		text = string(payload.Arguments)
+		text = payload.Input
 	}
-	if payload.Name != "request_user_input" && !strings.Contains(text, "request_user_input") {
-		return "", false
+	var arguments struct {
+		Questions []struct {
+			Question string `json:"question"`
+		} `json:"questions"`
 	}
-	m := questionPattern.FindStringSubmatch(text)
-	if m == nil {
-		return "requested user input", true
+	if err := json.Unmarshal([]byte(text), &arguments); err != nil || len(arguments.Questions) == 0 {
+		return []string{"requested user input"}, true
 	}
-	var question string
-	if err := json.Unmarshal([]byte(m[1]), &question); err != nil {
-		return "requested user input", true
+	questions := make([]string, 0, len(arguments.Questions))
+	for _, item := range arguments.Questions {
+		question := item.Question
+		if strings.TrimSpace(question) == "" {
+			question = "requested user input"
+		}
+		questions = append(questions, question)
 	}
-	return question, true
+	return questions, true
 }
 
 func commandFrom(payload codexPayload) (string, bool) {

--- a/collector/internal/vendors/codex/parse.go
+++ b/collector/internal/vendors/codex/parse.go
@@ -243,11 +243,8 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 				}
 				if questions := questionsFrom(row.Payload); len(questions) > 0 {
 					for _, question := range questions {
-						description := question.text
-						if answers := questionAnswers[row.Payload.CallID][question.id].Answers; len(answers) > 0 {
-							description += " ↳ " + strings.Join(answers, ", ")
-						}
-						analysis.digest.Push(analysis.prompts, session.DigestQuestion, description)
+						answer := strings.Join(questionAnswers[row.Payload.CallID][question.id].Answers, ", ")
+						analysis.digest.PushQuestion(analysis.prompts, question.text, answer)
 					}
 				}
 				analysis.notePlan(row.Payload)

--- a/collector/internal/vendors/codex/parse.go
+++ b/collector/internal/vendors/codex/parse.go
@@ -97,6 +97,7 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 	if err != nil {
 		return nil, err
 	}
+	questionAnswers := questionAnswersByCall(rows)
 	ownID := SessionIDFromRollout(file)
 	var metas []codexMeta
 	analysis := &codexSessionAnalysis{
@@ -242,7 +243,11 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 				}
 				if questions, ok := questionsFrom(row.Payload); ok {
 					for _, question := range questions {
-						analysis.digest.Push(analysis.prompts, session.DigestQuestion, question)
+						description := question.text
+						if answers := questionAnswers[row.Payload.CallID][question.id]; len(answers) > 0 {
+							description += " ↳ " + strings.Join(answers, ", ")
+						}
+						analysis.digest.Push(analysis.prompts, session.DigestQuestion, description)
 					}
 				}
 				analysis.notePlan(row.Payload)
@@ -509,7 +514,12 @@ func (analysis *codexSessionAnalysis) notePlan(payload codexPayload) {
 	analysis.plan = steps
 }
 
-func questionsFrom(payload codexPayload) ([]string, bool) {
+type codexQuestion struct {
+	id   string
+	text string
+}
+
+func questionsFrom(payload codexPayload) ([]codexQuestion, bool) {
 	if payload.Name != "request_user_input" {
 		return nil, false
 	}
@@ -519,21 +529,56 @@ func questionsFrom(payload codexPayload) ([]string, bool) {
 	}
 	var arguments struct {
 		Questions []struct {
+			ID       string `json:"id"`
 			Question string `json:"question"`
 		} `json:"questions"`
 	}
 	if err := json.Unmarshal([]byte(text), &arguments); err != nil || len(arguments.Questions) == 0 {
-		return []string{"requested user input"}, true
+		return []codexQuestion{{text: "requested user input"}}, true
 	}
-	questions := make([]string, 0, len(arguments.Questions))
+	questions := make([]codexQuestion, 0, len(arguments.Questions))
 	for _, item := range arguments.Questions {
 		question := item.Question
 		if strings.TrimSpace(question) == "" {
 			question = "requested user input"
 		}
-		questions = append(questions, question)
+		questions = append(questions, codexQuestion{id: item.ID, text: question})
 	}
 	return questions, true
+}
+
+func questionAnswersByCall(rows []codexRow) map[string]map[string][]string {
+	answersByCall := make(map[string]map[string][]string)
+	for _, row := range rows {
+		if row.Type != "response_item" || row.Payload.Type != "function_call_output" || row.Payload.CallID == "" {
+			continue
+		}
+		if answers, ok := questionAnswersFrom(row.Payload.Output); ok {
+			answersByCall[row.Payload.CallID] = answers
+		}
+	}
+	return answersByCall
+}
+
+func questionAnswersFrom(output json.RawMessage) (map[string][]string, bool) {
+	body := string(output)
+	var encoded string
+	if err := json.Unmarshal(output, &encoded); err == nil {
+		body = encoded
+	}
+	var result struct {
+		Answers map[string]struct {
+			Answers []string `json:"answers"`
+		} `json:"answers"`
+	}
+	if err := json.Unmarshal([]byte(body), &result); err != nil || result.Answers == nil {
+		return nil, false
+	}
+	answers := make(map[string][]string, len(result.Answers))
+	for id, answer := range result.Answers {
+		answers[id] = answer.Answers
+	}
+	return answers, true
 }
 
 func commandFrom(payload codexPayload) (string, bool) {

--- a/collector/internal/vendors/codex/parse.go
+++ b/collector/internal/vendors/codex/parse.go
@@ -243,7 +243,7 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 				}
 				if questions := questionsFrom(row.Payload); len(questions) > 0 {
 					for _, question := range questions {
-						answer := strings.Join(questionAnswers[row.Payload.CallID][question.id].Answers, ", ")
+						answer := strings.Join(questionAnswers[row.Payload.CallID][question.id].values(), ", ")
 						analysis.digest.PushQuestion(analysis.prompts, question.text, answer)
 					}
 				}
@@ -563,7 +563,27 @@ func questionsFrom(payload codexPayload) []codexQuestion {
 }
 
 type codexQuestionAnswer struct {
-	Answers []string `json:"answers"`
+	Answers  []string `json:"answers"`
+	Selected []string `json:"selected"`
+	Other    string   `json:"other"`
+}
+
+func (answer codexQuestionAnswer) values() []string {
+	values := make([]string, 0, len(answer.Answers)+len(answer.Selected)+1)
+	values = append(values, answer.Answers...)
+	values = append(values, answer.Selected...)
+	if answer.Other != "" {
+		values = append(values, answer.Other)
+	}
+
+	cleaned := values[:0]
+	for _, value := range values {
+		value = strings.TrimSpace(strings.TrimPrefix(value, "user_note:"))
+		if value != "" {
+			cleaned = append(cleaned, value)
+		}
+	}
+	return cleaned
 }
 
 func questionAnswersByCall(rows []codexRow) map[string]map[string]codexQuestionAnswer {

--- a/collector/internal/vendors/codex/parse.go
+++ b/collector/internal/vendors/codex/parse.go
@@ -241,10 +241,10 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 						analysis.pullRequests++
 					}
 				}
-				if questions, ok := questionsFrom(row.Payload); ok {
+				if questions := questionsFrom(row.Payload); len(questions) > 0 {
 					for _, question := range questions {
 						description := question.text
-						if answers := questionAnswers[row.Payload.CallID][question.id]; len(answers) > 0 {
+						if answers := questionAnswers[row.Payload.CallID][question.id].Answers; len(answers) > 0 {
 							description += " ↳ " + strings.Join(answers, ", ")
 						}
 						analysis.digest.Push(analysis.prompts, session.DigestQuestion, description)
@@ -479,15 +479,15 @@ func unifiedDiffStat(diff string) (additions, deletions int) {
 var execCmdPattern = regexp.MustCompile(
 	`(?:^|[{,]\s*)(?:"cmd"|cmd)\s*:\s*("(?:[^"\\]|\\.)*")`,
 )
+var requestUserInputCallPattern = regexp.MustCompile(`\brequest_user_input\s*\(`)
+var questionIDPattern = regexp.MustCompile(`"id"\s*:\s*("(?:[^"\\]|\\.)*")`)
+var questionPattern = regexp.MustCompile(`"question"\s*:\s*("(?:[^"\\]|\\.)*")`)
 var planStepPattern = regexp.MustCompile(
 	`"?step"?\s*:\s*("(?:[^"\\]|\\.)*")\s*,\s*"?status"?\s*:\s*"(\w+)"`,
 )
 
 func (analysis *codexSessionAnalysis) notePlan(payload codexPayload) {
-	text := payload.Input
-	if text == "" {
-		text = string(payload.Arguments)
-	}
+	text := payloadText(payload)
 	if payload.Name != "update_plan" && !strings.Contains(text, "update_plan") {
 		return
 	}
@@ -519,13 +519,10 @@ type codexQuestion struct {
 	text string
 }
 
-func questionsFrom(payload codexPayload) ([]codexQuestion, bool) {
-	if payload.Name != "request_user_input" {
-		return nil, false
-	}
-	text := string(payload.Arguments)
-	if text == "" {
-		text = payload.Input
+func questionsFrom(payload codexPayload) []codexQuestion {
+	text := payloadText(payload)
+	if payload.Name != "request_user_input" && !requestUserInputCallPattern.MatchString(text) {
+		return nil
 	}
 	var arguments struct {
 		Questions []struct {
@@ -533,24 +530,51 @@ func questionsFrom(payload codexPayload) ([]codexQuestion, bool) {
 			Question string `json:"question"`
 		} `json:"questions"`
 	}
-	if err := json.Unmarshal([]byte(text), &arguments); err != nil || len(arguments.Questions) == 0 {
-		return []codexQuestion{{text: "requested user input"}}, true
+	if err := json.Unmarshal([]byte(text), &arguments); err == nil && len(arguments.Questions) > 0 {
+		questions := make([]codexQuestion, 0, len(arguments.Questions))
+		for _, item := range arguments.Questions {
+			question := item.Question
+			if strings.TrimSpace(question) == "" {
+				question = "requested user input"
+			}
+			questions = append(questions, codexQuestion{id: item.ID, text: question})
+		}
+		return questions
 	}
-	questions := make([]codexQuestion, 0, len(arguments.Questions))
-	for _, item := range arguments.Questions {
-		question := item.Question
+
+	ids := questionIDPattern.FindAllStringSubmatch(text, -1)
+	questionMatches := questionPattern.FindAllStringSubmatch(text, -1)
+	questions := make([]codexQuestion, 0, len(questionMatches))
+	for i, match := range questionMatches {
+		var question string
+		if json.Unmarshal([]byte(match[1]), &question) != nil {
+			continue
+		}
 		if strings.TrimSpace(question) == "" {
 			question = "requested user input"
 		}
-		questions = append(questions, codexQuestion{id: item.ID, text: question})
+		id := ""
+		if i < len(ids) {
+			_ = json.Unmarshal([]byte(ids[i][1]), &id)
+		}
+		questions = append(questions, codexQuestion{id: id, text: question})
 	}
-	return questions, true
+	if len(questions) == 0 {
+		return []codexQuestion{{text: "requested user input"}}
+	}
+	return questions
 }
 
-func questionAnswersByCall(rows []codexRow) map[string]map[string][]string {
-	answersByCall := make(map[string]map[string][]string)
+type codexQuestionAnswer struct {
+	Answers []string `json:"answers"`
+}
+
+func questionAnswersByCall(rows []codexRow) map[string]map[string]codexQuestionAnswer {
+	answersByCall := make(map[string]map[string]codexQuestionAnswer)
 	for _, row := range rows {
-		if row.Type != "response_item" || row.Payload.Type != "function_call_output" || row.Payload.CallID == "" {
+		if row.Type != "response_item" ||
+			(row.Payload.Type != "function_call_output" && row.Payload.Type != "custom_tool_call_output") ||
+			row.Payload.CallID == "" {
 			continue
 		}
 		if answers, ok := questionAnswersFrom(row.Payload.Output); ok {
@@ -560,32 +584,29 @@ func questionAnswersByCall(rows []codexRow) map[string]map[string][]string {
 	return answersByCall
 }
 
-func questionAnswersFrom(output json.RawMessage) (map[string][]string, bool) {
-	body := string(output)
+func questionAnswersFrom(output json.RawMessage) (map[string]codexQuestionAnswer, bool) {
 	var encoded string
-	if err := json.Unmarshal(output, &encoded); err == nil {
-		body = encoded
-	}
-	var result struct {
-		Answers map[string]struct {
-			Answers []string `json:"answers"`
-		} `json:"answers"`
-	}
-	if err := json.Unmarshal([]byte(body), &result); err != nil || result.Answers == nil {
+	if err := json.Unmarshal(output, &encoded); err != nil {
 		return nil, false
 	}
-	answers := make(map[string][]string, len(result.Answers))
-	for id, answer := range result.Answers {
-		answers[id] = answer.Answers
+	var result struct {
+		Answers map[string]codexQuestionAnswer `json:"answers"`
 	}
-	return answers, true
+	if err := json.Unmarshal([]byte(encoded), &result); err != nil || result.Answers == nil {
+		return nil, false
+	}
+	return result.Answers, true
+}
+
+func payloadText(payload codexPayload) string {
+	if payload.Input != "" {
+		return payload.Input
+	}
+	return string(payload.Arguments)
 }
 
 func commandFrom(payload codexPayload) (string, bool) {
-	text := payload.Input
-	if text == "" {
-		text = string(payload.Arguments)
-	}
+	text := payloadText(payload)
 	m := execCmdPattern.FindStringSubmatch(text)
 	if m == nil {
 		return "", false

--- a/collector/internal/vendors/codex/types.go
+++ b/collector/internal/vendors/codex/types.go
@@ -28,6 +28,7 @@ type codexPayload struct {
 	Input          string            `json:"input"`
 	Arguments      codexArguments    `json:"arguments"`
 	Name           string            `json:"name"`
+	CallID         string            `json:"call_id"`
 	Output         json.RawMessage   `json:"output"`
 	Changes        codexPatchChanges `json:"changes"`
 	ID             string            `json:"id"`

--- a/frontend/src/pages/coslash/components/SessionInspector.tsx
+++ b/frontend/src/pages/coslash/components/SessionInspector.tsx
@@ -494,16 +494,13 @@ function DigestRow({ entry }: { entry: DigestEntry }) {
   const [expanded, setExpanded] = useState(false);
   const meta = DIGEST_CATEGORIES[entry.category];
   const collapsible = entry.category === 'recap' && entry.description.length > 120;
-  const answerSeparator = entry.category === 'question' ? entry.description.indexOf(' ↳ ') : -1;
-  const description = answerSeparator < 0 ? entry.description : entry.description.slice(0, answerSeparator);
-  const answer = answerSeparator < 0 ? null : entry.description.slice(answerSeparator + ' ↳ '.length);
 
   return (
     <div className="flex items-baseline gap-2 border-b border-neutral-100 py-1">
       <span className={cn('w-24 shrink-0 text-xs font-bold tracking-wide', meta.fg)}>{meta.label}</span>
       <div className="min-w-0 flex-1">
-        <div className={cn('text-xs', { 'line-clamp-1': collapsible && !expanded })}>{description}</div>
-        {answer != null && <div className="text-xs">↳ {answer}</div>}
+        <div className={cn('text-xs', { 'line-clamp-1': collapsible && !expanded })}>{entry.description}</div>
+        {entry.answer != null && <div className="text-xs">↳ {entry.answer}</div>}
         {collapsible && (
           <div
             className="text-brand flex cursor-pointer items-center gap-1 pt-1 text-xs"

--- a/frontend/src/pages/coslash/components/SessionInspector.tsx
+++ b/frontend/src/pages/coslash/components/SessionInspector.tsx
@@ -494,12 +494,16 @@ function DigestRow({ entry }: { entry: DigestEntry }) {
   const [expanded, setExpanded] = useState(false);
   const meta = DIGEST_CATEGORIES[entry.category];
   const collapsible = entry.category === 'recap' && entry.description.length > 120;
+  const answerSeparator = entry.category === 'question' ? entry.description.indexOf(' ↳ ') : -1;
+  const description = answerSeparator < 0 ? entry.description : entry.description.slice(0, answerSeparator);
+  const answer = answerSeparator < 0 ? null : entry.description.slice(answerSeparator + ' ↳ '.length);
 
   return (
     <div className="flex items-baseline gap-2 border-b border-neutral-100 py-1">
       <span className={cn('w-24 shrink-0 text-xs font-bold tracking-wide', meta.fg)}>{meta.label}</span>
       <div className="min-w-0 flex-1">
-        <div className={cn('text-xs', { 'line-clamp-1': collapsible && !expanded })}>{entry.description}</div>
+        <div className={cn('text-xs', { 'line-clamp-1': collapsible && !expanded })}>{description}</div>
+        {answer != null && <div className="text-xs">↳ {answer}</div>}
         {collapsible && (
           <div
             className="text-brand flex cursor-pointer items-center gap-1 pt-1 text-xs"

--- a/frontend/src/pages/coslash/components/SessionInspector.tsx
+++ b/frontend/src/pages/coslash/components/SessionInspector.tsx
@@ -500,7 +500,7 @@ function DigestRow({ entry }: { entry: DigestEntry }) {
       <span className={cn('w-24 shrink-0 text-xs font-bold tracking-wide', meta.fg)}>{meta.label}</span>
       <div className="min-w-0 flex-1">
         <div className={cn('text-xs', { 'line-clamp-1': collapsible && !expanded })}>{entry.description}</div>
-        {entry.answer != null && <div className="text-xs">↳ {entry.answer}</div>}
+        {entry.answer != null && <div className="pl-4 text-xs">{entry.answer}</div>}
         {collapsible && (
           <div
             className="text-brand flex cursor-pointer items-center gap-1 pt-1 text-xs"

--- a/frontend/src/pages/coslash/lib/session.ts
+++ b/frontend/src/pages/coslash/lib/session.ts
@@ -76,6 +76,7 @@ export type DigestEntry = {
   turn: number;
   category: 'first_prompt' | 'user' | 'question' | 'todos' | 'compaction' | 'recap' | 'subagent';
   description: string;
+  answer?: string;
   subagentId?: string;
 };
 


### PR DESCRIPTION
## Context

Codex input requests can contain multiple questions, with responses recorded separately. coSlash previously retained only the first question and omitted its answer, leaving the session timeline incomplete.

## Changes

- Parse every question in Codex input requests and correlate responses by call and question ID
- Preserve unanswered questions and combine multi-select responses
- Display each answer beneath its question in the session timeline

## Test

Before: if a session asked 3 questions in a row, only displayed the last question
After: all questions displayed