### PR TITLE
Add semver:major and semver:minor version-resolver rules to Release Drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -37,6 +37,16 @@ categories:
   - title: Other changes
 
   - type: version-resolver
+    semver-increment: major
+    when:
+      label: "semver:major"
+
+  - type: version-resolver
+    semver-increment: minor
+    when:
+      label: "semver:minor"
+
+  - type: version-resolver
     semver-increment: patch
 
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"


### PR DESCRIPTION
Adds major and minor version-resolver rules before the existing patch fallback. Labeling a PR semver:minor or semver:major will now cause the rolling draft to suggest the corresponding bump. Unlabeled PRs continue to default to patch.