### PR TITLE
Support non-file session sources in the collector

### DIFF
--- a/collector/cmd/coslash/api.go
+++ b/collector/cmd/coslash/api.go
@@ -55,7 +55,7 @@ func parseSince(value string) (int64, error) {
 }
 
 // /api/synthesis?id=X → cached synthesis for one session, triggering a run
-// when eligible. Parses one file, never the whole machine — Get skips fork,
+// when eligible. Loads one session, never the whole machine — Get skips fork,
 // subagents, and name/status resolution because BuildInput and Eligible read
 // none of those.
 func handleSynthesis(w http.ResponseWriter, id string, mgr *synthesis.Manager) {

--- a/collector/cmd/coslash/api.go
+++ b/collector/cmd/coslash/api.go
@@ -33,11 +33,7 @@ func handleList(w http.ResponseWriter, r *http.Request, mgr *synthesis.Manager) 
 		return
 	}
 	for _, session := range sessions {
-		mtime, err := synthesis.TranscriptMtime(session.LogPath)
-		if err != nil || mtime <= 0 {
-			continue
-		}
-		session.Synthesis = mgr.Lookup(session.ID, mtime)
+		session.Synthesis = mgr.Lookup(session.ID, session.LastActivityTime)
 	}
 	writeJSON(w, sessions)
 	log.Printf("list sessions: %d", len(sessions))
@@ -74,14 +70,14 @@ func handleSynthesis(w http.ResponseWriter, id string, mgr *synthesis.Manager) {
 		SynthesisPending bool                      `json:"synthesisPending"`
 		SynthesisError   string                    `json:"synthesisError,omitempty"`
 	}{}
