### PR TITLE
Use actual tags and group generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,55 @@
+changelog:
+  categories:
+    - title: Features and improvements
+      labels:
+        - enhancement
+      exclude:
+        labels:
+          - bug
+
+    - title: Bug fixes
+      labels:
+        - bug
+
+    - title: Documentation
+      labels:
+        - documentation
+      exclude:
+        labels:
+          - enhancement
+          - bug
+
+    - title: Refactoring
+      labels:
+        - refactor
+      exclude:
+        labels:
+          - enhancement
+          - bug
+          - documentation
+
+    - title: Tooling and CI
+      labels:
+        - devtools
+        - github_actions
+      exclude:
+        labels:
+          - enhancement
+          - bug
+          - documentation
+          - refactor
+          - dependencies
+
+    - title: Dependencies
+      labels:
+        - dependencies
+      exclude:
+        labels:
+          - enhancement
+          - bug
+          - documentation
+          - refactor
+
+    - title: Other changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
           The `.tar.gz` assets below are for manual installs:
 
           ```sh
-          VERSION=v0.0.1
+          VERSION=__TAG__
           ARCH=arm64  # or amd64 on Intel
           ASSET="coslash_${VERSION}_darwin_${ARCH}.tar.gz"
           BASE_URL="https://github.com/centauri-ai/coslash/releases/download/${VERSION}"
@@ -151,6 +151,7 @@ jobs:
           unsigned and unnotarized, so macOS may warn about an archive downloaded
           through a browser; the Homebrew install above is not affected.
           NOTES
+          sed -i '' "s/__TAG__/$TAG/g" "$notes"
 
           if ! gh release view "$TAG" >/dev/null 2>&1; then
             create=(gh release create "$TAG" --draft


### PR DESCRIPTION
## Context

Generated release notes hard-code `v0.0.1` in the manual-install example, causing future release links to target the wrong assets. The generated changelog is also a flat list despite PRs having useful labels.

## Changes

- Substitute the validated release tag into the quoted install example while preserving its shell variables.
- Group generated PR entries into features, fixes, documentation, refactoring, tooling, dependencies, and other changes.

## Test

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/release.yml` — passed
- `yq '.' .github/release.yml` — passed
- Manual: published `v0.0.2-rc.1` and verified the release body contains `VERSION=v0.0.2-rc.1`.