### PR TITLE
Show session-specific file diffs in the inspector

### DIFF
--- a/collector/cmd/coslash/api.go
+++ b/collector/cmd/coslash/api.go
@@ -50,6 +50,40 @@ func parseSince(value string) (int64, error) {
 	return since, nil
 }
 
+func handleDiff(
+	w http.ResponseWriter,
+	r *http.Request,
+	getSession func(string) (*session.Session, error),
+) {
+	query := r.URL.Query()
+	found, err := getSession(query.Get("id"))
+	if err != nil {
+		log.Printf("diff: %v", err)
+		http.Error(w, "could not load diff", http.StatusInternalServerError)
+		return
+	}
+	if found == nil {
+		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+	path := query.Get("path")
+	var selected *session.FileEdit
+	for index := range found.FileEdits {
+		edit := &found.FileEdits[index]
+		if edit.Path == path {
+			selected = edit
+			break
+		}
+	}
+	if selected == nil {
+		http.Error(w, "file not found in session", http.StatusNotFound)
+		return
+	}
+	writeJSON(w, struct {
+		Changes []session.FileChange `json:"changes"`
+	}{Changes: selected.Changes()})
+}
+
 // /api/synthesis?id=X → cached synthesis for one session, triggering a run
 // when eligible. Loads one session, never the whole machine; GetSessionFacts skips fork,
 // subagents, and name/status resolution because BuildInput and Eligible read

--- a/collector/cmd/coslash/main.go
+++ b/collector/cmd/coslash/main.go
@@ -141,6 +141,9 @@ func routes(mgr *synthesis.Manager, settingsStore *settings.Store) *http.ServeMu
 	api.HandleFunc("GET /api/synthesis", func(w http.ResponseWriter, r *http.Request) {
 		handleSynthesis(w, r.URL.Query().Get("id"), mgr)
 	})
+	api.HandleFunc("GET /api/diff", func(w http.ResponseWriter, r *http.Request) {
+		handleDiff(w, r, collector.Get)
+	})
 	api.HandleFunc("GET /api/settings", func(w http.ResponseWriter, _ *http.Request) {
 		writeSettings(w, settingsStore.State())
 	})

--- a/collector/cmd/coslash/main.go
+++ b/collector/cmd/coslash/main.go
@@ -39,7 +39,12 @@ type options struct {
 func parseOptions(arguments []string) (options, error) {
 	flags := flag.NewFlagSet("coslash", flag.ContinueOnError)
 	var opts options
-	flags.IntVar(&opts.port, "port", defaultPort, "port to serve on, loopback only; 0 picks any free port")
+	flags.IntVar(
+		&opts.port,
+		"port",
+		defaultPort,
+		"port to serve on, loopback only; 0 picks any free port",
+	)
 	flags.BoolVar(&opts.noOpen, "no-open", false, "do not open a browser on startup")
 	flags.BoolVar(&opts.showVersion, "version", false, "print the version and exit")
 	if err := flags.Parse(arguments); err != nil {
@@ -121,7 +126,11 @@ func main() {
 	}
 }
 
-func newServer(guard httpsec.Guard, mgr *synthesis.Manager, settingsStore *settings.Store) *http.Server {
+func newServer(
+	guard httpsec.Guard,
+	mgr *synthesis.Manager,
+	settingsStore *settings.Store,
+) *http.Server {
 	return &http.Server{
 		Handler:           guard.Wrap(routes(mgr, settingsStore)),
 		ReadHeaderTimeout: 10 * time.Second,
@@ -142,7 +151,7 @@ func routes(mgr *synthesis.Manager, settingsStore *settings.Store) *http.ServeMu
 		handleSynthesis(w, r.URL.Query().Get("id"), mgr)
 	})
 	api.HandleFunc("GET /api/diff", func(w http.ResponseWriter, r *http.Request) {
-		handleDiff(w, r, collector.Get)
+		handleDiff(w, r, collector.GetSessionFacts)
 	})
 	api.HandleFunc("GET /api/settings", func(w http.ResponseWriter, _ *http.Request) {
 		writeSettings(w, settingsStore.State())
@@ -175,7 +184,10 @@ func listen(port int) (net.Listener, error) {
 	listener, err := net.Listen("tcp", address)
 	if err != nil {
 		if errors.Is(err, syscall.EADDRINUSE) {
-			return nil, fmt.Errorf("port %d is already in use; quit the other process or pass --port", port)
+			return nil, fmt.Errorf(
+				"port %d is already in use; quit the other process or pass --port",
+				port,
+			)
 		}
 		return nil, fmt.Errorf("listen on %s: %w", address, err)
 	}

--- a/collector/cmd/coslash/main_test.go
+++ b/collector/cmd/coslash/main_test.go
@@ -173,8 +173,8 @@ func TestHandleDiffReturnsRecordedEditsInOrder(t *testing.T) {
 	}
 	if body.Changes[0].Operation != "Edit" ||
 		body.Changes[0].Additions != 1 || body.Changes[0].Deletions != 1 ||
-		!strings.Contains(body.Changes[0].Text, "-before\n+middle") ||
-		!strings.Contains(body.Changes[1].Text, "-middle\n+after") {
+		body.Changes[0].Text != "@@\n-before\n+middle\n" ||
+		body.Changes[1].Text != "@@\n-middle\n+after\n" {
 		t.Fatalf("changes = %#v, want recorded edits in transcript order", body.Changes)
 	}
 }

--- a/collector/cmd/coslash/main_test.go
+++ b/collector/cmd/coslash/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"net"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/centauri-ai/coslash/collector/internal/httpsec"
+	"github.com/centauri-ai/coslash/collector/internal/session"
 	"github.com/centauri-ai/coslash/collector/internal/settings"
 	"github.com/centauri-ai/coslash/collector/internal/synthesis"
 )
@@ -45,6 +47,7 @@ func TestAPIRoutesRejectUnsupportedMethods(t *testing.T) {
 	}{
 		{method: http.MethodPost, path: "/api/sessions"},
 		{method: http.MethodPost, path: "/api/synthesis"},
+		{method: http.MethodPost, path: "/api/diff"},
 		{method: http.MethodGet, path: "/api/launch"},
 		{method: http.MethodPost, path: "/api/diagnostics"},
 	} {
@@ -125,5 +128,71 @@ func TestWriteTokenPreservesHomePermissions(t *testing.T) {
 	}
 	if info.Mode().Perm() != 0o750 {
 		t.Fatalf("home mode = %o, want 750", info.Mode().Perm())
+	}
+}
+
+func TestHandleDiffReturnsRecordedEditsInOrder(t *testing.T) {
+	edits := session.NewFileEditSet()
+	edits.Add("file.txt", 1, 1, false)
+	edits.Change("file.txt", "before\n", "middle\n")
+	edits.Add("file.txt", 1, 1, false)
+	edits.Change("file.txt", "middle\n", "after\n")
+	found := &session.Session{
+		ID: "session-1",
+		SessionDetails: session.SessionDetails{
+			FileEdits: edits.Edits,
+		},
+	}
+	request := httptest.NewRequest(http.MethodGet, "/api/diff?id=session-1&path=file.txt", nil)
+	response := httptest.NewRecorder()
+
+	handleDiff(response, request, func(id string) (*session.Session, error) {
+		if id != found.ID {
+			t.Fatalf("session id = %q, want %q", id, found.ID)
+		}
+		return found, nil
+	})
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusOK)
+	}
+	var body struct {
+		Changes []struct {
+			Kind      string `json:"kind"`
+			Text      string `json:"text"`
+			Operation string `json:"operation"`
+			Additions int    `json:"additions"`
+			Deletions int    `json:"deletions"`
+		} `json:"changes"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Changes) != 2 {
+		t.Fatalf("changes = %#v, want two recorded edits", body.Changes)
+	}
+	if body.Changes[0].Operation != "Edit" ||
+		body.Changes[0].Additions != 1 || body.Changes[0].Deletions != 1 ||
+		!strings.Contains(body.Changes[0].Text, "-before\n+middle") ||
+		!strings.Contains(body.Changes[1].Text, "-middle\n+after") {
+		t.Fatalf("changes = %#v, want recorded edits in transcript order", body.Changes)
+	}
+}
+
+func TestHandleDiffRejectsFilesOutsideTheSession(t *testing.T) {
+	found := &session.Session{
+		ID:               "session-1",
+		WorkingDirectory: t.TempDir(),
+		SessionDetails: session.SessionDetails{
+			FileEdits: []session.FileEdit{{Path: "recorded.txt"}},
+		},
+	}
+	request := httptest.NewRequest(http.MethodGet, "/api/diff?id=session-1&path=../secret.txt", nil)
+	response := httptest.NewRecorder()
+
+	handleDiff(response, request, func(string) (*session.Session, error) { return found, nil })
+
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusNotFound)
 	}
 }

--- a/collector/internal/session/diffstat.go
+++ b/collector/internal/session/diffstat.go
@@ -18,5 +18,5 @@ func CountLines(content string) int {
 	if content == "" {
 		return 0
 	}
-	return strings.Count(content, "\n") + 1
+	return len(strings.Split(strings.TrimSuffix(content, "\n"), "\n"))
 }

--- a/collector/internal/session/file_edits.go
+++ b/collector/internal/session/file_edits.go
@@ -1,5 +1,15 @@
 package session
 
+import "strings"
+
+type FileChange struct {
+	Kind      string `json:"kind"`
+	Text      string `json:"text"`
+	Operation string `json:"operation"`
+	Additions int    `json:"additions"`
+	Deletions int    `json:"deletions"`
+}
+
 type FileEditSet struct {
 	Edits []FileEdit
 	index map[string]int
@@ -10,6 +20,11 @@ func NewFileEditSet() *FileEditSet {
 }
 
 func (s *FileEditSet) Add(path string, additions, deletions int, isNew bool) {
+	operation := "Edit"
+	if isNew {
+		operation = "Add"
+	}
+	change := FileChange{Operation: operation, Additions: additions, Deletions: deletions}
 	if i, ok := s.index[path]; ok {
 		edit := &s.Edits[i]
 		edit.Additions += additions
@@ -18,6 +33,7 @@ func (s *FileEditSet) Add(path string, additions, deletions int, isNew bool) {
 		if isNew {
 			edit.IsNew = true
 		}
+		edit.changes = append(edit.changes, change)
 		return
 	}
 	s.index[path] = len(s.Edits)
@@ -27,5 +43,72 @@ func (s *FileEditSet) Add(path string, additions, deletions int, isNew bool) {
 		Deletions: deletions,
 		Edits:     1,
 		IsNew:     isNew,
+		changes:   []FileChange{change},
 	})
+}
+
+func (s *FileEditSet) Change(path, before, after string) {
+	change := s.pendingChange(path)
+	if before == after && change.Operation != "Add" {
+		return
+	}
+	change.Kind = "diff"
+	change.Text = renderChange(path, before, after)
+}
+
+func (s *FileEditSet) Write(path, content string) {
+	change := s.pendingChange(path)
+	change.Kind = "content"
+	change.Text = content
+	change.Operation = "Write"
+}
+
+func (s *FileEditSet) Patch(path, patch string) {
+	change := s.pendingChange(path)
+	change.Kind = "diff"
+	change.Text = patch
+	if change.Operation != "Add" {
+		change.Operation = "Patch"
+	}
+}
+
+func (e FileEdit) Changes() []FileChange {
+	changes := make([]FileChange, 0, len(e.changes))
+	for _, change := range e.changes {
+		if change.Kind != "" {
+			changes = append(changes, change)
+		}
+	}
+	return changes
+}
+
+func (s *FileEditSet) pendingChange(path string) *FileChange {
+	edit := &s.Edits[s.index[path]]
+	if len(edit.changes) == 0 || edit.changes[len(edit.changes)-1].Kind != "" {
+		edit.changes = append(edit.changes, FileChange{Operation: "Edit"})
+	}
+	return &edit.changes[len(edit.changes)-1]
+}
+
+func renderChange(path, before, after string) string {
+	var output strings.Builder
+	output.WriteString("--- " + path + "\n+++ " + path + "\n@@\n")
+	writeSnippetDiff(&output, before, after)
+	return output.String()
+}
+
+func writeSnippetDiff(output *strings.Builder, before, after string) {
+	for _, line := range splitLines(before) {
+		output.WriteString("-" + line + "\n")
+	}
+	for _, line := range splitLines(after) {
+		output.WriteString("+" + line + "\n")
+	}
+}
+
+func splitLines(text string) []string {
+	if text == "" {
+		return nil
+	}
+	return strings.Split(strings.TrimSuffix(text, "\n"), "\n")
 }

--- a/collector/internal/session/file_edits.go
+++ b/collector/internal/session/file_edits.go
@@ -53,7 +53,7 @@ func (s *FileEditSet) Change(path, before, after string) {
 		return
 	}
 	change.Kind = "diff"
-	change.Text = renderChange(path, before, after)
+	change.Text = renderChange(before, after)
 }
 
 func (s *FileEditSet) Write(path, content string) {
@@ -90,9 +90,9 @@ func (s *FileEditSet) pendingChange(path string) *FileChange {
 	return &edit.changes[len(edit.changes)-1]
 }
 
-func renderChange(path, before, after string) string {
+func renderChange(before, after string) string {
 	var output strings.Builder
-	output.WriteString("--- " + path + "\n+++ " + path + "\n@@\n")
+	output.WriteString("@@\n")
 	writeSnippetDiff(&output, before, after)
 	return output.String()
 }

--- a/collector/internal/session/session.go
+++ b/collector/internal/session/session.go
@@ -84,6 +84,7 @@ type FileEdit struct {
 	Deletions int    `json:"dels"`
 	Edits     int    `json:"edits"`
 	IsNew     bool   `json:"isNew"`
+	changes   []FileChange
 }
 
 type GitDrift struct {

--- a/collector/internal/vendors/claude/parse.go
+++ b/collector/internal/vendors/claude/parse.go
@@ -311,6 +311,10 @@ func analyzeClaudeSession(file string) (*claudeSessionAnalysis, error) {
 				var diffLines []string
 				createdContent := ""
 				for _, patch := range result.StructuredPatch {
+					diffLines = append(diffLines, fmt.Sprintf(
+						"@@ -%d,%d +%d,%d @@",
+						patch.OldStart, patch.OldLines, patch.NewStart, patch.NewLines,
+					))
 					diffLines = append(diffLines, patch.Lines...)
 				}
 				lineAdditions, lineDeletions := session.DiffStat(diffLines)

--- a/collector/internal/vendors/claude/parse.go
+++ b/collector/internal/vendors/claude/parse.go
@@ -309,13 +309,13 @@ func analyzeClaudeSession(file string) (*claudeSessionAnalysis, error) {
 			}
 			if result != nil && result.FilePath != "" {
 				var diffLines []string
+				createdContent := ""
 				for _, patch := range result.StructuredPatch {
 					diffLines = append(diffLines, patch.Lines...)
 				}
 				lineAdditions, lineDeletions := session.DiffStat(diffLines)
 				if len(result.StructuredPatch) == 0 && result.Type == "create" {
-					var content string
-					if err := json.Unmarshal(result.Content, &content); err != nil {
+					if err := json.Unmarshal(result.Content, &createdContent); err != nil {
 						log.Printf(
 							"%s: skipping unreadable new file for %s: %v",
 							file,
@@ -323,12 +323,17 @@ func analyzeClaudeSession(file string) (*claudeSessionAnalysis, error) {
 							err,
 						)
 					} else {
-						lineAdditions = session.CountLines(content)
+						lineAdditions = session.CountLines(createdContent)
 					}
 				}
 				analysis.fileEdits.Add(
 					result.FilePath, lineAdditions, lineDeletions, result.Type == "create",
 				)
+				if len(diffLines) > 0 {
+					analysis.fileEdits.Patch(result.FilePath, strings.Join(diffLines, "\n"))
+				} else if result.Type == "create" {
+					analysis.fileEdits.Change(result.FilePath, "", createdContent)
+				}
 			}
 			if result != nil && result.Task != nil && result.Task.ID != "" {
 				if _, ok := analysis.tasks[result.Task.ID]; !ok {

--- a/collector/internal/vendors/claude/types.go
+++ b/collector/internal/vendors/claude/types.go
@@ -111,7 +111,11 @@ type claudeToolUseResult struct {
 	Type            string          `json:"type"`
 	Content         json.RawMessage `json:"content"`
 	StructuredPatch []struct {
-		Lines []string `json:"lines"`
+		OldStart int      `json:"oldStart"`
+		OldLines int      `json:"oldLines"`
+		NewStart int      `json:"newStart"`
+		NewLines int      `json:"newLines"`
+		Lines    []string `json:"lines"`
 	} `json:"structuredPatch"`
 	Task *struct {
 		ID      string `json:"id"`

--- a/collector/internal/vendors/codex/parse.go
+++ b/collector/internal/vendors/codex/parse.go
@@ -68,6 +68,11 @@ func (analysis *codexSessionAnalysis) noteFileChanges(changes codexPatchChanges)
 			additions = session.CountLines(change.Content)
 		}
 		analysis.fileEdits.Add(entry.Path, additions, deletions, isNew)
+		if change.UnifiedDiff != "" {
+			analysis.fileEdits.Patch(entry.Path, change.UnifiedDiff)
+		} else if isNew {
+			analysis.fileEdits.Change(entry.Path, "", change.Content)
+		}
 	}
 }
 

--- a/collector/internal/vendors/opencode/parse.go
+++ b/collector/internal/vendors/opencode/parse.go
@@ -369,8 +369,13 @@ func addCompletedToolEdits(cwd string, part *storedPart, edits *session.FileEdit
 		if patch == "" {
 			patch = applyPatchForFile(part.State.Input.PatchText, cwd, path)
 		}
+		if patch == "" && part.Tool == "edit" {
+			patch = part.State.Metadata.FileDiff.Patch
+		}
 		if patch != "" {
 			edits.Patch(path, patch)
+		} else if part.Tool == "edit" {
+			edits.Change(path, part.State.Input.OldString, part.State.Input.NewString)
 		}
 		edited = true
 	}
@@ -383,7 +388,11 @@ func addCompletedToolEdits(cwd string, part *storedPart, edits *session.FileEdit
 		if path != "" {
 			path = normalizeFilePath(cwd, path)
 			edits.Add(path, file.Additions, file.Deletions, false)
-			edits.Change(path, part.State.Input.OldString, part.State.Input.NewString)
+			if file.Patch != "" {
+				edits.Patch(path, file.Patch)
+			} else {
+				edits.Change(path, part.State.Input.OldString, part.State.Input.NewString)
+			}
 			edited = true
 		}
 	}

--- a/collector/internal/vendors/opencode/parse.go
+++ b/collector/internal/vendors/opencode/parse.go
@@ -319,6 +319,36 @@ func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 }
 
 func addCompletedToolEdits(cwd string, part *storedPart, edits *session.FileEditSet) bool {
+	if part.Tool == "write" {
+		file := storedToolFile{}
+		if len(part.State.Metadata.Files) > 0 {
+			file = part.State.Metadata.Files[0]
+		}
+		path := file.RelativePath
+		if path == "" {
+			path = file.FilePath
+		}
+		if path == "" {
+			path = part.State.Metadata.FilePath
+		}
+		if path == "" {
+			path = part.State.Input.FilePath
+		}
+		if path == "" {
+			return false
+		}
+		isNew := file.Type == "add" || file.Type == "added" ||
+			(part.State.Metadata.Exists != nil && !*part.State.Metadata.Exists)
+		additions := file.Additions
+		if isNew && additions == 0 {
+			additions = session.CountLines(part.State.Input.Content)
+		}
+		path = normalizeFilePath(cwd, path)
+		edits.Add(path, additions, file.Deletions, isNew)
+		edits.Write(path, part.State.Input.Content)
+		return true
+	}
+
 	edited := false
 	for _, file := range part.State.Metadata.Files {
 		path := file.RelativePath
@@ -328,12 +358,20 @@ func addCompletedToolEdits(cwd string, part *storedPart, edits *session.FileEdit
 		if path == "" {
 			continue
 		}
+		path = normalizeFilePath(cwd, path)
 		edits.Add(
-			normalizeFilePath(cwd, path),
+			path,
 			file.Additions,
 			file.Deletions,
 			file.Type == "add" || file.Type == "added",
 		)
+		patch := file.Patch
+		if patch == "" {
+			patch = applyPatchForFile(part.State.Input.PatchText, cwd, path)
+		}
+		if patch != "" {
+			edits.Patch(path, patch)
+		}
 		edited = true
 	}
 	if part.Tool == "edit" && len(part.State.Metadata.Files) == 0 {
@@ -343,26 +381,40 @@ func addCompletedToolEdits(cwd string, part *storedPart, edits *session.FileEdit
 			path = part.State.Input.FilePath
 		}
 		if path != "" {
-			edits.Add(normalizeFilePath(cwd, path), file.Additions, file.Deletions, false)
-			edited = true
-		}
-	}
-	if part.Tool == "write" && len(part.State.Metadata.Files) == 0 {
-		path := part.State.Metadata.FilePath
-		if path == "" {
-			path = part.State.Input.FilePath
-		}
-		if path != "" {
-			isNew := part.State.Metadata.Exists != nil && !*part.State.Metadata.Exists
-			additions := 0
-			if isNew {
-				additions = session.CountLines(part.State.Input.Content)
-			}
-			edits.Add(normalizeFilePath(cwd, path), additions, 0, isNew)
+			path = normalizeFilePath(cwd, path)
+			edits.Add(path, file.Additions, file.Deletions, false)
+			edits.Change(path, part.State.Input.OldString, part.State.Input.NewString)
 			edited = true
 		}
 	}
 	return edited
+}
+
+func applyPatchForFile(patchText, cwd, path string) string {
+	var patch strings.Builder
+	active := false
+	for rawLine := range strings.Lines(patchText) {
+		line := strings.TrimSuffix(rawLine, "\n")
+		marker, marked := strings.CutPrefix(line, "*** Update File: ")
+		if !marked {
+			marker, marked = strings.CutPrefix(line, "*** Add File: ")
+		}
+		if !marked {
+			marker, marked = strings.CutPrefix(line, "*** Delete File: ")
+		}
+		if marked {
+			active = normalizeFilePath(cwd, marker) == path
+			continue
+		}
+		if strings.HasPrefix(line, "*** ") {
+			active = false
+			continue
+		}
+		if active {
+			patch.WriteString(rawLine)
+		}
+	}
+	return patch.String()
 }
 
 func mergeFileEditSources(

--- a/collector/internal/vendors/opencode/types.go
+++ b/collector/internal/vendors/opencode/types.go
@@ -57,6 +57,9 @@ type storedPart struct {
 			Command      string           `json:"command"`
 			FilePath     string           `json:"filePath"`
 			Content      string           `json:"content"`
+			OldString    string           `json:"oldString"`
+			NewString    string           `json:"newString"`
+			PatchText    string           `json:"patchText"`
 			Description  string           `json:"description"`
 			SubagentType string           `json:"subagent_type"`
 			Questions    []storedQuestion `json:"questions"`
@@ -89,6 +92,7 @@ type storedToolFile struct {
 	Additions    int    `json:"additions"`
 	Deletions    int    `json:"deletions"`
 	Type         string `json:"type"`
+	Patch        string `json:"patch"`
 }
 
 type storedQuestion struct {

--- a/frontend/src/pages/coslash/components/DiffList.tsx
+++ b/frontend/src/pages/coslash/components/DiffList.tsx
@@ -1,0 +1,95 @@
+import { LoaderCircleIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { FileChange } from '@/pages/coslash/hooks/use-sessions';
+
+type DiffLineKind = 'meta' | 'hunk' | 'addition' | 'deletion' | 'context';
+
+/* oxlint-disable react/only-export-components -- exported for focused rendering tests */
+export function diffLineKind(line: string): DiffLineKind {
+  if (line.startsWith('+++') || line.startsWith('---')) return 'meta';
+  if (line.startsWith('@@')) return 'hunk';
+  if (line.startsWith('+')) return 'addition';
+  if (line.startsWith('-')) return 'deletion';
+  return 'context';
+}
+
+export function fileChangeLabel(change: Pick<FileChange, 'operation'>, index: number) {
+  return `${change.operation} ${index + 1}`;
+}
+/* oxlint-enable react/only-export-components */
+
+export function DiffList({
+  changes,
+  isLoading,
+  loadError,
+}: {
+  changes: FileChange[] | null;
+  isLoading: boolean;
+  loadError: string | null;
+}) {
+  if (isLoading) {
+    return (
+      <div className="text-muted-foreground flex flex-1 items-center justify-center gap-1 text-xs">
+        <LoaderCircleIcon className="size-3 animate-spin" />
+        Loading file changes…
+      </div>
+    );
+  }
+  if (loadError != null) {
+    return (
+      <div role="alert" className="text-destructive flex flex-1 items-center justify-center text-xs">
+        {loadError}
+      </div>
+    );
+  }
+  if (changes?.length === 0) {
+    return (
+      <div className="text-muted-foreground flex flex-1 items-center justify-center text-xs">
+        No recorded changes from this session.
+      </div>
+    );
+  }
+  if (changes == null) return null;
+
+  return (
+    <div className="flex-1 space-y-3 overflow-auto p-3">
+      {changes.map((change, changeIndex) => (
+        <section key={changeIndex} className="overflow-hidden rounded-lg border">
+          <div className="bg-muted flex items-center justify-between gap-2 border-b px-3 py-2 text-xs">
+            <span className="font-medium">{fileChangeLabel(change, changeIndex)}</span>
+            {change.kind === 'content' ? (
+              <span className="text-muted-foreground">Full content</span>
+            ) : (
+              <span className="flex gap-2">
+                <span className="text-success-fg">+{change.additions}</span>
+                <span className="text-destructive">−{change.deletions}</span>
+              </span>
+            )}
+          </div>
+          {change.kind === 'content' ? (
+            <pre className="overflow-auto p-3 font-mono text-xs leading-relaxed">{change.text}</pre>
+          ) : (
+            <pre className="overflow-auto py-2 font-mono text-xs leading-relaxed">
+              {change.text.split('\n').map((line, lineIndex) => {
+                const kind = diffLineKind(line);
+                return (
+                  <span
+                    key={lineIndex}
+                    className={cn('block min-w-max px-3', {
+                      'text-muted-foreground': kind === 'meta',
+                      'text-brand': kind === 'hunk',
+                      'bg-success-bg text-success-fg': kind === 'addition',
+                      'bg-destructive/10 text-destructive': kind === 'deletion',
+                    })}
+                  >
+                    {line || ' '}
+                  </span>
+                );
+              })}
+            </pre>
+          )}
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/pages/coslash/components/DiffList.tsx
+++ b/frontend/src/pages/coslash/components/DiffList.tsx
@@ -2,11 +2,10 @@ import { LoaderCircleIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { FileChange } from '@/pages/coslash/hooks/use-sessions';
 
-type DiffLineKind = 'meta' | 'hunk' | 'addition' | 'deletion' | 'context';
+type DiffLineKind = 'hunk' | 'addition' | 'deletion' | 'context';
 
 /* oxlint-disable react/only-export-components -- exported for focused rendering tests */
 export function diffLineKind(line: string): DiffLineKind {
-  if (line.startsWith('+++') || line.startsWith('---')) return 'meta';
   if (line.startsWith('@@')) return 'hunk';
   if (line.startsWith('+')) return 'addition';
   if (line.startsWith('-')) return 'deletion';
@@ -76,10 +75,9 @@ export function DiffList({
                   <span
                     key={lineIndex}
                     className={cn('block min-w-max px-3', {
-                      'text-muted-foreground': kind === 'meta',
                       'text-brand': kind === 'hunk',
                       'bg-success-bg text-success-fg': kind === 'addition',
-                      'bg-destructive/10 text-destructive': kind === 'deletion',
+                      'text-destructive bg-red-50 dark:bg-red-950': kind === 'deletion',
                     })}
                   >
                     {line || ' '}

--- a/frontend/src/pages/coslash/components/SessionInspector.tsx
+++ b/frontend/src/pages/coslash/components/SessionInspector.tsx
@@ -17,6 +17,7 @@ import { Dialog, DialogTrigger } from '@/components/ui/dialog';
 import { Sheet, SheetContent, SheetFooter, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { cn } from '@/lib/utils';
 import { CopyableBadge } from '@/pages/coslash/components/CopyableBadge';
+import { DiffList } from '@/pages/coslash/components/DiffList';
 import {
   SessionId,
   SessionName,
@@ -27,6 +28,7 @@ import {
 } from '@/pages/coslash/components/SessionCard';
 import { UnpricedModelWarning } from '@/pages/coslash/components/UnpricedModelWarning';
 import { useLaunchTerminal } from '@/pages/coslash/hooks/use-launch-terminal';
+import { useFileDiff, type FileSelection } from '@/pages/coslash/hooks/use-sessions';
 import { ApiAuthenticationError, apiFetch } from '@/pages/coslash/lib/api';
 import { formatDuration, formatEstimatedCost, formatTimeAgo, formatTokens } from '@/pages/coslash/lib/format';
 import { handoffBrief } from '@/pages/coslash/lib/handoff';
@@ -50,6 +52,12 @@ type SynthesisResponse = {
   synthesisPending: boolean;
   synthesisError?: string;
 };
+
+/* oxlint-disable react/only-export-components -- exported for focused rendering tests */
+export function filePanelOpen(selection: FileSelection | null, sessionId: string): boolean {
+  return selection?.sessionId === sessionId;
+}
+/* oxlint-enable react/only-export-components */
 
 function useSessionDetail(
   session: Session | null,
@@ -635,7 +643,13 @@ function ArtifactStats({ detail }: { detail: SessionDetail }) {
   );
 }
 
-function FilesChangedList({ detail }: { detail: SessionDetail }) {
+function FilesChangedList({
+  detail,
+  onSelectFile,
+}: {
+  detail: SessionDetail;
+  onSelectFile: (path: string) => void;
+}) {
   if (detail.fileEdits.length === 0) return null;
   const newFiles = detail.fileEdits.filter((fileEdit) => fileEdit.isNew).length;
   return (
@@ -644,14 +658,19 @@ function FilesChangedList({ detail }: { detail: SessionDetail }) {
       <div className="rounded-sm border p-2">
         {detail.fileEdits.map((fileEdit) => (
           <div key={fileEdit.path} className="flex items-center justify-between gap-2 py-1 font-mono text-xs">
-            <span
+            <button
+              type="button"
               title={fileEdit.path}
-              className={cn('text-muted-foreground min-w-0 truncate', {
-                'text-success-fg': fileEdit.isNew,
-              })}
+              className={cn(
+                'text-muted-foreground min-w-0 cursor-pointer truncate text-left hover:underline',
+                {
+                  'text-success-fg': fileEdit.isNew,
+                },
+              )}
+              onClick={() => onSelectFile(fileEdit.path)}
             >
               {fileEdit.path.split('/').pop()}
-            </span>
+            </button>
             <span className="whitespace-nowrap">
               <span className="text-success-fg">+{fileEdit.adds}</span>{' '}
               <span className="text-destructive">−{fileEdit.dels}</span>{' '}
@@ -733,7 +752,13 @@ function CommandsSection({ detail }: { detail: SessionDetail }) {
   );
 }
 
-function InspectorBody({ detail }: { detail: SessionDetail }) {
+function InspectorBody({
+  detail,
+  onSelectFile,
+}: {
+  detail: SessionDetail;
+  onSelectFile: (path: string) => void;
+}) {
   // scroll on the outer div, layout on the inner one — flex children of a
   // scroll container shrink to fit instead of overflowing, which collapses
   // the overflow-hidden stat grids
@@ -745,7 +770,7 @@ function InspectorBody({ detail }: { detail: SessionDetail }) {
         <DigestSection detail={detail} />
         <ArtifactStats detail={detail} />
         <CommandsSection detail={detail} />
-        <FilesChangedList detail={detail} />
+        <FilesChangedList detail={detail} onSelectFile={onSelectFile} />
         <CommitsAndTodos detail={detail} />
       </div>
     </div>
@@ -779,13 +804,22 @@ export function SessionInspector({
 }) {
   const { detail, loadError } = useSessionDetail(session, sessionsVersion, synthesisSettingsKey);
   const contentRef = useRef<HTMLDivElement>(null);
+  const [selectedDiff, setSelectedDiff] = useState<FileSelection | null>(null);
+  const {
+    changes: fileChanges,
+    isLoading: fileDiffLoading,
+    loadError: fileDiffError,
+  } = useFileDiff(selectedDiff);
   const isOpen = session != null;
 
   return (
     <Sheet
       open={isOpen}
       onOpenChange={(open) => {
-        if (!open) onClose();
+        if (!open) {
+          setSelectedDiff(null);
+          onClose();
+        }
       }}
     >
       <SheetContent
@@ -818,11 +852,38 @@ export function SessionInspector({
                 {loadError}
               </div>
             )}
-            <InspectorBody detail={detail} />
+            <InspectorBody
+              detail={detail}
+              onSelectFile={(path) => setSelectedDiff({ sessionId: detail.id, path })}
+            />
             <InspectorFooter detail={detail} />
           </>
         )}
       </SheetContent>
+      <Sheet
+        open={filePanelOpen(selectedDiff, detail?.id ?? '')}
+        onOpenChange={(open) => {
+          if (!open) setSelectedDiff(null);
+        }}
+      >
+        <SheetContent className="w-1/2! max-w-none! gap-0" showCloseButton={true}>
+          {selectedDiff != null && (
+            <>
+              <SheetHeader className="border-b">
+                <div className="flex min-w-0 items-center gap-2 pr-10">
+                  <span className="text-brand shrink-0 text-xs font-semibold tracking-wide">
+                    FILE CHANGES
+                  </span>
+                  <SheetTitle className="min-w-0 flex-1 truncate font-mono text-xs" title={selectedDiff.path}>
+                    {selectedDiff.path}
+                  </SheetTitle>
+                </div>
+              </SheetHeader>
+              <DiffList changes={fileChanges} isLoading={fileDiffLoading} loadError={fileDiffError} />
+            </>
+          )}
+        </SheetContent>
+      </Sheet>
     </Sheet>
   );
 }

--- a/frontend/src/pages/coslash/hooks/use-sessions.ts
+++ b/frontend/src/pages/coslash/hooks/use-sessions.ts
@@ -7,6 +7,58 @@ import { timeWindowStart, type TimeWindow } from '@/pages/coslash/lib/time-windo
 // Background refresh keeps statuses and "ago" times current.
 const REFRESH_INTERVAL_MS = MINUTE;
 
+export type FileSelection = { sessionId: string; path: string };
+export type FileChange = {
+  kind: 'diff' | 'content';
+  text: string;
+  operation: string;
+  additions: number;
+  deletions: number;
+};
+
+export function diffRequestPath(selection: FileSelection) {
+  return `/api/diff?${new URLSearchParams({ id: selection.sessionId, path: selection.path })}`;
+}
+
+export function useFileDiff(selection: FileSelection | null) {
+  const [loaded, setLoaded] = useState<
+    (FileSelection & { changes: FileChange[] | null; loadError: string | null }) | null
+  >(null);
+
+  useEffect(() => {
+    if (selection == null) return;
+    const controller = new AbortController();
+
+    apiFetch(diffRequestPath(selection), { signal: controller.signal })
+      .then((response) => {
+        if (!response.ok) throw new Error(`Diff request failed (${response.status})`);
+        return response.json() as Promise<{ changes: FileChange[] }>;
+      })
+      .then(({ changes }) => {
+        if (!controller.signal.aborted) setLoaded({ ...selection, changes, loadError: null });
+      })
+      .catch(() => {
+        if (!controller.signal.aborted) {
+          setLoaded({
+            ...selection,
+            changes: null,
+            loadError: 'Could not load this session’s file changes.',
+          });
+        }
+      });
+
+    return () => controller.abort();
+  }, [selection]);
+
+  const isCurrent =
+    selection != null && loaded?.sessionId === selection.sessionId && loaded.path === selection.path;
+  return {
+    changes: isCurrent ? loaded.changes : null,
+    isLoading: selection != null && !isCurrent,
+    loadError: isCurrent ? loaded.loadError : null,
+  };
+}
+
 export function useSessions(timeWindow: TimeWindow) {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [isLoading, setIsLoading] = useState(true);


### PR DESCRIPTION
## Context

The session inspector lists edited files but does not show the changes that produced them. This adds a per-file view backed by recorded session edits instead of the current working tree. Changes remain in session order, while file writes show their full content.

## Changes

- Make edited filenames clickable and open a dedicated file-changes panel over the inspector
- Show sequential edits with colored lines and addition/deletion statistics
- Preserve recorded changes from Claude, Codex, and OpenCode, including accurate OpenCode replacement patches
- Add a session-scoped `/api/diff` endpoint with loading, empty, and error states

## Test

- `go test ./cmd/coslash -count=1` — passed
- `go build ./...` — passed
- `npm test` — passed
- `npm run build` — passed
- Manual: not run after restarting the collector

### Screenshots

- [x] Session inspector — clickable file list and overlaid sequential diff panel
<img width="1165" height="1371" alt="Screenshot 2026-08-13 at 16 29 01" src="https://github.com/user-attachments/assets/aaf54d36-ec72-4b8c-88e8-10ba974bdb79" />
