### PR TITLE
Drop sessions that hold no conversation

### DIFF
--- a/collector/internal/collector/collector.go
+++ b/collector/internal/collector/collector.go
@@ -263,7 +263,11 @@ func servableRoots(roots []*vendors.ParsedTranscript) []*session.Session {
 		if filepath.Clean(s.WorkingDirectory) == synthesisCwd {
 			continue
 		}
-		if s.Status == nil && s.Turns == 0 && s.ToolUses == 0 && len(s.Tokens) == 0 {
+		// FirstPrompt keeps a session that recorded a prompt but never ran it.
+		// Codex counts a turn on task_started, not on the prompt, so an
+		// interrupted rollout reaches here with real user work and zero counters.
+		if s.Status == nil && s.FirstPrompt == nil &&
+			s.Turns == 0 && s.ToolUses == 0 && len(s.Tokens) == 0 {
 			continue
 		}
 		kept = append(kept, s)

--- a/collector/internal/collector/collector.go
+++ b/collector/internal/collector/collector.go
@@ -82,7 +82,7 @@ func List(since int64) ([]*session.Session, error) {
 	probeEnvironment(roots)
 	resolveNames(roots, metadata)
 	resolveStatus(roots, metadata)
-	return excludeSynthesisRuns(roots), nil
+	return servableRoots(roots), nil
 }
 
 func applyForkedUsage(parsed []*vendors.ParsedTranscript) {
@@ -252,16 +252,21 @@ func resolveStatus(
 	}
 }
 
-// excludeSynthesisRuns drops the collector's own synthesis CLI sessions, which
-// run in SynthesisCwd and would otherwise show up as sessions of their own.
-func excludeSynthesisRuns(roots []*vendors.ParsedTranscript) []*session.Session {
+// drop synthesis cli sessions
+// claude: drop /clear stub sessions
+// codex: drop session_meta-only sessions
+func servableRoots(roots []*vendors.ParsedTranscript) []*session.Session {
 	synthesisCwd := filepath.Clean(synthesis.SynthesisCwd())
 	kept := []*session.Session{}
 	for _, p := range roots {
-		if filepath.Clean(p.Session.WorkingDirectory) == synthesisCwd {
+		s := p.Session
+		if filepath.Clean(s.WorkingDirectory) == synthesisCwd {
 			continue
 		}
-		kept = append(kept, p.Session)
+		if s.Status == nil && s.Turns == 0 && s.ToolUses == 0 && len(s.Tokens) == 0 {
+			continue
+		}
+		kept = append(kept, s)
 	}
 	return kept
 }


### PR DESCRIPTION
## Context

Some sessions appeared in the UI with no data: unknown model, `≈$0.00`, and `<1m · 0 turns · 0 tools · 0 errors`. These transcripts hold no conversation. Claude Code writes one for each `/clear`, and Codex writes one when a rollout ends before its first turn.

## Changes

- Sessions that never got past their opening records no longer appear in the UI. A root is dropped when it has no turns, no tool uses, and no tokens.
- The filter applies to both agents. A Claude `/clear` stub and a `session_meta`-only Codex rollout are the same case.
- A live session stays listed before its first turn. `servableRoots` runs after `resolveStatus`, so a non-nil `Status` marks the session as live and exempts it.
- `excludeSynthesisRuns` becomes `servableRoots`. The function already dropped the synthesis CLI sessions, so the new rule reuses that pass instead of adding another one.

## Test

- `go vet ./...` — passed
- `go test ./...` — passed
- Manual: `List(0)` over the local transcripts. The two `/clear` stubs are gone. 187 of 189 roots remain, and every session with content is still listed.

### Screenshots

before
<img width="2323" height="730" alt="Screenshot 2026-08-06 at 17 55 01" src="https://github.com/user-attachments/assets/1a73a0fd-da70-45f7-b072-b73165a11197" />
after
<img width="2318" height="698" alt="Screenshot 2026-08-06 at 17 57 25" src="https://github.com/user-attachments/assets/b1e34f94-21ce-49e3-9aaf-239852089ccb" />
