### PR TITLE
Use canonical Git remote identities for sessions

### DIFF
--- a/collector/internal/collector/collector.go
+++ b/collector/internal/collector/collector.go
@@ -201,18 +201,23 @@ func probeEnvironment(roots []*vendors.ParsedTranscript) {
 	// filesystem lookup, per cwd.
 	type driftKey struct{ cwd, branch string }
 	type driftSlot struct{ drift *session.GitDrift }
-	repoByCwd := map[string]string{}
+	type repository struct {
+		name      string
+		localOnly bool
+	}
+	repoByCwd := map[string]repository{}
 	drifts := map[driftKey]*driftSlot{}
 	for _, p := range roots {
 		s := p.Session
 		if s.WorkingDirectory == "" {
 			continue
 		}
-		repoByCwd[s.WorkingDirectory] = ""
+		repoByCwd[s.WorkingDirectory] = repository{}
 		drifts[driftKey{s.WorkingDirectory, deref(s.Branch)}] = &driftSlot{}
 	}
 	for cwd := range repoByCwd {
-		repoByCwd[cwd] = session.CanonicalRepositoryName(cwd)
+		name, localOnly := session.CanonicalRepositoryName(cwd)
+		repoByCwd[cwd] = repository{name: name, localOnly: localOnly}
 	}
 	// BranchDrift waits on git subprocesses, so distinct keys probe
 	// concurrently. Results land through slot pointers — never map writes,
@@ -239,7 +244,8 @@ func probeEnvironment(roots []*vendors.ParsedTranscript) {
 		}
 		s.Git = drifts[driftKey{s.WorkingDirectory, deref(s.Branch)}].drift
 		repo := repoByCwd[s.WorkingDirectory]
-		s.Repository = &repo
+		s.Repository = &repo.name
+		s.RepositoryLocalOnly = repo.localOnly
 	}
 }
 

--- a/collector/internal/session/probes.go
+++ b/collector/internal/session/probes.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -31,31 +32,36 @@ func FileModificationTime(filePath string) int64 {
 	return info.ModTime().UnixMilli()
 }
 
