### PR TITLE
Add OpenCode subagent support

### DIFF
--- a/collector/internal/collector/helpers.go
+++ b/collector/internal/collector/helpers.go
@@ -114,16 +114,18 @@ func subagentFrom(
 ) session.Subagent {
 	s := child.Session
 	subagent := session.Subagent{
-		ID:         s.ID,
-		Name:       cmp.Or(child.Name, s.ID),
-		Model:      s.Model,
-		Status:     subagentStatus(child, parent, metadata),
-		Task:       session.Truncate(deref(s.FirstPrompt), session.TruncateTextLimit),
-		Result:     session.Truncate(deref(s.Summary), session.TruncateTextLimit),
-		DurationMs: s.DurationMs,
-		ToolUses:   s.ToolUses,
-		Commands:   child.Commands,
-		Tokens:     s.Tokens,
+		ID:           s.ID,
+		Name:         cmp.Or(child.Name, s.ID),
+		Model:        s.Model,
+		Status:       subagentStatus(child, parent, metadata),
+		Task:         session.Truncate(deref(s.FirstPrompt), session.TruncateTextLimit),
+		Result:       session.Truncate(deref(s.Summary), session.TruncateTextLimit),
+		DurationMs:   s.DurationMs,
+		ToolUses:     s.ToolUses,
+		Commands:     child.Commands,
+		Tokens:       s.Tokens,
+		Cost:         s.Cost,
+		CostRecorded: s.CostRecorded,
 	}
 	if turn, ok := parent.SpawnTurns[child.SpawnKey]; ok {
 		subagent.SpawnedAtTurn = &turn

--- a/collector/internal/session/models.go
+++ b/collector/internal/session/models.go
@@ -120,6 +120,8 @@ func AttachCosts(s *Session) {
 		s.UnpricedModels = UnpricedModels(s.Tokens)
 	}
 	for index := range s.Subagents {
-		s.Subagents[index].Cost = EstimatedCost(s.Subagents[index].Tokens)
+		if !s.Subagents[index].CostRecorded {
+			s.Subagents[index].Cost = EstimatedCost(s.Subagents[index].Tokens)
+		}
 	}
 }

--- a/collector/internal/session/session.go
+++ b/collector/internal/session/session.go
@@ -35,6 +35,7 @@ type Subagent struct {
 	Commands      []SubagentCommand      `json:"commands"`
 	Tokens        map[string]ModelTokens `json:"tokens"`
 	Cost          float64                `json:"cost"`
+	CostRecorded  bool                   `json:"-"`
 }
 
 type Session struct {

--- a/collector/internal/vendors/opencode/source.go
+++ b/collector/internal/vendors/opencode/source.go
@@ -15,10 +15,48 @@ import (
 	"github.com/centauri-ai/coslash/collector/internal/vendors"
 )
 
-const activeRootsQuery = `
-SELECT id, directory, title, summary_files, summary_diffs, model, cost, time_updated
-FROM session
-WHERE parent_id IS NULL AND time_archived IS NULL`
+const activeFamiliesQuery = `
+WITH selected_roots AS (
+	SELECT root.id,
+		MAX(root.time_updated,
+			COALESCE(MAX(child.time_updated), root.time_updated),
+			COALESCE(MAX(child.time_archived), root.time_updated)) AS family_updated
+	FROM session AS root
+	LEFT JOIN session AS child ON child.parent_id = root.id
+	WHERE root.parent_id IS NULL AND root.time_archived IS NULL
+	GROUP BY root.id
+)
+SELECT member.id, member.parent_id, member.directory, member.title, member.summary_files,
+	member.summary_diffs, member.model, member.cost,
+	CASE WHEN member.id = selected_roots.id THEN selected_roots.family_updated ELSE member.time_updated END
+FROM selected_roots
+JOIN session AS member ON member.id = selected_roots.id OR member.parent_id = selected_roots.id
+WHERE member.time_archived IS NULL`
+
+const activeRootQuery = `
+SELECT root.id, root.parent_id, root.directory, root.title, root.summary_files,
+	root.summary_diffs, root.model, root.cost,
+	MAX(root.time_updated, COALESCE((
+		SELECT MAX(child.time_updated)
+		FROM session AS child
+		WHERE child.parent_id = root.id
+	), root.time_updated), COALESCE((
+		SELECT MAX(child.time_archived)
+		FROM session AS child
+		WHERE child.parent_id = root.id
+	), root.time_updated))
+FROM session AS root
+WHERE root.parent_id IS NULL AND root.time_archived IS NULL`
+
+type taskLink struct {
+	name   string
+	status string
+}
+
+type parsedSession struct {
+	transcript *vendors.ParsedTranscript
+	tasks      map[string]taskLink
+}
 
 func Collect(since int64) ([]*vendors.ParsedTranscript, *vendors.SessionMetadata, error) {
 	db, err := open()
@@ -30,13 +68,14 @@ func Collect(since int64) ([]*vendors.ParsedTranscript, *vendors.SessionMetadata
 	}
 	defer db.Close()
 
-	query := activeRootsQuery
+	query := activeFamiliesQuery
 	var args []any
 	if since > 0 {
-		query += " AND time_updated >= ?"
+		query += " AND selected_roots.family_updated >= ?"
 		args = append(args, since)
 	}
-	query += " ORDER BY time_updated DESC, id"
+	query += ` ORDER BY selected_roots.family_updated DESC,
+		member.parent_id IS NOT NULL, member.time_updated, member.id`
 	parsed, err := load(db, query, args...)
 	return parsed, emptyMetadata(), err
 }
@@ -54,7 +93,7 @@ func Get(id string) (*vendors.ParsedTranscript, error) {
 	}
 	defer db.Close()
 
-	parsed, err := load(db, activeRootsQuery+" AND id = ?", id)
+	parsed, err := load(db, activeRootQuery+" AND root.id = ?", id)
 	if err != nil || len(parsed) == 0 {
 		return nil, err
 	}
@@ -99,7 +138,7 @@ func load(db *sql.DB, query string, args ...any) ([]*vendors.ParsedTranscript, e
 	for rows.Next() {
 		var row storedSession
 		if err := rows.Scan(
-			&row.id, &row.directory, &row.title, &row.summaryFiles, &row.summaryDiffs,
+			&row.id, &row.parentID, &row.directory, &row.title, &row.summaryFiles, &row.summaryDiffs,
 			&row.model, &row.cost, &row.updatedAt,
 		); err != nil {
 			rows.Close()
@@ -115,7 +154,7 @@ func load(db *sql.DB, query string, args ...any) ([]*vendors.ParsedTranscript, e
 		return nil, err
 	}
 
-	parsed := make([]*vendors.ParsedTranscript, 0, len(stored))
+	parsed := make([]parsedSession, 0, len(stored))
 	for _, row := range stored {
 		item, err := parse(tx, row)
 		if err != nil {
@@ -123,37 +162,61 @@ func load(db *sql.DB, query string, args ...any) ([]*vendors.ParsedTranscript, e
 		}
 		parsed = append(parsed, item)
 	}
+	byID := make(map[string]*vendors.ParsedTranscript, len(parsed))
+	for _, item := range parsed {
+		byID[item.transcript.Session.ID] = item.transcript
+	}
+	for _, parent := range parsed {
+		for childID, task := range parent.tasks {
+			child, ok := byID[childID]
+			if !ok || child.ParentID != parent.transcript.Session.ID {
+				continue
+			}
+			child.SpawnKey = childID
+			child.Stopped = task.status == "error"
+			if task.name != "" {
+				child.Name = task.name
+			}
+		}
+	}
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
-	return parsed, nil
+	transcripts := make([]*vendors.ParsedTranscript, 0, len(parsed))
+	for _, item := range parsed {
+		transcripts = append(transcripts, item.transcript)
+	}
+	return transcripts, nil
 }
 
-func parse(tx *sql.Tx, row storedSession) (*vendors.ParsedTranscript, error) {
+func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 	modelID := ""
 	if row.model.Valid {
 		var model storedModel
 		if err := json.Unmarshal([]byte(row.model.String), &model); err != nil {
-			return nil, fmt.Errorf("decode model: %w", err)
+			return parsedSession{}, fmt.Errorf("decode model: %w", err)
 		}
 		modelID = modelName(model.ProviderID, model.ID)
 	}
 	messages, err := loadMessages(tx, row.id)
 	if err != nil {
-		return nil, err
+		return parsedSession{}, err
 	}
 	todos, err := loadTodos(tx, row.id)
 	if err != nil {
-		return nil, err
+		return parsedSession{}, err
 	}
 	summaryEdits, err := loadFileEdits(row.summaryDiffs)
 	if err != nil {
-		return nil, err
+		return parsedSession{}, err
 	}
 
 	tokens := map[string]session.ModelTokens{}
 	var digest session.DigestLog
 	var commands session.CommandLog
+	spawnTurns := map[string]int{}
+	completed := map[string]struct{}{}
+	tasks := map[string]taskLink{}
 	turns := 0
 	toolUses := 0
 	errorsCount := 0
@@ -240,8 +303,32 @@ func parse(tx *sql.Tx, row storedSession) (*vendors.ParsedTranscript, error) {
 				if part.State.Status == "error" {
 					errorsCount++
 				}
-				if part.State.Status == "pending" || part.State.Status == "running" {
+				if part.Tool != "task" &&
+					(part.State.Status == "pending" || part.State.Status == "running") {
 					busy = true
+				}
+				if part.Tool == "task" {
+					childID := part.State.Metadata.SessionID
+					parentID := part.State.Metadata.ParentSessionID
+					if childID != "" && (parentID == "" || parentID == row.id) {
+						link, exists := tasks[childID]
+						if !exists {
+							spawnTurns[childID] = max(turns, 1)
+							digest.PushSubagent(turns, childID)
+						}
+						if part.State.Input.Description != "" {
+							link.name = part.State.Input.Description
+						} else if link.name == "" {
+							link.name = part.State.Input.SubagentType
+						}
+						link.status = part.State.Status
+						tasks[childID] = link
+						if part.State.Status == "completed" {
+							completed[childID] = struct{}{}
+						} else {
+							delete(completed, childID)
+						}
+					}
 				}
 				isShell := part.Tool == "bash" || part.Tool == "shell"
 				if isShell && part.State.Status == "completed" && part.State.Input.Command != "" {
@@ -334,6 +421,12 @@ func parse(tx *sql.Tx, row storedSession) (*vendors.ParsedTranscript, error) {
 			digest.Push(turns, session.DigestRecap, text)
 		}
 	}
+	for _, task := range tasks {
+		if task.status == "pending" || task.status == "running" {
+			busy = true
+			break
+		}
+	}
 
 	details := session.SessionDetails{
 		Turns:          turns,
@@ -395,12 +488,17 @@ func parse(tx *sql.Tx, row storedSession) (*vendors.ParsedTranscript, error) {
 		value := session.Truncate(summary, session.TruncateTextLimit)
 		result.Summary = &value
 	}
-	return &vendors.ParsedTranscript{
-		Session:    result,
-		Name:       row.title,
-		SpawnTurns: map[string]int{},
-		Completed:  map[string]struct{}{},
-		Commands:   []session.SubagentCommand{},
+	return parsedSession{
+		transcript: &vendors.ParsedTranscript{
+			Session:    result,
+			ParentID:   row.parentID.String,
+			Name:       row.title,
+			InTurn:     busy,
+			SpawnTurns: spawnTurns,
+			Completed:  completed,
+			Commands:   commands.Labelled(),
+		},
+		tasks: tasks,
 	}, nil
 }
 

--- a/collector/internal/vendors/opencode/types.go
+++ b/collector/internal/vendors/opencode/types.go
@@ -13,6 +13,7 @@ type SourceHealth struct {
 
 type storedSession struct {
 	id           string
+	parentID     sql.NullString
 	directory    string
 	title        string
 	summaryFiles sql.NullInt64
@@ -57,22 +58,26 @@ type storedPart struct {
 		Status string `json:"status"`
 		Title  string `json:"title"`
 		Input  struct {
-			Command   string           `json:"command"`
-			FilePath  string           `json:"filePath"`
-			Content   string           `json:"content"`
-			Questions []storedQuestion `json:"questions"`
-			Todos     []struct {
+			Command      string           `json:"command"`
+			FilePath     string           `json:"filePath"`
+			Content      string           `json:"content"`
+			Description  string           `json:"description"`
+			SubagentType string           `json:"subagent_type"`
+			Questions    []storedQuestion `json:"questions"`
+			Todos        []struct {
 				Content string `json:"content"`
 				Status  string `json:"status"`
 			} `json:"todos"`
 		} `json:"input"`
 		Metadata struct {
-			Answers  [][]string       `json:"answers"`
-			Exists   *bool            `json:"exists"`
-			Exit     *int             `json:"exit"`
-			FileDiff storedToolFile   `json:"filediff"`
-			FilePath string           `json:"filepath"`
-			Files    []storedToolFile `json:"files"`
+			Answers         [][]string       `json:"answers"`
+			Exists          *bool            `json:"exists"`
+			Exit            *int             `json:"exit"`
+			FileDiff        storedToolFile   `json:"filediff"`
+			FilePath        string           `json:"filepath"`
+			Files           []storedToolFile `json:"files"`
+			SessionID       string           `json:"sessionId"`
+			ParentSessionID string           `json:"parentSessionId"`
 		} `json:"metadata"`
 		Time struct {
 			End *int64 `json:"end"`


### PR DESCRIPTION
## Context

OpenCode stores delegated tasks as child sessions in its SQLite database. Root-session support currently omits this delegated work from dashboard cards and the session inspector. This adds direct child-session parity with the existing vendors.

## Changes

- Load non-archived direct child sessions and retain roots when child activity is newer.
- Link task metadata to child names, results, models, durations, commands, tokens, exact costs, and digest entries.
- Normalize running, returned, and aborted states while deduplicating repeated task links.

## Test

- `make test` - passed
- `make check` - passed
- `npm test` - passed
- `./node_modules/.bin/oxlint` - passed with two existing warnings
- `npm run format:check` - passed
- `npm run build` - passed
- `CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build ./...` - passed
- `CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build ./...` - passed
- Manual: Loaded an active OpenCode database and verified linked child sessions, digest entries, and normalized statuses.

### Screenshots

- [x] Dashboard - OpenCode root card with its subagent rail
<img width="1106" height="456" alt="Screenshot 2026-08-11 at 15 31 25" src="https://github.com/user-attachments/assets/5f1cfc68-fc2a-4bc6-b397-dc4b37d69900" />

- [x] Session inspector - linked subagent digest row and detail dialog
<img width="1378" height="980" alt="Screenshot 2026-08-11 at 15 31 41" src="https://github.com/user-attachments/assets/10ac344b-4f95-44e5-a482-04589fa92e91" />
