### PR TITLE
Group Dependabot updates into one weekly PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,22 @@
 version: 2
+
+multi-ecosystem-groups:
+  dependencies:
+    schedule:
+      interval: weekly
+
 updates:
   - package-ecosystem: gomod
     directory: /collector
-    schedule:
-      interval: weekly
+    patterns: ["*"]
+    multi-ecosystem-group: dependencies
+
   - package-ecosystem: npm
     directory: /frontend
-    schedule:
-      interval: weekly
+    patterns: ["*"]
+    multi-ecosystem-group: dependencies
+
   - package-ecosystem: github-actions
-    directory: "/"
-    schedule:
-      interval: weekly
+    directory: /
+    patterns: ["*"]
+    multi-ecosystem-group: dependencies


### PR DESCRIPTION
## Context

Dependabot currently opens separate pull requests for dependency updates across each package ecosystem. A shared weekly group reduces review noise while keeping npm, Go module, and GitHub Actions dependencies current.

## Changes

- Group all scheduled dependency updates into one weekly `dependencies` pull request.
- Keep security updates outside the scheduled group so they retain their existing behavior.

## Test

- `ruby -e 'require "yaml"; YAML.safe_load(File.read(".github/dependabot.yml"))'` - passed
- `git diff --check origin/main...HEAD` - passed