### PR TITLE
Fix: workflow guard matching

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -442,7 +442,7 @@ jobs:
             exit 1
           fi
           release_body="$(jq -r .body <<<"$release")"
-          if [[ "$release_body" != *"VERSION=$TAG"* ]]; then
+          if [[ "$release_body" != *"VERSION=\"$TAG\""* ]]; then
             echo "error: release notes do not reference VERSION=$TAG" >&2
             exit 1
           fi


### PR DESCRIPTION
Follow up #72 

Fix workflow guard matching for the tag

<img width="967" height="103" alt="Screenshot 2026-08-13 at 2 18 16 PM" src="https://github.com/user-attachments/assets/b59b8d0a-364f-41eb-b283-25ef0636af0a" />
