### PR TITLE
Fix brand color tokens keeping light values in dark mode

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -47,48 +47,72 @@
   --radius-4xl: calc(var(--radius) * 2.6);
 }
 
-/* coSlash semantic colors — generates utilities like bg-brand, text-success-fg, bg-warning-bg */
-@theme {
+/* coSlash semantic colors — generates utilities like bg-brand, text-success-fg, bg-warning-bg.
+   Aliases only: the literals live in :root / .dark below, so these follow the theme the same
+   way the shadcn neutrals above do. A literal here would be unreachable from .dark. */
+@theme inline {
   /* brand accent (logo, primary actions) */
-  --color-brand: #3554d1;
+  --color-brand: var(--brand);
 
   /* status: active */
-  --color-success: #2f9e63;
-  --color-success-fg: #2f7d55;
-  --color-success-bg: #e4f2ea;
+  --color-success: var(--success);
+  --color-success-fg: var(--success-fg);
+  --color-success-bg: var(--success-bg);
 
   /* status: idle */
-  --color-info: #6366f1;
-  --color-info-fg: #4f46b5;
-  --color-info-bg: #ecebfb;
+  --color-info: var(--info);
+  --color-info-fg: var(--info-fg);
+  --color-info-bg: var(--info-bg);
 
   /* status: waiting */
-  --color-warning: #c08a2e;
-  --color-warning-fg: #8a6316;
-  --color-warning-bg: #f7efdd;
+  --color-warning: var(--warning);
+  --color-warning-fg: var(--warning-fg);
+  --color-warning-bg: var(--warning-bg);
 
   /* vendor: Claude Code */
-  --color-claude: #a24218;
-  --color-claude-bg: #f6e7de;
+  --color-claude: var(--claude);
+  --color-claude-bg: var(--claude-bg);
 
   /* vendor: Codex */
-  --color-codex: #4f5eea;
-  --color-codex-bg: #e8eaff;
+  --color-codex: var(--codex);
+  --color-codex-bg: var(--codex-bg);
 
   /* subagent rail */
-  --color-subagent: #0b7c91;
-  --color-subagent-bg: #dff4f7;
-  --color-subagent-card: #f2fbfc;
-  --color-subagent-rail: #d5e9ee;
+  --color-subagent: var(--subagent);
+  --color-subagent-bg: var(--subagent-bg);
+  --color-subagent-card: var(--subagent-card);
+  --color-subagent-rail: var(--subagent-rail);
 
   /* digest categories (session drawer ledger); goal reuses success-fg,
      user reuses brand, todos reuses muted-foreground */
-  --color-question: #c2701f;
-  --color-recap: #b5468a;
-  --color-compaction: #b5852f;
+  --color-question: var(--question);
+  --color-recap: var(--recap);
+  --color-compaction: var(--compaction);
 }
 
 :root {
+  --brand: #3554d1;
+  --success: #2f9e63;
+  --success-fg: #2f7d55;
+  --success-bg: #e4f2ea;
+  --info: #6366f1;
+  --info-fg: #4f46b5;
+  --info-bg: #ecebfb;
+  --warning: #c08a2e;
+  --warning-fg: #8a6316;
+  --warning-bg: #f7efdd;
+  --claude: #a24218;
+  --claude-bg: #f6e7de;
+  --codex: #4f5eea;
+  --codex-bg: #e8eaff;
+  --subagent: #0b7c91;
+  --subagent-bg: #dff4f7;
+  --subagent-card: #f2fbfc;
+  --subagent-rail: #d5e9ee;
+  --question: #c2701f;
+  --recap: #b5468a;
+  --compaction: #b5852f;
+
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -124,6 +148,31 @@
 }
 
 .dark {
+  /* Light triples are (solid, darkened-for-text, pale wash). On dark that inverts to
+     (solid slightly brightened, lightened-for-text, deep low-chroma wash). Every -fg
+     clears 5.9:1 on its own -bg. */
+  --brand: #6f89ee;
+  --success: #35b073;
+  --success-fg: #5fd39b;
+  --success-bg: #10291d;
+  --info: #7c7ff5;
+  --info-fg: #a5a6fb;
+  --info-bg: #1d1d3d;
+  --warning: #d69f3f;
+  --warning-fg: #e8bd6b;
+  --warning-bg: #2e2311;
+  --claude: #e88a58;
+  --claude-bg: #2e1509;
+  --codex: #8b95f7;
+  --codex-bg: #1a1d40;
+  --subagent: #38b6cd;
+  --subagent-bg: #0d2b32;
+  --subagent-card: #0c1315;
+  --subagent-rail: #2a94a8;
+  --question: #dd9247;
+  --recap: #d478ae;
+  --compaction: #d2a555;
+
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);
@@ -175,4 +224,9 @@
 [data-slot='sheet-overlay'] {
   background: rgba(23, 39, 66, 0.28);
   backdrop-filter: none;
+}
+
+/* A light navy scrim does nothing over a near-black page. */
+.dark [data-slot='sheet-overlay'] {
+  background: rgba(0, 0, 0, 0.6);
 }

--- a/frontend/src/pages/coslash/components/SessionInspector.tsx
+++ b/frontend/src/pages/coslash/components/SessionInspector.tsx
@@ -527,7 +527,7 @@ function SubagentDigestRow({ subagentId, detail }: { subagentId: string; detail:
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <div className="bg-subagent-card border-subagent-rail flex cursor-pointer items-baseline gap-2 rounded-lg border p-2">
+        <div className="bg-subagent-card flex cursor-pointer items-baseline gap-2 rounded-lg border p-2">
           <span className="text-subagent w-24 shrink-0 text-xs font-bold tracking-wide">Subagent</span>
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">


### PR DESCRIPTION
## Context

In dark mode, the cards on the subagent rail still rendered in the light palette. The cause is in `src/index.css`. The 21 coSlash brand tokens were literal hex values inside a plain `@theme` block. A literal in `@theme` has nothing for `.dark` to override, so every brand token kept its light value on a dark page. The subagent card was the most visible case, because it is the largest painted surface and it repeats once per subagent.

## Changes

- All 21 brand tokens now follow the theme. The `@theme` block became `@theme inline` aliases that point at `:root` variables, plus a `.dark` override set. This is the same indirection the shadcn neutrals already use in this file. No component reads these through anything but a utility class, so no consumer changed.
- The subagent card lifts off the page instead of mirroring light mode. In light mode the card sits 1.05 *below* a white page. Below `#0a0a0a` is mud, so on dark it sits 1.06 *above* the page at `#0c1315`.
- The card tint stays a whisper on purpose. `DetailedSubagentRow` paints the `subagent-bg` badge directly onto the card, and a saturated card swallows that badge. The rail carries the subagent identity instead, at `#2a94a8`.
- The sheet scrim gets a dark value. It was a hardcoded light navy `rgba(23, 39, 66, 0.28)`, which does nothing over a near-black page. On dark it is now `rgba(0, 0, 0, 0.6)`.
- The subagent digest row in `SessionInspector` no longer uses `border-subagent-rail` as a full box border. That token becomes strong teal on dark, which would ring the row in loud teal. The row now uses the default card border, which matches `SubagentCard`.
- Light mode is unchanged. Every `:root` value is the same hex as before.

## Test

- `npm run lint` — passed. Two warnings remain in `SessionSortDropdownMenu.tsx`, both present before this branch.
- `npx tsc --noEmit` — passed
- `npm test` — passed, 10 tests
- `npx vite build` — passed. In the built CSS, `.bg-subagent-card` now emits `background-color:var(--subagent-card)` instead of a baked hex, `:root` keeps `#f2fbfc`, and `.dark` carries `#0c1315`.

### Screenshots

<img width="1258" height="349" alt="Screenshot 2026-08-11 at 20 09 36" src="https://github.com/user-attachments/assets/bec98420-72e9-484a-bf0c-dfcf96e39ae7" />
