### PR TITLE
Settle forked-skill subagents from their own transcript

### DIFF
--- a/collector/internal/collector/helpers.go
+++ b/collector/internal/collector/helpers.go
@@ -106,9 +106,17 @@ func subagentStatus(
 	if _, ok := parent.Completed[child.SpawnKey]; ok {
 		return session.SubagentReturned
 	}
-	// A forked skill is not spawned by a tool call, fall back to child transcript
-	if child.SpawnKey == "" && !child.InTurn {
-		return session.SubagentReturned
+	// A forked skill is not spawned by a tool call, so its meta.json carries no
+	// toolUseId and it never reaches parent.Completed. Settle it from its own
+	// transcript, which clears InTurn on a terminal stop_reason.
+	if child.SpawnKey == "" {
+		if !child.InTurn {
+			return session.SubagentReturned
+		}
+		// The transcript stops mid-turn when the run dies with its parent.
+		if _, live := metadata.Live[parent.Session.ID]; !live {
+			return session.SubagentAborted
+		}
 	}
 	return session.SubagentRunning
 }

--- a/collector/internal/collector/helpers.go
+++ b/collector/internal/collector/helpers.go
@@ -106,5 +106,9 @@ func subagentStatus(
 	if _, ok := parent.Completed[child.SpawnKey]; ok {
 		return session.SubagentReturned
 	}
+	// A forked skill is not spawned by a tool call, fall back to child transcript
+	if child.SpawnKey == "" && !child.InTurn {
+		return session.SubagentReturned
+	}
 	return session.SubagentRunning
 }

--- a/collector/internal/vendors/claude/parse.go
+++ b/collector/internal/vendors/claude/parse.go
@@ -95,6 +95,10 @@ func analyzeClaudeSession(file string) (*claudeSessionAnalysis, error) {
 		return nil, err
 	}
 	analysis := &claudeSessionAnalysis{
+		// A subagent transcript opens mid-turn: the spawn already happened, and
+		// its task prompt is a meta row that emitPrompt skips. A forked skill has
+		// no other prompt row, so nothing else would ever raise this.
+		inTurn:                   ParentIDFromPath(file) != "",
 		dedupedMessageTokenUsage: map[string]messageUsage{},
 		completedToolUses:        map[string]struct{}{},
 		pullRequests:             map[string]struct{}{},

--- a/collector/internal/vendors/transcript.go
+++ b/collector/internal/vendors/transcript.go
@@ -23,5 +23,5 @@ type ParsedTranscript struct {
 
 	// consumed at resolveNames / resolveStatus
 	Name   string // from the file: transcript title (roots), meta description/agentType (children)
-	InTurn bool   // refines "interactive" to busy/idle
+	InTurn bool   // roots: refines "interactive" to busy/idle. children: still running
 }


### PR DESCRIPTION
## Context

A subagent kept the `running` badge after its session closed. The subagent came from a forked skill, for example `/code-review`. No tool call spawns a forked skill, so its `meta.json` carries no `toolUseId`. `subagentStatus` matched that empty key against the completed tool results of the parent, and the match never succeeded.

## Changes

- When its own transcript is complete, a forked-skill subagent now reads `returned`. Before this change it read `running` forever.
- The fallback needs an empty spawn key. A normal Task subagent keeps the tool-result path, which stays authoritative. That path settles a child only after the parent writes the tool result, so a child mid-handoff never flickers to `returned`.
- `InTurn` is the signal, and it already clears on a terminal `stop_reason` (`claude/parse.go:275`). The fix reads a value the parser produces today and adds no new parsing.
- Note: the digest gap remains. `linkSpawnDigest` still logs `has no spawn row in the parent transcript` for a forked skill, so the subagent shows in the rail with no turn anchor.

## Test

- `go vet ./...` — passed
- `go test ./...` — passed
- Manual: `List(0)` over the local transcripts. Subagent `agent-a5101e8ad9c72bdc6` in session `cebc97ec` reads `returned`. It read `running` before the fix.

### Screenshots

with session closed
before
<img width="2319" height="211" alt="Screenshot 2026-08-06 at 18 03 50" src="https://github.com/user-attachments/assets/174b60bb-330f-47db-a03e-16d9141009d7" />


after
<img width="2310" height="255" alt="Screenshot 2026-08-06 at 18 04 05" src="https://github.com/user-attachments/assets/71cbe043-09df-439f-a61b-32f128a592cb" />
