### PR TITLE
Improve OpenCode session accuracy and live status

### DIFF
--- a/collector/internal/collector/collector.go
+++ b/collector/internal/collector/collector.go
@@ -212,9 +212,8 @@ func unresolvedSpawn(entry session.DigestEntry) bool {
 }
 
 func probeEnvironment(roots []*vendors.ParsedTranscript) {
-	// Drift is measured for the session's recorded branch against the repo's
-	// base branch, so it memoizes per (cwd, branch); the repo name is a pure
-	// filesystem lookup, per cwd.
+	// Drift is measured for the recorded or best-effort current branch against
+	// the repo's base branch, so it memoizes per (cwd, branch).
 	type driftKey struct{ cwd, branch string }
 	type driftSlot struct{ drift *session.GitDrift }
 	type repository struct {
@@ -222,6 +221,7 @@ func probeEnvironment(roots []*vendors.ParsedTranscript) {
 		localOnly bool
 	}
 	repoByCwd := map[string]repository{}
+	branchByCwd := map[string]*string{}
 	drifts := map[driftKey]*driftSlot{}
 	for _, p := range roots {
 		s := p.Session
@@ -229,11 +229,26 @@ func probeEnvironment(roots []*vendors.ParsedTranscript) {
 			continue
 		}
 		repoByCwd[s.WorkingDirectory] = repository{}
-		drifts[driftKey{s.WorkingDirectory, deref(s.Branch)}] = &driftSlot{}
+		if deref(s.Branch) == "" {
+			branchByCwd[s.WorkingDirectory] = nil
+		}
 	}
 	for cwd := range repoByCwd {
 		name, localOnly := session.CanonicalRepositoryName(cwd)
 		repoByCwd[cwd] = repository{name: name, localOnly: localOnly}
+		if _, missing := branchByCwd[cwd]; missing {
+			branchByCwd[cwd] = session.CurrentBranch(cwd)
+		}
+	}
+	for _, p := range roots {
+		s := p.Session
+		if s.WorkingDirectory == "" {
+			continue
+		}
+		if deref(s.Branch) == "" {
+			s.Branch = branchByCwd[s.WorkingDirectory]
+		}
+		drifts[driftKey{s.WorkingDirectory, deref(s.Branch)}] = &driftSlot{}
 	}
 	// BranchDrift waits on git subprocesses, so distinct keys probe
 	// concurrently. Results land through slot pointers — never map writes,

--- a/collector/internal/collector/helpers.go
+++ b/collector/internal/collector/helpers.go
@@ -157,6 +157,9 @@ func subagentStatus(
 	if child.Stopped {
 		return session.SubagentAborted
 	}
+	if child.Session.Agent == vendors.AgentOpenCode && child.InTurn {
+		return session.SubagentRunning
+	}
 	if _, ok := parent.Completed[child.SpawnKey]; ok {
 		return session.SubagentReturned
 	}

--- a/collector/internal/session/probes.go
+++ b/collector/internal/session/probes.go
@@ -123,6 +123,18 @@ func repositoryRoot(cwd string) string {
 	}
 }
 
+func CurrentBranch(cwd string) *string {
+	out, err := exec.Command("git", "-C", cwd, "symbolic-ref", "--quiet", "--short", "HEAD").Output()
+	if err != nil {
+		return nil
+	}
+	branch := strings.TrimSpace(string(out))
+	if branch == "" {
+		return nil
+	}
+	return &branch
+}
+
 func BranchDrift(cwd string, recordedBranch *string) *GitDrift {
 	if cwd == "" || recordedBranch == nil {
 		return nil

--- a/collector/internal/vendors/opencode/metadata.go
+++ b/collector/internal/vendors/opencode/metadata.go
@@ -1,0 +1,51 @@
+package opencode
+
+import (
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/centauri-ai/coslash/collector/internal/vendors"
+)
+
+var sessionIDPattern = regexp.MustCompile(`^ses_[0-9A-Za-z]+$`)
+
+func loadMetadata() *vendors.SessionMetadata {
+	metadata := emptyMetadata()
+	output, err := exec.Command("ps", "-ww", "-axo", "command=").Output()
+	if err != nil {
+		return metadata
+	}
+	for id := range liveSessionIDs(string(output)) {
+		metadata.Live[id] = "interactive"
+	}
+	return metadata
+}
+
+func liveSessionIDs(processes string) map[string]struct{} {
+	live := map[string]struct{}{}
+	for line := range strings.SplitSeq(processes, "\n") {
+		args := strings.Fields(line)
+		if len(args) == 0 || filepath.Base(args[0]) != "opencode" {
+			continue
+		}
+		for index, argument := range args[1:] {
+			var id string
+			switch {
+			case argument == "-s" || argument == "--session":
+				if index+2 < len(args) {
+					id = args[index+2]
+				}
+			case strings.HasPrefix(argument, "-s="):
+				id = strings.TrimPrefix(argument, "-s=")
+			case strings.HasPrefix(argument, "--session="):
+				id = strings.TrimPrefix(argument, "--session=")
+			}
+			if sessionIDPattern.MatchString(id) {
+				live[id] = struct{}{}
+			}
+		}
+	}
+	return live
+}

--- a/collector/internal/vendors/opencode/metadata.go
+++ b/collector/internal/vendors/opencode/metadata.go
@@ -1,51 +1,289 @@
 package opencode
 
 import (
+	"database/sql"
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/centauri-ai/coslash/collector/internal/vendors"
 )
 
+const (
+	newSessionWindow     = time.Minute
+	resumedSessionWindow = 3 * time.Minute
+)
+
 var sessionIDPattern = regexp.MustCompile(`^ses_[0-9A-Za-z]+$`)
 
-func loadMetadata() *vendors.SessionMetadata {
+var nonTUICommands = map[string]struct{}{
+	"acp": {}, "agent": {}, "attach": {}, "auth": {}, "completion": {}, "db": {},
+	"debug": {}, "export": {}, "github": {}, "import": {}, "mcp": {}, "models": {},
+	"plugin": {}, "pr": {}, "providers": {}, "run": {}, "serve": {}, "session": {},
+	"stats": {}, "uninstall": {}, "upgrade": {}, "web": {},
+}
+
+var valueFlags = map[string]struct{}{
+	"--agent": {}, "--cors": {}, "--hostname": {}, "--log-level": {}, "--mdns-domain": {},
+	"--model": {}, "--port": {}, "--prompt": {}, "--replay-limit": {}, "--session": {},
+	"-m": {}, "-s": {},
+}
+
+type tuiProcess struct {
+	pid       int
+	startedAt int64
+	directory string
+	project   string
+	sessionID string
+	fork      bool
+}
+
+type liveCandidate struct {
+	id           string
+	directory    string
+	createdAt    int64
+	userMessages []int64
+}
+
+func loadMetadata(db *sql.DB) *vendors.SessionMetadata {
 	metadata := emptyMetadata()
-	output, err := exec.Command("ps", "-ww", "-axo", "command=").Output()
+	output, err := exec.Command("ps", "-ww", "-axo", "pid=,lstart=,command=").Output()
 	if err != nil {
 		return metadata
 	}
-	for id := range liveSessionIDs(string(output)) {
+	processes := parseTUIProcesses(string(output))
+	for index := range processes {
+		cwd := processWorkingDirectory(processes[index].pid)
+		if cwd == "" {
+			continue
+		}
+		if project := processes[index].project; project != "" {
+			if filepath.IsAbs(project) {
+				cwd = project
+			} else {
+				cwd = filepath.Join(cwd, project)
+			}
+		}
+		processes[index].directory = filepath.Clean(cwd)
+	}
+	candidates, err := loadLiveCandidates(db)
+	if err != nil {
+		return metadata
+	}
+	for id := range matchLiveSessions(processes, candidates) {
 		metadata.Live[id] = "interactive"
 	}
 	return metadata
 }
 
-func liveSessionIDs(processes string) map[string]struct{} {
-	live := map[string]struct{}{}
-	for line := range strings.SplitSeq(processes, "\n") {
-		args := strings.Fields(line)
-		if len(args) == 0 || filepath.Base(args[0]) != "opencode" {
+func parseTUIProcesses(output string) []tuiProcess {
+	var processes []tuiProcess
+	for line := range strings.SplitSeq(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 7 || filepath.Base(fields[6]) != "opencode" {
 			continue
 		}
-		for index, argument := range args[1:] {
-			var id string
-			switch {
-			case argument == "-s" || argument == "--session":
-				if index+2 < len(args) {
-					id = args[index+2]
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil {
+			continue
+		}
+		started, err := time.ParseInLocation(
+			"Mon Jan 2 15:04:05 2006",
+			strings.Join(fields[1:6], " "),
+			time.Local,
+		)
+		if err != nil {
+			continue
+		}
+		project, sessionID, fork, tui := parseTUIArgs(fields[7:])
+		if !tui {
+			continue
+		}
+		processes = append(processes, tuiProcess{
+			pid: pid, startedAt: started.UnixMilli(), project: project,
+			sessionID: sessionID, fork: fork,
+		})
+	}
+	return processes
+}
+
+func parseTUIArgs(args []string) (project, sessionID string, fork, tui bool) {
+	tui = true
+	for index := 0; index < len(args); index++ {
+		argument := args[index]
+		switch {
+		case argument == "-h" || argument == "--help" || argument == "-v" || argument == "--version":
+			tui = false
+		case argument == "--fork":
+			fork = true
+		case argument == "-s" || argument == "--session":
+			if index+1 < len(args) {
+				index++
+				if sessionIDPattern.MatchString(args[index]) {
+					sessionID = args[index]
 				}
-			case strings.HasPrefix(argument, "-s="):
-				id = strings.TrimPrefix(argument, "-s=")
-			case strings.HasPrefix(argument, "--session="):
-				id = strings.TrimPrefix(argument, "--session=")
 			}
+		case strings.HasPrefix(argument, "-s="):
+			id := strings.TrimPrefix(argument, "-s=")
 			if sessionIDPattern.MatchString(id) {
-				live[id] = struct{}{}
+				sessionID = id
+			}
+		case strings.HasPrefix(argument, "--session="):
+			id := strings.TrimPrefix(argument, "--session=")
+			if sessionIDPattern.MatchString(id) {
+				sessionID = id
+			}
+		case strings.Contains(argument, "=") || strings.HasPrefix(argument, "-"):
+			if _, takesValue := valueFlags[argument]; takesValue && index+1 < len(args) {
+				index++
+			}
+		default:
+			if project == "" {
+				project = argument
 			}
 		}
 	}
+	if _, excluded := nonTUICommands[project]; excluded {
+		project = ""
+		tui = false
+	}
+	return
+}
+
+func processWorkingDirectory(pid int) string {
+	output, err := exec.Command(
+		"lsof", "-a", "-p", strconv.Itoa(pid), "-d", "cwd", "-Fn",
+	).Output()
+	if err != nil {
+		return ""
+	}
+	for line := range strings.SplitSeq(string(output), "\n") {
+		if strings.HasPrefix(line, "n") {
+			return strings.TrimPrefix(line, "n")
+		}
+	}
+	return ""
+}
+
+func loadLiveCandidates(db *sql.DB) ([]liveCandidate, error) {
+	rows, err := db.Query(`
+		SELECT session.id, session.directory, session.time_created, message.time_created
+		FROM session
+		LEFT JOIN message ON message.session_id = session.id
+			AND json_extract(message.data, '$.role') = 'user'
+		WHERE session.parent_id IS NULL AND session.time_archived IS NULL
+		ORDER BY session.id, message.time_created
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var candidates []liveCandidate
+	for rows.Next() {
+		var id, directory string
+		var createdAt int64
+		var messageAt sql.NullInt64
+		if err := rows.Scan(&id, &directory, &createdAt, &messageAt); err != nil {
+			return nil, err
+		}
+		if len(candidates) == 0 || candidates[len(candidates)-1].id != id {
+			candidates = append(candidates, liveCandidate{
+				id: id, directory: filepath.Clean(directory), createdAt: createdAt,
+			})
+		}
+		if messageAt.Valid {
+			last := len(candidates) - 1
+			candidates[last].userMessages = append(candidates[last].userMessages, messageAt.Int64)
+		}
+	}
+	return candidates, rows.Err()
+}
+
+func matchLiveSessions(processes []tuiProcess, candidates []liveCandidate) map[string]struct{} {
+	// OpenCode does not expose in-TUI session switches, so this only infers the
+	// launch or first activity and leaves ambiguous process/session pairs inactive.
+	live := map[string]struct{}{}
+	matchedProcesses := map[int]bool{}
+	matchedSessions := map[string]bool{}
+	byID := make(map[string]liveCandidate, len(candidates))
+	for _, candidate := range candidates {
+		byID[candidate.id] = candidate
+	}
+	for index, process := range processes {
+		if process.fork || process.sessionID == "" {
+			continue
+		}
+		if _, exists := byID[process.sessionID]; !exists {
+			continue
+		}
+		live[process.sessionID] = struct{}{}
+		matchedProcesses[index] = true
+		matchedSessions[process.sessionID] = true
+	}
+
+	matchUnique(processes, candidates, matchedProcesses, matchedSessions, func(
+		process tuiProcess, candidate liveCandidate,
+	) bool {
+		delta := candidate.createdAt - process.startedAt
+		return delta >= -time.Second.Milliseconds() && delta <= newSessionWindow.Milliseconds()
+	})
+	matchUnique(processes, candidates, matchedProcesses, matchedSessions, func(
+		process tuiProcess, candidate liveCandidate,
+	) bool {
+		if candidate.createdAt >= process.startedAt {
+			return false
+		}
+		for _, messageAt := range candidate.userMessages {
+			delta := messageAt - process.startedAt
+			if delta >= 0 && delta <= resumedSessionWindow.Milliseconds() {
+				return true
+			}
+		}
+		return false
+	})
+	for id := range matchedSessions {
+		live[id] = struct{}{}
+	}
 	return live
+}
+
+func matchUnique(
+	processes []tuiProcess,
+	candidates []liveCandidate,
+	matchedProcesses map[int]bool,
+	matchedSessions map[string]bool,
+	matches func(tuiProcess, liveCandidate) bool,
+) {
+	type edge struct {
+		process int
+		session string
+	}
+	var edges []edge
+	processDegrees := map[int]int{}
+	sessionDegrees := map[string]int{}
+	for processIndex, process := range processes {
+		if matchedProcesses[processIndex] || process.directory == "" {
+			continue
+		}
+		for _, candidate := range candidates {
+			if matchedSessions[candidate.id] || process.directory != candidate.directory ||
+				!matches(process, candidate) {
+				continue
+			}
+			edges = append(edges, edge{process: processIndex, session: candidate.id})
+			processDegrees[processIndex]++
+			sessionDegrees[candidate.id]++
+		}
+	}
+	for _, edge := range edges {
+		if processDegrees[edge.process] != 1 || sessionDegrees[edge.session] != 1 {
+			continue
+		}
+		matchedProcesses[edge.process] = true
+		matchedSessions[edge.session] = true
+	}
 }

--- a/collector/internal/vendors/opencode/source.go
+++ b/collector/internal/vendors/opencode/source.go
@@ -231,6 +231,7 @@ func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 	commits := []string{}
 	pullRequests := 0
 	fileEdits := session.NewFileEditSet()
+	patchEdits := session.NewFileEditSet()
 	var lastEditAt *int64
 	todoStatus := map[string]string{}
 	for _, message := range messages {
@@ -297,6 +298,21 @@ func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 			case "text":
 				if text := strings.TrimSpace(part.Text); text != "" {
 					texts = append(texts, text)
+				}
+			case "patch":
+				patched := false
+				for _, path := range part.Files {
+					if strings.TrimSpace(path) == "" {
+						continue
+					}
+					path = normalizeFilePath(row.directory, path)
+					patchEdits.Add(path, 0, 0, false)
+					patched = true
+				}
+				if patched && part.updatedAt > 0 &&
+					(lastEditAt == nil || part.updatedAt > *lastEditAt) {
+					updatedAt := part.updatedAt
+					lastEditAt = &updatedAt
 				}
 			case "tool":
 				toolUses++
@@ -427,6 +443,30 @@ func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 			break
 		}
 	}
+	seenFiles := make(map[string]struct{}, len(fileEdits.Edits)+len(summaryEdits)+len(patchEdits.Edits))
+	for _, edit := range fileEdits.Edits {
+		seenFiles[edit.Path] = struct{}{}
+	}
+	for _, edit := range summaryEdits {
+		edit.Path = normalizeFilePath(row.directory, edit.Path)
+		if edit.Path == "" {
+			continue
+		}
+		if _, exists := seenFiles[edit.Path]; exists {
+			continue
+		}
+		fileEdits.Add(edit.Path, edit.Additions, edit.Deletions, edit.IsNew)
+		seenFiles[edit.Path] = struct{}{}
+	}
+	for _, edit := range patchEdits.Edits {
+		if _, exists := seenFiles[edit.Path]; exists {
+			continue
+		}
+		for range edit.Edits {
+			fileEdits.Add(edit.Path, 0, 0, false)
+		}
+		seenFiles[edit.Path] = struct{}{}
+	}
 
 	details := session.SessionDetails{
 		Turns:          turns,
@@ -454,12 +494,6 @@ func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 		details.ContextTokens = &contextTokens
 	}
 
-	if len(fileEdits.Edits) == 0 {
-		for index := range summaryEdits {
-			summaryEdits[index].Path = normalizeFilePath(row.directory, summaryEdits[index].Path)
-		}
-		details.FileEdits = summaryEdits
-	}
 	editedFileCount := len(details.FileEdits)
 	if editedFileCount == 0 && row.summaryFiles.Valid {
 		editedFileCount = int(row.summaryFiles.Int64)
@@ -523,7 +557,7 @@ func normalizeFilePath(cwd, path string) string {
 
 func loadMessages(tx *sql.Tx, sessionID string) ([]storedMessage, error) {
 	rows, err := tx.Query(`
-		SELECT message.id, message.data, part.data
+		SELECT message.id, message.data, part.data, part.time_updated
 		FROM message
 		LEFT JOIN part ON part.message_id = message.id
 		WHERE message.session_id = ?
@@ -540,7 +574,8 @@ func loadMessages(tx *sql.Tx, sessionID string) ([]storedMessage, error) {
 		var id string
 		var messageJSON string
 		var partJSON sql.NullString
-		if err := rows.Scan(&id, &messageJSON, &partJSON); err != nil {
+		var partUpdatedAt sql.NullInt64
+		if err := rows.Scan(&id, &messageJSON, &partJSON, &partUpdatedAt); err != nil {
 			return nil, fmt.Errorf("read message: %w", err)
 		}
 		if id != lastID {
@@ -556,6 +591,7 @@ func loadMessages(tx *sql.Tx, sessionID string) ([]storedMessage, error) {
 			if err := json.Unmarshal([]byte(partJSON.String), &part); err != nil {
 				return nil, fmt.Errorf("decode part for message %q: %w", id, err)
 			}
+			part.updatedAt = partUpdatedAt.Int64
 			messages[len(messages)-1].parts = append(messages[len(messages)-1].parts, part)
 		}
 	}

--- a/collector/internal/vendors/opencode/source.go
+++ b/collector/internal/vendors/opencode/source.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -58,6 +59,13 @@ type parsedSession struct {
 	tasks      map[string]taskLink
 }
 
+type skippedFamily struct {
+	id  string
+	err error
+}
+
+var errMalformedSession = errors.New("malformed OpenCode session data")
+
 func Collect(since int64) ([]*vendors.ParsedTranscript, *vendors.SessionMetadata, error) {
 	db, err := open()
 	if errors.Is(err, os.ErrNotExist) {
@@ -76,7 +84,10 @@ func Collect(since int64) ([]*vendors.ParsedTranscript, *vendors.SessionMetadata
 	}
 	query += ` ORDER BY selected_roots.family_updated DESC,
 		member.parent_id IS NOT NULL, member.time_updated, member.id`
-	parsed, err := load(db, query, args...)
+	parsed, skipped, err := load(db, query, args...)
+	for _, family := range skipped {
+		log.Printf("OpenCode session family %q: %v; skipping", family.id, family.err)
+	}
 	return parsed, emptyMetadata(), err
 }
 
@@ -93,8 +104,11 @@ func Get(id string) (*vendors.ParsedTranscript, error) {
 	}
 	defer db.Close()
 
-	parsed, err := load(db, activeRootQuery+" AND root.id = ?", id)
+	parsed, skipped, err := load(db, activeRootQuery+" AND root.id = ?", id)
 	if err != nil || len(parsed) == 0 {
+		if len(skipped) > 0 {
+			return nil, fmt.Errorf("parse OpenCode session family %q: %w", skipped[0].id, skipped[0].err)
+		}
 		return nil, err
 	}
 	return parsed[0], nil
@@ -123,16 +137,16 @@ func emptyMetadata() *vendors.SessionMetadata {
 	return &vendors.SessionMetadata{Names: map[string]string{}, Live: map[string]string{}}
 }
 
-func load(db *sql.DB, query string, args ...any) ([]*vendors.ParsedTranscript, error) {
+func load(db *sql.DB, query string, args ...any) ([]*vendors.ParsedTranscript, []skippedFamily, error) {
 	tx, err := db.BeginTx(context.Background(), &sql.TxOptions{ReadOnly: true})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer tx.Rollback()
 
 	rows, err := tx.Query(query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("query OpenCode sessions: %w", err)
+		return nil, nil, fmt.Errorf("query OpenCode sessions: %w", err)
 	}
 	stored := []storedSession{}
 	for rows.Next() {
@@ -142,25 +156,47 @@ func load(db *sql.DB, query string, args ...any) ([]*vendors.ParsedTranscript, e
 			&row.model, &row.cost, &row.updatedAt,
 		); err != nil {
 			rows.Close()
-			return nil, fmt.Errorf("read OpenCode session: %w", err)
+			return nil, nil, fmt.Errorf("read OpenCode session: %w", err)
 		}
 		stored = append(stored, row)
 	}
 	if err := rows.Err(); err != nil {
 		rows.Close()
-		return nil, fmt.Errorf("read OpenCode sessions: %w", err)
+		return nil, nil, fmt.Errorf("read OpenCode sessions: %w", err)
 	}
 	if err := rows.Close(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	parsed := make([]parsedSession, 0, len(stored))
+	families := map[string][]storedSession{}
+	familyIDs := []string{}
 	for _, row := range stored {
-		item, err := parse(tx, row)
-		if err != nil {
-			return nil, fmt.Errorf("parse OpenCode session %q: %w", row.id, err)
+		familyID := row.id
+		if row.parentID.Valid {
+			familyID = row.parentID.String
 		}
-		parsed = append(parsed, item)
+		if _, exists := families[familyID]; !exists {
+			familyIDs = append(familyIDs, familyID)
+		}
+		families[familyID] = append(families[familyID], row)
+	}
+	parsed := make([]parsedSession, 0, len(stored))
+	skipped := []skippedFamily{}
+	for _, familyID := range familyIDs {
+		family := make([]parsedSession, 0, len(families[familyID]))
+		for _, row := range families[familyID] {
+			item, err := parse(tx, row)
+			if err != nil {
+				if !errors.Is(err, errMalformedSession) {
+					return nil, nil, fmt.Errorf("parse OpenCode session %q: %w", row.id, err)
+				}
+				skipped = append(skipped, skippedFamily{id: familyID, err: err})
+				family = nil
+				break
+			}
+			family = append(family, item)
+		}
+		parsed = append(parsed, family...)
 	}
 	byID := make(map[string]*vendors.ParsedTranscript, len(parsed))
 	for _, item := range parsed {
@@ -180,13 +216,13 @@ func load(db *sql.DB, query string, args ...any) ([]*vendors.ParsedTranscript, e
 		}
 	}
 	if err := tx.Commit(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	transcripts := make([]*vendors.ParsedTranscript, 0, len(parsed))
 	for _, item := range parsed {
 		transcripts = append(transcripts, item.transcript)
 	}
-	return transcripts, nil
+	return transcripts, skipped, nil
 }
 
 func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
@@ -194,7 +230,7 @@ func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 	if row.model.Valid {
 		var model storedModel
 		if err := json.Unmarshal([]byte(row.model.String), &model); err != nil {
-			return parsedSession{}, fmt.Errorf("decode model: %w", err)
+			return parsedSession{}, fmt.Errorf("%w: decode model: %w", errMalformedSession, err)
 		}
 		modelID = modelName(model.ProviderID, model.ID)
 	}
@@ -581,7 +617,7 @@ func loadMessages(tx *sql.Tx, sessionID string) ([]storedMessage, error) {
 		if id != lastID {
 			var message storedMessage
 			if err := json.Unmarshal([]byte(messageJSON), &message); err != nil {
-				return nil, fmt.Errorf("decode message %q: %w", id, err)
+				return nil, fmt.Errorf("%w: decode message %q: %w", errMalformedSession, id, err)
 			}
 			messages = append(messages, message)
 			lastID = id
@@ -589,7 +625,7 @@ func loadMessages(tx *sql.Tx, sessionID string) ([]storedMessage, error) {
 		if partJSON.Valid {
 			var part storedPart
 			if err := json.Unmarshal([]byte(partJSON.String), &part); err != nil {
-				return nil, fmt.Errorf("decode part for message %q: %w", id, err)
+				return nil, fmt.Errorf("%w: decode part for message %q: %w", errMalformedSession, id, err)
 			}
 			part.updatedAt = partUpdatedAt.Int64
 			messages[len(messages)-1].parts = append(messages[len(messages)-1].parts, part)
@@ -635,7 +671,7 @@ func loadFileEdits(raw sql.NullString) ([]session.FileEdit, error) {
 	}
 	var diffs []storedDiff
 	if err := json.Unmarshal([]byte(raw.String), &diffs); err != nil {
-		return nil, fmt.Errorf("decode file summary: %w", err)
+		return nil, fmt.Errorf("%w: decode file summary: %w", errMalformedSession, err)
 	}
 	edits := make([]session.FileEdit, 0, len(diffs))
 	for _, diff := range diffs {

--- a/collector/internal/vendors/opencode/source.go
+++ b/collector/internal/vendors/opencode/source.go
@@ -28,7 +28,7 @@ WITH selected_roots AS (
 	GROUP BY root.id
 )
 SELECT member.id, member.parent_id, member.directory, member.title, member.summary_files,
-	member.summary_diffs, member.model, member.cost,
+	member.summary_diffs, member.agent, member.model, member.cost,
 	CASE WHEN member.id = selected_roots.id THEN selected_roots.family_updated ELSE member.time_updated END
 FROM selected_roots
 JOIN session AS member ON member.id = selected_roots.id OR member.parent_id = selected_roots.id
@@ -36,7 +36,7 @@ WHERE member.time_archived IS NULL`
 
 const activeRootQuery = `
 SELECT root.id, root.parent_id, root.directory, root.title, root.summary_files,
-	root.summary_diffs, root.model, root.cost,
+	root.summary_diffs, root.agent, root.model, root.cost,
 	MAX(root.time_updated, COALESCE((
 		SELECT MAX(child.time_updated)
 		FROM session AS child
@@ -88,7 +88,7 @@ func Collect(since int64) ([]*vendors.ParsedTranscript, *vendors.SessionMetadata
 	for _, family := range skipped {
 		log.Printf("OpenCode session family %q: %v; skipping", family.id, family.err)
 	}
-	return parsed, emptyMetadata(), err
+	return parsed, loadMetadata(), err
 }
 
 func Get(id string) (*vendors.ParsedTranscript, error) {
@@ -153,7 +153,7 @@ func load(db *sql.DB, query string, args ...any) ([]*vendors.ParsedTranscript, [
 		var row storedSession
 		if err := rows.Scan(
 			&row.id, &row.parentID, &row.directory, &row.title, &row.summaryFiles, &row.summaryDiffs,
-			&row.model, &row.cost, &row.updatedAt,
+			&row.agent, &row.model, &row.cost, &row.updatedAt,
 		); err != nil {
 			rows.Close()
 			return nil, nil, fmt.Errorf("read OpenCode session: %w", err)
@@ -383,6 +383,10 @@ func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 					}
 				}
 				isShell := part.Tool == "bash" || part.Tool == "shell"
+				if isShell && part.State.Status == "completed" &&
+					part.State.Metadata.Exit != nil && *part.State.Metadata.Exit != 0 {
+					errorsCount++
+				}
 				if isShell && part.State.Status == "completed" && part.State.Input.Command != "" {
 					commands.Note(part.State.Input.Command, part.State.Title)
 					if part.State.Metadata.Exit == nil || *part.State.Metadata.Exit == 0 {
@@ -557,6 +561,10 @@ func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 	if summary != "" {
 		value := session.Truncate(summary, session.TruncateTextLimit)
 		result.Summary = &value
+	}
+	if row.agent.Valid && strings.TrimSpace(row.agent.String) != "" {
+		value := strings.TrimSpace(row.agent.String)
+		result.Entrypoint = &value
 	}
 	return parsedSession{
 		transcript: &vendors.ParsedTranscript{

--- a/collector/internal/vendors/opencode/source.go
+++ b/collector/internal/vendors/opencode/source.go
@@ -75,12 +75,21 @@ func Collect(since int64) ([]*vendors.ParsedTranscript, *vendors.SessionMetadata
 		return nil, nil, err
 	}
 	defer db.Close()
+	metadata := loadMetadata(db)
 
 	query := activeFamiliesQuery
 	var args []any
 	if since > 0 {
-		query += " AND selected_roots.family_updated >= ?"
+		query += " AND (selected_roots.family_updated >= ?"
 		args = append(args, since)
+		if len(metadata.Live) > 0 {
+			query += " OR selected_roots.id IN (" +
+				strings.TrimSuffix(strings.Repeat("?,", len(metadata.Live)), ",") + ")"
+			for id := range metadata.Live {
+				args = append(args, id)
+			}
+		}
+		query += ")"
 	}
 	query += ` ORDER BY selected_roots.family_updated DESC,
 		member.parent_id IS NOT NULL, member.time_updated, member.id`
@@ -88,7 +97,7 @@ func Collect(since int64) ([]*vendors.ParsedTranscript, *vendors.SessionMetadata
 	for _, family := range skipped {
 		log.Printf("OpenCode session family %q: %v; skipping", family.id, family.err)
 	}
-	return parsed, loadMetadata(), err
+	return parsed, metadata, err
 }
 
 func Get(id string) (*vendors.ParsedTranscript, error) {

--- a/collector/internal/vendors/opencode/sqlite.go
+++ b/collector/internal/vendors/opencode/sqlite.go
@@ -1,24 +1,39 @@
 package opencode
 
 import (
+	"context"
 	"database/sql"
+	"fmt"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
+	"time"
 
 	_ "modernc.org/sqlite"
 )
 
 func Root() (string, error) {
 	dataHome := os.Getenv("XDG_DATA_HOME")
-	if dataHome == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-		dataHome = filepath.Join(home, ".local", "share")
+	if dataHome != "" {
+		return filepath.Join(dataHome, "opencode", "opencode.db"), nil
 	}
-	return filepath.Join(dataHome, "opencode", "opencode.db"), nil
+	if executable, err := exec.LookPath("opencode"); err == nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		if output, err := exec.CommandContext(ctx, executable, "db", "path").Output(); err == nil {
+			path := strings.TrimSpace(string(output))
+			if filepath.IsAbs(path) {
+				return filepath.Clean(path), nil
+			}
+		}
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".local", "share", "opencode", "opencode.db"), nil
 }
 
 func open() (*sql.DB, error) {
@@ -47,5 +62,25 @@ func open() (*sql.DB, error) {
 		db.Close()
 		return nil, err
 	}
+	if err := validateSchema(db); err != nil {
+		db.Close()
+		return nil, err
+	}
 	return db, nil
+}
+
+func validateSchema(db *sql.DB) error {
+	statement, err := db.Prepare(`
+		SELECT s.id, s.parent_id, s.directory, s.title, s.summary_files, s.summary_diffs,
+			s.model, s.cost, s.time_updated, s.time_archived,
+			m.id, m.session_id, m.time_created, m.data,
+			p.id, p.message_id, p.session_id, p.time_updated, p.data,
+			t.session_id, t.content, t.status, t.position
+		FROM session AS s, message AS m, part AS p, todo AS t
+		WHERE 0
+	`)
+	if err != nil {
+		return fmt.Errorf("unsupported OpenCode database schema; update OpenCode or coSlash to a compatible version: %w", err)
+	}
+	return statement.Close()
 }

--- a/collector/internal/vendors/opencode/sqlite.go
+++ b/collector/internal/vendors/opencode/sqlite.go
@@ -72,7 +72,7 @@ func open() (*sql.DB, error) {
 func validateSchema(db *sql.DB) error {
 	statement, err := db.Prepare(`
 		SELECT s.id, s.parent_id, s.directory, s.title, s.summary_files, s.summary_diffs,
-			s.model, s.cost, s.time_updated, s.time_archived,
+			s.agent, s.model, s.cost, s.time_updated, s.time_archived,
 			m.id, m.session_id, m.time_created, m.data,
 			p.id, p.message_id, p.session_id, p.time_updated, p.data,
 			t.session_id, t.content, t.status, t.position

--- a/collector/internal/vendors/opencode/types.go
+++ b/collector/internal/vendors/opencode/types.go
@@ -50,10 +50,11 @@ type storedTokens struct {
 }
 
 type storedPart struct {
-	Type      string `json:"type"`
-	Text      string `json:"text"`
-	Synthetic bool   `json:"synthetic"`
-	Tool      string `json:"tool"`
+	Type      string   `json:"type"`
+	Text      string   `json:"text"`
+	Synthetic bool     `json:"synthetic"`
+	Tool      string   `json:"tool"`
+	Files     []string `json:"files"`
 	State     struct {
 		Status string `json:"status"`
 		Title  string `json:"title"`
@@ -83,6 +84,7 @@ type storedPart struct {
 			End *int64 `json:"end"`
 		} `json:"time"`
 	} `json:"state"`
+	updatedAt int64
 }
 
 type storedToolFile struct {

--- a/collector/internal/vendors/opencode/types.go
+++ b/collector/internal/vendors/opencode/types.go
@@ -18,6 +18,7 @@ type storedSession struct {
 	title        string
 	summaryFiles sql.NullInt64
 	summaryDiffs sql.NullString
+	agent        sql.NullString
 	model        sql.NullString
 	cost         float64
 	updatedAt    int64

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -81,6 +81,10 @@
   --color-opencode: #20751c;
   --color-opencode-bg: #e3f3e2;
 
+  /* vendor: OpenCode */
+  --color-opencode: #20751c;
+  --color-opencode-bg: #e3f3e2;
+
   /* subagent rail */
   --color-subagent: var(--subagent);
   --color-subagent-bg: var(--subagent-bg);

--- a/frontend/src/pages/coslash/components/SessionCard.tsx
+++ b/frontend/src/pages/coslash/components/SessionCard.tsx
@@ -84,8 +84,8 @@ export function SessionId({ id, shortened = false }: { id: string; shortened?: b
   return (
     <CopyableBadge
       value={id}
-      ariaLabel={`Copy session UUID ${id}`}
-      copiedLabel="UUID copied"
+      ariaLabel={`Copy session ID ${id}`}
+      copiedLabel="Session ID copied"
       className="text-muted-foreground font-mono text-xs"
     >
       {shortened ? shortenSessionId(id) : id}

--- a/frontend/src/pages/coslash/lib/handoff.ts
+++ b/frontend/src/pages/coslash/lib/handoff.ts
@@ -26,6 +26,7 @@ export function handoffBrief(detail: SessionDetail): string {
     ? detail.fileEdits.map((fileEdit) => `- ${fileEdit.path} (+${fileEdit.adds}/-${fileEdit.dels})`)
     : ['- —'];
   const commits = detail.commits.length ? detail.commits.map((commit) => `- ${commit}`) : ['- —'];
+  const costLabel = detail.agent === 'opencode' ? 'Recorded cost' : 'Estimated cost at list API prices';
 
   return [
     `# Handoff — ${detail.name ?? detail.id}`,
@@ -58,7 +59,7 @@ export function handoffBrief(detail: SessionDetail): string {
     `- Working directory: ${detail.cwd}`,
     `- Runtime: ${formatDuration(detail.durationMs)}`,
     `- Tokens: ${formatTokens(getTotalTokens(detail.tokens))}`,
-    `- Estimated cost at list API prices: ${formatEstimatedCost(detail.cost)}`,
+    `- ${costLabel}: ${formatEstimatedCost(detail.cost)}`,
     `- Errors: ${detail.errors}; subagents: ${detail.subagents.length}`,
   ].join('\n');
 }


### PR DESCRIPTION
## Context

OpenCode sessions could omit native patch files, rely on a guessed database location, and appear inactive even when a resumed TUI was running. This hardens collection and fills metadata already supported by the dashboard and inspector.

## Changes

- Include native patch paths without overriding richer tool or summary diff metadata.
- Discover the SQLite database through OpenCode when available, validate its schema, and skip malformed session families without hiding healthy ones.
- Add best-effort Git branches, recorded agent labels, failed-command errors, and exact process-backed live status for sessions launched with `-s` or `--session`.
- ~~Use session-ID terminology and identify persisted OpenCode costs as recorded; bare OpenCode processes remain unmatched rather than guessed.~~
- Use session-ID terminology and identify persisted OpenCode costs as recorded. Bare TUI liveness uses a conservative launch/activity heuristic; OpenCode does not expose in-TUI session switches, so an association can become stale after switching.

## Test

- `cd collector && make test` - passed
- `cd collector && make check` - passed
- `cd frontend && npm test` - passed
- `cd frontend && npm run lint` - passed with two pre-existing warnings
- `cd frontend && npm run format:check` - passed
- `cd frontend && npm run build` - passed
- Manual: Verified native patch files, CLI-reported database discovery, branch and agent metadata, and a resumed session reporting busy against OpenCode 1.18.16.

### Screenshots

- [x] OpenCode detailed card and inspector - branch, agent, session-ID wording, and busy or idle status
<img width="1253" height="461" alt="Screenshot 2026-08-11 at 18 04 55" src="https://github.com/user-attachments/assets/1980347d-42b4-4376-9e81-fb28d301a40f" />
<img width="1259" height="901" alt="Screenshot 2026-08-11 at 18 05 02" src="https://github.com/user-attachments/assets/6fb75d7a-252c-4ec9-bcf9-6b5066b4ed32" />