-	mtime, err := synthesis.TranscriptMtime(found.LogPath)
-	if err == nil && mtime > 0 {
-		response.Synthesis = mgr.Lookup(found.ID, mtime)
-		mgr.Ensure(found, mtime)
+	revision := found.LastActivityTime
+	if revision > 0 {
+		response.Synthesis = mgr.Lookup(found.ID, revision)
+		mgr.Ensure(found, revision)
 		response.SynthesisPending = response.Synthesis == nil && synthesis.Eligible(found) &&
-			!mgr.InCooldown(found.ID, mtime)
+			!mgr.InCooldown(found.ID, revision)
 		if response.Synthesis == nil {
-			response.SynthesisError = mgr.Failure(found.ID, mtime)
+			response.SynthesisError = mgr.Failure(found.ID, revision)
 		}
 	}
 	writeJSON(w, response)

--- a/collector/internal/collector/collector.go
+++ b/collector/internal/collector/collector.go
@@ -23,6 +23,14 @@ const (
 )
 
 type vendorSource struct {
+	name    string
+	collect func(since int64) ([]*vendors.ParsedTranscript, *vendors.SessionMetadata, error)
+	get     func(id string) (*vendors.ParsedTranscript, error)
+	health  func() SourceHealth
+	fork    func(parsed []*vendors.ParsedTranscript)
+}
+
+type fileSource struct {
 	name     string
 	root     func() (string, error)
 	files    func() ([]string, error)
@@ -35,14 +43,16 @@ type vendorSource struct {
 }
 
 var vendorSources = []vendorSource{
-	{
-		vendors.AgentClaude, claude.Root, claude.Files, claude.Scan, claude.IDFromPath,
-		claude.Parse, claude.LoadMetadata, claude.ApplyForkedUsage, claude.FilesSince,
-	},
-	{
-		vendors.AgentCodex, codex.Root, codex.Files, codex.Scan, codex.SessionIDFromRollout,
-		codex.Parse, codex.LoadMetadata, codex.ApplyForkedUsage, codex.FilesSince,
-	},
+	adaptFileVendor(fileSource{
+		name: vendors.AgentClaude, root: claude.Root, files: claude.Files, scan: claude.Scan,
+		id: claude.IDFromPath, parse: claude.Parse, metadata: claude.LoadMetadata,
+		fork: claude.ApplyForkedUsage, window: claude.FilesSince,
+	}),
+	adaptFileVendor(fileSource{
+		name: vendors.AgentCodex, root: codex.Root, files: codex.Files, scan: codex.Scan,
+		id: codex.SessionIDFromRollout, parse: codex.Parse, metadata: codex.LoadMetadata,
+		fork: codex.ApplyForkedUsage, window: codex.FilesSince,
+	}),
 }
 
 type SourceHealth struct {
@@ -55,13 +65,7 @@ type SourceHealth struct {
 func Sources() []SourceHealth {
 	health := make([]SourceHealth, 0, len(vendorSources))
 	for _, source := range vendorSources {
-		root, rootErr := source.root()
-		if rootErr != nil {
-			health = append(health, SourceHealth{Agent: source.name, ScanErr: rootErr})
-			continue
-		}
-		scan, scanErr := source.scan()
-		health = append(health, SourceHealth{Agent: source.name, Root: root, Scan: scan, ScanErr: scanErr})
+		health = append(health, source.health())
 	}
 	return health
 }
@@ -99,12 +103,14 @@ func applyForkedUsage(parsed []*vendors.ParsedTranscript) {
 	}
 }
 
-func collect(since int64) ([]*vendors.ParsedTranscript, map[string]*vendors.SessionMetadata, error) {
+func collect(
+	since int64,
+) ([]*vendors.ParsedTranscript, map[string]*vendors.SessionMetadata, error) {
 	parsed := []*vendors.ParsedTranscript{}
 	metadata := map[string]*vendors.SessionMetadata{}
 	var failures []error
 	for _, source := range vendorSources {
-		vendorParsed, vendorMetadata, err := collectAndParseVendor(source, since)
+		vendorParsed, vendorMetadata, err := source.collect(since)
 		if err != nil {
 			log.Printf("%s session collection failed: %v; serving other vendors", source.name, err)
 			failures = append(failures, fmt.Errorf("%s: %w", source.name, err))
@@ -286,8 +292,8 @@ func deref(value *string) string {
 	return *value
 }
 
-// Get returns one session by id: a directory walk, one file parse, and its
-// probes. No fork pass, no subagents, no name/status resolution — synthesis (BuildInput,
+// Get returns one session by id using the vendor's native lookup and its probes.
+// No fork pass, no subagents, no name/status resolution — synthesis (BuildInput,
 // Eligible) and launch read none of those. Sessions in the synthesis cwd stay
 // invisible, as in the list. Returns nil when the id is unknown.
 func Get(id string) (*session.Session, error) {
@@ -296,24 +302,13 @@ func Get(id string) (*session.Session, error) {
 	}
 	var p *vendors.ParsedTranscript
 	for _, source := range vendorSources {
-		files, err := source.files()
-		if err != nil {
+		var err error
+		if p, err = source.get(id); err != nil {
 			return nil, err
 		}
-		path := ""
-		for _, file := range files {
-			if source.id(file) == id {
-				path = file
-				break
-			}
+		if p != nil {
+			break
 		}
-		if path == "" {
-			continue
-		}
-		if p, err = source.parse(path); err != nil {
-			return nil, err
-		}
-		break
 	}
 	if p == nil {
 		return nil, nil

--- a/collector/internal/collector/helpers.go
+++ b/collector/internal/collector/helpers.go
@@ -12,8 +12,38 @@ import (
 
 const maxParseWorkers = 8
 
-func collectAndParseVendor(
-	source vendorSource,
+func adaptFileVendor(source fileSource) vendorSource {
+	return vendorSource{
+		name: source.name,
+		collect: func(since int64) ([]*vendors.ParsedTranscript, *vendors.SessionMetadata, error) {
+			return collectAndParseFiles(source, since)
+		},
+		get: func(id string) (*vendors.ParsedTranscript, error) {
+			files, err := source.files()
+			if err != nil {
+				return nil, err
+			}
+			for _, file := range files {
+				if source.id(file) == id {
+					return source.parse(file)
+				}
+			}
+			return nil, nil
+		},
+		health: func() SourceHealth {
+			root, err := source.root()
+			if err != nil {
+				return SourceHealth{Agent: source.name, ScanErr: err}
+			}
+			scan, err := source.scan()
+			return SourceHealth{Agent: source.name, Root: root, Scan: scan, ScanErr: err}
+		},
+		fork: source.fork,
+	}
+}
+
+func collectAndParseFiles(
+	source fileSource,
 	since int64,
 ) ([]*vendors.ParsedTranscript, *vendors.SessionMetadata, error) {
 	files, err := source.files()

--- a/collector/internal/synthesis/cache.go
+++ b/collector/internal/synthesis/cache.go
@@ -12,7 +12,7 @@ import (
 
 type Record struct {
 	SessionID   string                   `json:"sessionId"`
-	Mtime       int64                    `json:"mtime"`
+	Revision    int64                    `json:"mtime"`
 	Model       string                   `json:"model"`
 	GeneratedAt int64                    `json:"generatedAt"`
 	Synthesis   session.SessionSynthesis `json:"synthesis"`
@@ -75,12 +75,12 @@ func (c *Cache) Store(id string, record Record) error {
 	return nil
 }
 
-func (c *Cache) Lookup(id string, mtime int64) *session.SessionSynthesis {
-	if mtime <= 0 {
+func (c *Cache) Lookup(id string, revision int64) *session.SessionSynthesis {
+	if revision <= 0 {
 		return nil
 	}
 	record, err := c.Load(id)
-	if err != nil || record.Mtime != mtime {
+	if err != nil || record.Revision != revision {
 		return nil
 	}
 	synthesis := record.Synthesis

--- a/collector/internal/synthesis/manager.go
+++ b/collector/internal/synthesis/manager.go
@@ -22,8 +22,8 @@ const (
 )
 
 type failureKey struct {
-	id    string
-	mtime int64
+	id       string
+	revision int64
 }
 
 type failure struct {
@@ -59,21 +59,21 @@ func NewManager(runner Runner) *Manager {
 	}
 }
 
-func (m *Manager) Lookup(id string, mtime int64) *session.SessionSynthesis {
+func (m *Manager) Lookup(id string, revision int64) *session.SessionSynthesis {
 	if m == nil {
 		return nil
 	}
-	return m.cache.Lookup(id, mtime)
+	return m.cache.Lookup(id, revision)
 }
 
-func (m *Manager) Ensure(s *session.Session, mtime int64) bool {
-	if m == nil || mtime <= 0 || !Eligible(s) {
+func (m *Manager) Ensure(s *session.Session, revision int64) bool {
+	if m == nil || revision <= 0 || !Eligible(s) {
 		return false
 	}
 	if m.currentRunner() == nil {
 		return false
 	}
-	if m.Lookup(s.ID, mtime) != nil || m.InCooldown(s.ID, mtime) {
+	if m.Lookup(s.ID, revision) != nil || m.InCooldown(s.ID, revision) {
 		return false
 	}
 	if _, loaded := m.inFlight.LoadOrStore(s.ID, struct{}{}); loaded {
@@ -92,23 +92,23 @@ func (m *Manager) Ensure(s *session.Session, mtime int64) bool {
 		}
 		result, err := runner.Run(context.Background(), input)
 		if err != nil {
-			m.recordFailure(id, mtime, err)
+			m.recordFailure(id, revision, err)
 			log.Printf("synthesize session %s: %v", id, err)
 			return
 		}
 		record := Record{
 			SessionID:   id,
-			Mtime:       mtime,
+			Revision:    revision,
 			Model:       runnerModel(runner),
 			GeneratedAt: m.now().UnixMilli(),
 			Synthesis:   result,
 		}
 		if err := m.cache.Store(id, record); err != nil {
-			m.recordFailure(id, mtime, err)
+			m.recordFailure(id, revision, err)
 			log.Printf("cache synthesis for session %s: %v", id, err)
 			return
 		}
-		m.failures.Delete(failureKey{id: id, mtime: mtime})
+		m.failures.Delete(failureKey{id: id, revision: revision})
 		m.cliMissingUntil.Store(0)
 	}()
 	return true
@@ -123,7 +123,7 @@ func buildInputWithDetailProbes(s *session.Session) string {
 	return BuildInput(&inputSession)
 }
 
-func (m *Manager) InCooldown(id string, mtime int64) bool {
+func (m *Manager) InCooldown(id string, revision int64) bool {
 	if m == nil {
 		return true
 	}
@@ -135,7 +135,7 @@ func (m *Manager) InCooldown(id string, mtime int64) bool {
 	if until := m.cliMissingUntil.Load(); until > now.UnixNano() {
 		return true
 	}
-	key := failureKey{id: id, mtime: mtime}
+	key := failureKey{id: id, revision: revision}
 	value, ok := m.failures.Load(key)
 	if !ok {
 		return false
@@ -181,11 +181,7 @@ func (m *Manager) sweep(list func() ([]*session.Session, error)) {
 		if candidate.Status == nil && candidate.LastActivityTime < startOfToday {
 			continue
 		}
-		mtime, err := TranscriptMtime(candidate.LogPath)
-		if err != nil || mtime <= 0 {
-			continue
-		}
-		if m.Ensure(candidate, mtime) {
+		if m.Ensure(candidate, candidate.LastActivityTime) {
 			initiated++
 			if initiated == m.sweepLimit {
 				return
@@ -194,9 +190,9 @@ func (m *Manager) sweep(list func() ([]*session.Session, error)) {
 	}
 }
 
-func (m *Manager) recordFailure(id string, mtime int64, err error) {
+func (m *Manager) recordFailure(id string, revision int64, err error) {
 	now := m.now()
-	m.failures.Store(failureKey{id: id, mtime: mtime}, failure{at: now, message: err.Error()})
+	m.failures.Store(failureKey{id: id, revision: revision}, failure{at: now, message: err.Error()})
 	if errors.Is(err, exec.ErrNotFound) {
 		m.cliMissingUntil.Store(now.Add(m.cliMissingCooldown).UnixNano())
 	}
@@ -216,17 +212,17 @@ func (m *Manager) SetRunner(runner Runner) {
 	})
 }
 
-func (m *Manager) Failure(id string, mtime int64) string {
+func (m *Manager) Failure(id string, revision int64) string {
 	if m == nil {
 		return ""
 	}
-	value, ok := m.failures.Load(failureKey{id: id, mtime: mtime})
+	value, ok := m.failures.Load(failureKey{id: id, revision: revision})
 	if !ok {
 		return ""
 	}
 	failed := value.(failure)
 	if m.now().Sub(failed.at) >= m.failureCooldown {
-		m.failures.Delete(failureKey{id: id, mtime: mtime})
+		m.failures.Delete(failureKey{id: id, revision: revision})
 		return ""
 	}
 	return failed.message

--- a/collector/internal/synthesis/paths.go
+++ b/collector/internal/synthesis/paths.go
@@ -26,11 +26,3 @@ func EnsureDirs() error {
 	}
 	return nil
 }
-
-func TranscriptMtime(logPath string) (int64, error) {
-	info, err := os.Stat(logPath)
-	if err != nil {
-		return 0, err
-	}
-	return info.ModTime().UnixMilli(), nil
-}

--- a/collector/internal/vendors/transcript.go
+++ b/collector/internal/vendors/transcript.go
@@ -2,11 +2,10 @@ package vendors
 
 import "github.com/centauri-ai/coslash/collector/internal/session"
 
-// ParsedTranscript is everything Parse extracts from one transcript file:
-// the servable Session plus the cross-file facts no single file can resolve.
-// Parse may read the file and its own sidecar, nothing else — no cross-file
-// reads, no git, no liveness probes. Parse writes every field; later stages
-// only read them, writing their results into Session.
+// ParsedTranscript is everything a vendor extracts for one session: the
+// servable Session plus facts that later collection stages resolve. Vendor
+// extraction does no git or liveness probes and writes every field; later
+// stages only read them, writing their results into Session.
 type ParsedTranscript struct {
 	Session *session.Session
 


### PR DESCRIPTION
## Context

Session collection currently assumes each session is backed by its own transcript file. This refactor moves file-specific behavior behind an adapter and uses per-session activity for synthesis cache revisions, allowing non-file sources (i.e. opencode) without changing Claude or Codex behavior.

## Changes

- Add source-level collection, lookup, and health callbacks while retaining Claude and Codex through a file adapter.
- Invalidate synthesis per session using last activity while preserving compatibility with existing cache records.

## Test

- `go test ./...` - passed
- `go vet ./...` - passed