### PR TITLE
Make session source diagnostics storage-neutral

### DIFF
--- a/collector/cmd/coslash/doctor.go
+++ b/collector/cmd/coslash/doctor.go
@@ -62,7 +62,7 @@ func renderDoctor(w io.Writer, snapshot *diagnostics.Snapshot) {
 				cli += " (" + source.CLI.Version + ")"
 			}
 		}
-		fmt.Fprintf(w, "%s: %s, %d transcript files, %d session files; CLI %s\n", source.Label, source.Root, source.Transcripts, source.SessionFiles, cli)
+		fmt.Fprintf(w, "%s: %s, %d source entries, %d sessions; CLI %s\n", source.Label, source.Root, source.Entries, source.Sessions, cli)
 	}
 	fmt.Fprintf(w, "Storage: %s, writable=%t\n", snapshot.Storage.Home, snapshot.Storage.Writable)
 }

--- a/collector/internal/collector/collector.go
+++ b/collector/internal/collector/collector.go
@@ -35,7 +35,7 @@ type fileSource struct {
 	root     func() (string, error)
 	files    func() ([]string, error)
 	scan     func() (*vendors.SourceScan, error)
-	isRoot   func(path string) bool
+	isRoot   func(path string) (bool, error)
 	id       func(path string) string // session id without parsing, for Get
 	parse    func(path string) (*vendors.ParsedTranscript, error)
 	metadata func() (*vendors.SessionMetadata, error) // information not extractable from logs alone
@@ -46,7 +46,7 @@ type fileSource struct {
 var vendorSources = []vendorSource{
 	adaptFileVendor(fileSource{
 		name: vendors.AgentClaude, root: claude.Root, files: claude.Files, scan: claude.Scan,
-		isRoot: func(path string) bool { return claude.ParentIDFromPath(path) == "" },
+		isRoot: func(path string) (bool, error) { return claude.ParentIDFromPath(path) == "", nil },
 		id:     claude.IDFromPath, parse: claude.Parse, metadata: claude.LoadMetadata,
 		fork: claude.ApplyForkedUsage, window: claude.FilesSince,
 	}),

--- a/collector/internal/collector/collector.go
+++ b/collector/internal/collector/collector.go
@@ -35,6 +35,7 @@ type fileSource struct {
 	root     func() (string, error)
 	files    func() ([]string, error)
 	scan     func() (*vendors.SourceScan, error)
+	isRoot   func(path string) bool
 	id       func(path string) string // session id without parsing, for Get
 	parse    func(path string) (*vendors.ParsedTranscript, error)
 	metadata func() (*vendors.SessionMetadata, error) // information not extractable from logs alone
@@ -45,21 +46,27 @@ type fileSource struct {
 var vendorSources = []vendorSource{
 	adaptFileVendor(fileSource{
 		name: vendors.AgentClaude, root: claude.Root, files: claude.Files, scan: claude.Scan,
-		id: claude.IDFromPath, parse: claude.Parse, metadata: claude.LoadMetadata,
+		isRoot: func(path string) bool { return claude.ParentIDFromPath(path) == "" },
+		id:     claude.IDFromPath, parse: claude.Parse, metadata: claude.LoadMetadata,
 		fork: claude.ApplyForkedUsage, window: claude.FilesSince,
 	}),
 	adaptFileVendor(fileSource{
 		name: vendors.AgentCodex, root: codex.Root, files: codex.Files, scan: codex.Scan,
-		id: codex.SessionIDFromRollout, parse: codex.Parse, metadata: codex.LoadMetadata,
+		isRoot: codex.IsRootRollout,
+		id:     codex.SessionIDFromRollout, parse: codex.Parse, metadata: codex.LoadMetadata,
 		fork: codex.ApplyForkedUsage, window: codex.FilesSince,
 	}),
 }
 
 type SourceHealth struct {
-	Agent   string
-	Root    string
-	Scan    *vendors.SourceScan
-	ScanErr error
+	Agent        string
+	Root         string
+	Entries      int
+	Sessions     int
+	Missing      bool
+	Skipped      []vendors.SkippedPath
+	SkippedTotal int
+	Err          error
 }
 
 func Sources() []SourceHealth {

--- a/collector/internal/collector/helpers.go
+++ b/collector/internal/collector/helpers.go
@@ -33,10 +33,26 @@ func adaptFileVendor(source fileSource) vendorSource {
 		health: func() SourceHealth {
 			root, err := source.root()
 			if err != nil {
-				return SourceHealth{Agent: source.name, ScanErr: err}
+				return SourceHealth{Agent: source.name, Err: err}
 			}
 			scan, err := source.scan()
-			return SourceHealth{Agent: source.name, Root: root, Scan: scan, ScanErr: err}
+			if err != nil {
+				return SourceHealth{Agent: source.name, Root: root, Err: err}
+			}
+			health := SourceHealth{
+				Agent:        source.name,
+				Root:         root,
+				Entries:      len(scan.Files),
+				Missing:      scan.RootMissing,
+				Skipped:      scan.Skipped,
+				SkippedTotal: max(scan.SkippedTotal, len(scan.Skipped)),
+			}
+			for _, file := range scan.Files {
+				if source.isRoot(file) {
+					health.Sessions++
+				}
+			}
+			return health
 		},
 		fork: source.fork,
 	}

--- a/collector/internal/collector/helpers.go
+++ b/collector/internal/collector/helpers.go
@@ -39,20 +39,26 @@ func adaptFileVendor(source fileSource) vendorSource {
 			if err != nil {
 				return SourceHealth{Agent: source.name, Root: root, Err: err}
 			}
-			health := SourceHealth{
+			sessions := 0
+			for _, file := range scan.Files {
+				isRoot, err := source.isRoot(file)
+				if err != nil {
+					scan.RecordSkipped(file, err)
+					continue
+				}
+				if isRoot {
+					sessions++
+				}
+			}
+			return SourceHealth{
 				Agent:        source.name,
 				Root:         root,
 				Entries:      len(scan.Files),
+				Sessions:     sessions,
 				Missing:      scan.RootMissing,
 				Skipped:      scan.Skipped,
 				SkippedTotal: max(scan.SkippedTotal, len(scan.Skipped)),
 			}
-			for _, file := range scan.Files {
-				if source.isRoot(file) {
-					health.Sessions++
-				}
-			}
-			return health
 		},
 		fork: source.fork,
 	}

--- a/collector/internal/diagnostics/checks.go
+++ b/collector/internal/diagnostics/checks.go
@@ -13,17 +13,17 @@ func derive(snapshot *Snapshot) []Check {
 			Fix:    "Check that the current user has a valid home directory.",
 		})
 	}
-	noTranscripts := true
+	noEntries := true
 	scanFailed := false
 	for _, source := range snapshot.Sources {
 		checks = append(checks, sourceCheck(source))
-		if source.Transcripts > 0 {
-			noTranscripts = false
+		if source.Entries > 0 {
+			noEntries = false
 		}
 		if source.State == SourceUnreadable {
 			scanFailed = true
 		}
-		if source.Transcripts > 0 && !source.CLI.Found {
+		if source.Entries > 0 && !source.CLI.Found {
 			checks = append(checks, Check{
 				ID:     "cli." + source.Agent,
 				Title:  source.Label + " CLI",
@@ -33,13 +33,13 @@ func derive(snapshot *Snapshot) []Check {
 			})
 		}
 	}
-	if noTranscripts && !scanFailed && snapshot.homeError == "" {
+	if noEntries && !scanFailed && snapshot.homeError == "" {
 		checks = append(checks, Check{
 			ID:     "sources.none",
 			Title:  "Agent sessions",
 			Status: StatusFail,
-			Detail: "No Claude Code or Codex sessions were found on this machine.",
-			Fix:    "Run claude or codex in a repo for one turn, then re-run these checks.",
+			Detail: "No supported agent sessions were found on this machine.",
+			Fix:    "Run a supported agent in a repo for one turn, then re-run these checks.",
 		})
 	}
 	storage := Check{ID: "storage", Title: "coSlash storage", Status: StatusOK, Detail: "Writable at " + snapshot.Storage.Home}
@@ -91,27 +91,27 @@ func sourceCheck(source Source) Check {
 			check.Detail = "Could not locate the session root: " + source.Error
 			check.Fix = "Check that the home directory is available and readable."
 		} else {
-			check.Detail = fmt.Sprintf("Could not fully scan %s: %s", source.Root, source.Error)
+			check.Detail = fmt.Sprintf("Could not inspect %s: %s", source.Root, source.Error)
 			check.Fix = "Run ls -la " + source.Root + " and check ownership."
 		}
 	case source.State == SourceMissing:
 		check.Status = StatusWarn
-		check.Detail = "No " + source.Root + " directory; " + source.Label + " sessions will not appear."
+		check.Detail = "No session source at " + source.Root + "; " + source.Label + " sessions will not appear."
 		check.Fix = "Install " + source.Label + " and run it once in a repo, then re-run these checks."
 	case source.State == SourceEmpty:
 		check.Status = StatusWarn
 		check.Detail = source.Root + " exists, but no sessions have been recorded yet."
 		check.Fix = "Run " + source.CLI.Name + " in a repo for one turn, then re-run these checks."
-	case source.Transcripts > 0 && source.SessionFiles == 0:
+	case source.Entries > 0 && source.Sessions == 0:
 		check.Status = StatusFail
-		check.Detail = fmt.Sprintf("Found %d transcripts in %s, but no root session files.", source.Transcripts, source.Root)
-		check.Fix = "Check transcript formats and whether subagent transcripts still have their parent sessions."
+		check.Detail = fmt.Sprintf("Found %d source entries in %s, but no root sessions.", source.Entries, source.Root)
+		check.Fix = "Check source formats and whether child sessions still have their parent sessions."
 	case source.SkippedTotal > 0:
 		check.Status = StatusWarn
-		check.Detail = fmt.Sprintf("%d session files; skipped %d unreadable paths in %s.", source.SessionFiles, source.SkippedTotal, source.Root)
+		check.Detail = fmt.Sprintf("%d sessions; skipped %d unreadable entries in %s.", source.Sessions, source.SkippedTotal, source.Root)
 		check.Fix = "Run ls -la " + source.Root + " and check ownership."
 	default:
-		check.Detail = fmt.Sprintf("%d session files in %s", source.SessionFiles, source.Root)
+		check.Detail = fmt.Sprintf("%d sessions in %s", source.Sessions, source.Root)
 	}
 	return check
 }

--- a/collector/internal/diagnostics/snapshot.go
+++ b/collector/internal/diagnostics/snapshot.go
@@ -12,9 +12,6 @@ import (
 
 	"github.com/centauri-ai/coslash/collector/internal/collector"
 	"github.com/centauri-ai/coslash/collector/internal/settings"
-	"github.com/centauri-ai/coslash/collector/internal/vendors"
-	"github.com/centauri-ai/coslash/collector/internal/vendors/claude"
-	"github.com/centauri-ai/coslash/collector/internal/vendors/codex"
 )
 
 type Status string
@@ -70,8 +67,8 @@ type Source struct {
 	Label        string        `json:"label"`
 	Root         string        `json:"root"`
 	State        SourceState   `json:"state"`
-	Transcripts  int           `json:"transcripts"`
-	SessionFiles int           `json:"sessionFiles"`
+	Entries      int           `json:"entries"`
+	Sessions     int           `json:"sessions"`
 	Skipped      []SkippedPath `json:"skipped"`
 	SkippedTotal int           `json:"skippedTotal"`
 	Error        string        `json:"error"`
@@ -150,40 +147,37 @@ func collectSource(
 	includeVersion bool,
 ) Source {
 	source := Source{
-		Agent:   health.Agent,
-		Label:   sourceLabel(health.Agent),
-		Root:    displayPath(userHome, health.Root),
-		State:   SourceUnreadable,
-		Skipped: []SkippedPath{},
-		CLI:     CLI{Name: health.Agent},
+		Agent:        health.Agent,
+		Label:        sourceLabel(health.Agent),
+		Root:         displayPath(userHome, health.Root),
+		State:        SourceUnreadable,
+		Entries:      health.Entries,
+		Sessions:     health.Sessions,
+		Skipped:      []SkippedPath{},
+		SkippedTotal: health.SkippedTotal,
+		CLI:          CLI{Name: health.Agent},
 	}
-	if health.ScanErr != nil {
-		source.Error = displayError(userHome, health.ScanErr.Error())
-	} else if health.Scan != nil {
-		source.SkippedTotal = max(health.Scan.SkippedTotal, len(health.Scan.Skipped))
-		switch {
-		case health.Scan.RootMissing:
-			source.State = SourceMissing
-		case len(health.Scan.Files) == 0 && source.SkippedTotal > 0:
-			source.State = SourceUnreadable
-			source.Error = fmt.Sprintf("scan skipped %d unreadable paths", source.SkippedTotal)
-			if len(health.Scan.Skipped) > 0 {
-				source.Error += "; first failure: " + health.Scan.Skipped[0].Error
-			}
-			source.Error = displayError(userHome, source.Error)
-		case len(health.Scan.Files) == 0:
-			source.State = SourceEmpty
-		default:
-			source.State = SourceOK
+	switch {
+	case health.Err != nil:
+		source.Error = displayError(userHome, health.Err.Error())
+	case health.Missing:
+		source.State = SourceMissing
+	case health.Entries == 0 && health.SkippedTotal > 0:
+		source.Error = fmt.Sprintf("source skipped %d unreadable entries", health.SkippedTotal)
+		if len(health.Skipped) > 0 {
+			source.Error += "; first failure: " + health.Skipped[0].Error
 		}
-		source.Transcripts = len(health.Scan.Files)
-		source.SessionFiles = sessionFileCount(health.Agent, health.Scan.Files)
-		for _, skipped := range health.Scan.Skipped {
-			source.Skipped = append(source.Skipped, SkippedPath{
-				Path:  displayPath(userHome, skipped.Path),
-				Error: displayError(userHome, skipped.Error),
-			})
-		}
+		source.Error = displayError(userHome, source.Error)
+	case health.Entries == 0:
+		source.State = SourceEmpty
+	default:
+		source.State = SourceOK
+	}
+	for _, skipped := range health.Skipped {
+		source.Skipped = append(source.Skipped, SkippedPath{
+			Path:  displayPath(userHome, skipped.Path),
+			Error: displayError(userHome, skipped.Error),
+		})
 	}
 	if path, err := exec.LookPath(health.Agent); err == nil {
 		source.CLI.Found = true
@@ -193,23 +187,6 @@ func collectSource(
 		}
 	}
 	return source
-}
-
-func sessionFileCount(agent string, files []string) int {
-	count := 0
-	for _, file := range files {
-		switch agent {
-		case vendors.AgentClaude:
-			if claude.ParentIDFromPath(file) == "" {
-				count++
-			}
-		case vendors.AgentCodex:
-			if codex.SessionIDFromRollout(file) != "" {
-				count++
-			}
-		}
-	}
-	return count
 }
 
 func sourceLabel(agent string) string {

--- a/collector/internal/vendors/codex/discovery.go
+++ b/collector/internal/vendors/codex/discovery.go
@@ -34,6 +34,11 @@ func readHeader(path string) (string, string, bool) {
 	return id, row.Payload.ParentThreadID, true
 }
 
+func IsRootRollout(path string) bool {
+	_, parentID, ok := readHeader(path)
+	return ok && parentID == ""
+}
+
 // root/subagents: ~/.codex/sessions/<YYYY>/<MM>/<DD>/rollout-<timestamp>-<session-uuid>.jsonl
 func Root() (string, error) {
 	home, err := os.UserHomeDir()

--- a/collector/internal/vendors/codex/discovery.go
+++ b/collector/internal/vendors/codex/discovery.go
@@ -2,6 +2,7 @@ package codex
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -17,26 +18,32 @@ func SessionIDFromRollout(path string) string {
 	return rolloutID.FindString(filepath.Base(path))
 }
 
-func readHeader(path string) (string, string, bool) {
+func readHeader(path string) (string, string, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return "", "", false
+		return "", "", err
 	}
 	defer file.Close()
 	var row codexRow
 	if err := json.NewDecoder(file).Decode(&row); err != nil {
-		return "", "", false
+		return "", "", err
 	}
 	id := SessionIDFromRollout(path)
-	if row.Type != "session_meta" || id == "" || row.Payload.ID != id {
-		return "", "", false
+	if row.Type != "session_meta" {
+		return "", "", fmt.Errorf("first row type %q is not session_meta", row.Type)
 	}
-	return id, row.Payload.ParentThreadID, true
+	if id == "" {
+		return "", "", fmt.Errorf("rollout filename has no session ID")
+	}
+	if row.Payload.ID != id {
+		return "", "", fmt.Errorf("header session ID %q does not match filename ID %q", row.Payload.ID, id)
+	}
+	return id, row.Payload.ParentThreadID, nil
 }
 
-func IsRootRollout(path string) bool {
-	_, parentID, ok := readHeader(path)
-	return ok && parentID == ""
+func IsRootRollout(path string) (bool, error) {
+	_, parentID, err := readHeader(path)
+	return err == nil && parentID == "", err
 }
 
 // root/subagents: ~/.codex/sessions/<YYYY>/<MM>/<DD>/rollout-<timestamp>-<session-uuid>.jsonl
@@ -63,8 +70,8 @@ func FilesSince(files []string, live map[string]string, since int64) []string {
 	selected := map[string]struct{}{}
 	queue := []string{}
 	for _, file := range files {
-		id, parentID, ok := readHeader(file)
-		if !ok {
+		id, parentID, err := readHeader(file)
+		if err != nil {
 			selected[file] = struct{}{}
 			continue
 		}

--- a/collector/internal/vendors/discovery.go
+++ b/collector/internal/vendors/discovery.go
@@ -22,6 +22,13 @@ type SourceScan struct {
 	RootMissing  bool
 }
 
+func (scan *SourceScan) RecordSkipped(path string, err error) {
+	scan.SkippedTotal++
+	if len(scan.Skipped) < maxRecordedSkippedPaths {
+		scan.Skipped = append(scan.Skipped, SkippedPath{Path: path, Error: err.Error()})
+	}
+}
+
 func Scan(root string) (*SourceScan, error) {
 	scan := &SourceScan{Files: []string{}, Skipped: []SkippedPath{}}
 	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
@@ -33,10 +40,7 @@ func Scan(root string) (*SourceScan, error) {
 				}
 				return err
 			}
-			scan.SkippedTotal++
-			if len(scan.Skipped) < maxRecordedSkippedPaths {
-				scan.Skipped = append(scan.Skipped, SkippedPath{Path: path, Error: err.Error()})
-			}
+			scan.RecordSkipped(path, err)
 			return nil
 		}
 		if entry.Type().IsRegular() && strings.HasSuffix(entry.Name(), ".jsonl") {

--- a/frontend/src/pages/coslash/components/DiagnosticsDialog.tsx
+++ b/frontend/src/pages/coslash/components/DiagnosticsDialog.tsx
@@ -73,7 +73,7 @@ export function DiagnosticsDialog({
                 </div>
                 {diagnostics.sources.map((source) => (
                   <div key={source.agent}>
-                    {source.label}: {source.sessionFiles} session files in <code>{source.root}</code>
+                    {source.label}: {source.sessions} sessions in <code>{source.root}</code>
                     <br />
                     CLI: {source.cli.found ? source.cli.version || source.cli.path : 'not found'}
                   </div>

--- a/frontend/src/pages/coslash/lib/diagnostics.test.ts
+++ b/frontend/src/pages/coslash/lib/diagnostics.test.ts
@@ -27,8 +27,8 @@ function snapshot(): Diagnostics {
         label: 'Claude Code',
         root: '~/.claude/projects',
         state: 'ok',
-        transcripts: 4,
-        sessionFiles: 3,
+        entries: 4,
+        sessions: 3,
         skipped: [],
         skippedTotal: 0,
         error: '',
@@ -39,8 +39,8 @@ function snapshot(): Diagnostics {
         label: 'Codex',
         root: '~/.codex/sessions',
         state: 'missing',
-        transcripts: 0,
-        sessionFiles: 0,
+        entries: 0,
+        sessions: 0,
         skipped: [],
         skippedTotal: 0,
         error: '',
@@ -70,7 +70,7 @@ describe('diagnostics helpers', () => {
     ];
     const output = formatDiagnosticsForCopy(value);
     expect(output).toContain('~/.claude/projects');
-    expect(output).toContain('transcripts=4; session files=3');
+    expect(output).toContain('entries=4; sessions=3');
     expect(output).not.toContain('-Users-alice-private-repo');
     expect(output).not.toContain('/Users/alice');
     expect(output).not.toContain('secret session name');

--- a/frontend/src/pages/coslash/lib/diagnostics.ts
+++ b/frontend/src/pages/coslash/lib/diagnostics.ts
@@ -14,8 +14,8 @@ export type DiagnosticSource = {
   label: string;
   root: string;
   state: DiagnosticSourceState;
-  transcripts: number;
-  sessionFiles: number;
+  entries: number;
+  sessions: number;
   skipped: { path: string; error: string }[];
   skippedTotal: number;
   error: string;
@@ -53,7 +53,7 @@ export function formatDiagnosticsForCopy(snapshot: Diagnostics): string {
   ];
   for (const source of snapshot.sources) {
     lines.push(
-      `- ${source.label}: ${source.state}; root=${source.root}; transcripts=${source.transcripts}; session files=${source.sessionFiles}; skipped=${source.skippedTotal}`,
+      `- ${source.label}: ${source.state}; root=${source.root}; entries=${source.entries}; sessions=${source.sessions}; skipped=${source.skippedTotal}`,
       `  CLI: found=${source.cli.found}; path=${source.cli.path || 'unknown'}; version=${source.cli.version || 'unknown'}`,
     );
     for (const skipped of source.skipped) lines.push(`  Skipped: ${skipped.error}`);


### PR DESCRIPTION
## Context

follow up to https://github.com/centauri-ai/coslash/pull/50

Diagnostics currently inspect transcript files and derive vendor-specific session counts. This refactor moves source-specific health reporting behind vendor adapters so file- and database-backed sources can use the same diagnostics contract.

## Changes

- Report normalized source entries, root sessions, missing state, skipped entries, and errors without exposing file scans to diagnostics.
- Update diagnostic checks, CLI output, and the diagnostics dialog to use source-neutral counts and wording.
- Count only root Codex rollouts as sessions.

## Test

- `make test` - passed
- `make check` - passed
- `npm test` - passed
- `npm run lint` - passed
- `npm run format:check` - passed
- `npm run build` - passed
- Manual: `go run ./cmd/coslash doctor` reported source entries and root sessions for Claude and Codex.

### Screenshots

- [x] Diagnostics dialog - source facts show session counts without file-specific wording
<img width="617" height="560" alt="Screenshot 2026-08-11 at 09 31 55" src="https://github.com/user-attachments/assets/23adc550-bd29-4b4f-9066-c3c3b6613fcf" />