-func CanonicalRepositoryName(cwd string) string {
+func CanonicalRepositoryName(cwd string) (string, bool) {
 	if cwd == "" {
-		return ""
+		return "", false
 	}
 	fallback := filepath.Base(filepath.Clean(cwd))
 	resolved, err := filepath.EvalSymlinks(cwd)
 	if err != nil {
-		return fallback
+		return fallback, true
 	}
 	root := repositoryRoot(resolved)
 	if root == "" {
-		return fallback
+		return fallback, true
+	}
+	if output, err := exec.Command("git", "-C", root, "remote", "get-url", "origin").Output(); err == nil {
+		if remote := canonicalRemoteName(string(output)); remote != "" {
+			return remote, false
+		}
 	}
 	gitMarker := filepath.Join(root, ".git")
 	info, err := os.Stat(gitMarker)
 	if err == nil && info.IsDir() {
-		return filepath.Base(root)
+		return filepath.Base(root), true
 	}
 	contents, err := os.ReadFile(gitMarker)
 	if err != nil {
-		return filepath.Base(root)
+		return filepath.Base(root), true
 	}
 	gitDirValue := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(string(contents)), "gitdir:"))
 	if gitDirValue == "" || gitDirValue == strings.TrimSpace(string(contents)) {
-		return filepath.Base(root)
+		return filepath.Base(root), true
 	}
 	gitDir := gitDirValue
 	if !filepath.IsAbs(gitDir) {
@@ -63,7 +69,7 @@ func CanonicalRepositoryName(cwd string) string {
 	}
 	common, err := os.ReadFile(filepath.Join(filepath.Clean(gitDir), "commondir"))
 	if err != nil {
-		return filepath.Base(root)
+		return filepath.Base(root), true
 	}
 	commonDir := strings.TrimSpace(string(common))
 	if !filepath.IsAbs(commonDir) {
@@ -71,9 +77,38 @@ func CanonicalRepositoryName(cwd string) string {
 	}
 	commonDir = filepath.Clean(commonDir)
 	if filepath.Base(commonDir) == ".git" {
-		return filepath.Base(filepath.Dir(commonDir))
+		return filepath.Base(filepath.Dir(commonDir)), true
 	}
-	return filepath.Base(root)
+	return filepath.Base(root), true
+}
+
+func canonicalRemoteName(remote string) string {
+	remote = strings.TrimSpace(remote)
+	if !strings.Contains(remote, "://") {
+		host, path, ok := strings.Cut(remote, ":")
+		if !ok || host == "" || path == "" || strings.ContainsAny(host, `/\\`) {
+			return ""
+		}
+		remote = "ssh://" + host + "/" + strings.TrimPrefix(path, "/")
+	}
+	parsed, err := url.Parse(remote)
+	if err != nil || parsed.Hostname() == "" {
+		return ""
+	}
+	path := strings.Trim(parsed.Path, "/")
+	if strings.HasSuffix(strings.ToLower(path), ".git") {
+		path = path[:len(path)-len(".git")]
+	}
+	parts := strings.Split(path, "/")
+	if len(parts) < 2 {
+		return ""
+	}
+	for _, part := range parts {
+		if part == "" || part == "." || part == ".." {
+			return ""
+		}
+	}
+	return strings.ToLower(parsed.Hostname()) + "/" + path
 }
 
 func repositoryRoot(cwd string) string {

--- a/collector/internal/session/probes.go
+++ b/collector/internal/session/probes.go
@@ -99,16 +99,12 @@ func canonicalRemoteName(remote string) string {
 	if strings.HasSuffix(strings.ToLower(path), ".git") {
 		path = path[:len(path)-len(".git")]
 	}
-	parts := strings.Split(path, "/")
-	if len(parts) < 2 {
-		return ""
-	}
-	for _, part := range parts {
+	for _, part := range strings.Split(path, "/") {
 		if part == "" || part == "." || part == ".." {
 			return ""
 		}
 	}
-	return strings.ToLower(parsed.Hostname()) + "/" + path
+	return strings.ToLower(parsed.Host) + "/" + path
 }
 
 func repositoryRoot(cwd string) string {

--- a/collector/internal/session/session.go
+++ b/collector/internal/session/session.go
@@ -37,22 +37,23 @@ type Subagent struct {
 }
 
 type Session struct {
-	Agent            string                 `json:"agent"`
-	ID               string                 `json:"id"`
-	Name             *string                `json:"name"`
-	Summary          *string                `json:"summary"`
-	Status           *string                `json:"status"`
-	WorkingDirectory string                 `json:"cwd"`
-	Branch           *string                `json:"branch"`
-	Repository       *string                `json:"repo"`
-	EditedFileCount  int                    `json:"files"`
-	DurationMs       *int                   `json:"durationMs"`
-	Tokens           map[string]ModelTokens `json:"tokens"`
-	Cost             float64                `json:"cost"`
-	UnpricedModels   []string               `json:"unpricedModels"`
-	Subagents        []Subagent             `json:"subagents"`
-	LastActivityTime int64                  `json:"mtime"`
-	Entrypoint       *string                `json:"entrypoint"`
+	Agent               string                 `json:"agent"`
+	ID                  string                 `json:"id"`
+	Name                *string                `json:"name"`
+	Summary             *string                `json:"summary"`
+	Status              *string                `json:"status"`
+	WorkingDirectory    string                 `json:"cwd"`
+	Branch              *string                `json:"branch"`
+	Repository          *string                `json:"repo"`
+	RepositoryLocalOnly bool                   `json:"repoLocalOnly"`
+	EditedFileCount     int                    `json:"files"`
+	DurationMs          *int                   `json:"durationMs"`
+	Tokens              map[string]ModelTokens `json:"tokens"`
+	Cost                float64                `json:"cost"`
+	UnpricedModels      []string               `json:"unpricedModels"`
+	Subagents           []Subagent             `json:"subagents"`
+	LastActivityTime    int64                  `json:"mtime"`
+	Entrypoint          *string                `json:"entrypoint"`
 	SessionDetails
 }
 

--- a/frontend/src/pages/coslash/lib/session.ts
+++ b/frontend/src/pages/coslash/lib/session.ts
@@ -39,6 +39,7 @@ export type Session = {
   cwd: string;
   branch: string | null;
   repo: string | null;
+  repoLocalOnly: boolean;
   files: number;
   durationMs: number | null;
   tokens: Record<string, ModelTokens>;


### PR DESCRIPTION
## Context

Session repository grouping currently relies on local directory names, which can collide and vary across checkout layouts. Normalize origin remotes so repositories have stable identities across machines, while preserving local-only fallbacks.

## Changes

- Normalize HTTPS, SSH, and SCP-style origin URLs to `host/owner/repository`.
- Mark basename fallbacks as local-only and preserve linked worktree grouping.

## Test

- `go test ./...` - passed
- `go vet ./...` - passed
- `npm test` - passed
- `npm run build` - passed
- `npm run format:check` - passed

### Screenshots

- [x] Session board - canonical remote repository label and local-only fallback
<img width="1053" height="470" alt="Screenshot 2026-08-12 at 11 10 46" src="https://github.com/user-attachments/assets/e7209e71-83e7-4fa8-926d-b32f22585137" />
