### PR TITLE
Fix OpenCode waiting and live session statuses

### DIFF
--- a/collector/internal/collector/collector.go
+++ b/collector/internal/collector/collector.go
@@ -168,6 +168,10 @@ func groupSubagents(
 			log.Printf("%s: parent %s not found, dropping child", p.Session.ID, p.ParentID)
 			continue
 		}
+		if deref(p.Session.Status) == "waiting" {
+			status := "waiting"
+			parent.Session.Status = &status
+		}
 		subagent := subagentFrom(
 			p,
 			parent,
@@ -298,6 +302,9 @@ func resolveStatus(
 	now := time.Now().UnixMilli()
 	for _, p := range roots {
 		s := p.Session
+		if deref(s.Status) == "waiting" {
+			continue
+		}
 		if raw, live := metadata[s.Agent].Live[s.ID]; live {
 			status := raw
 			if raw == "interactive" {

--- a/collector/internal/vendors/opencode/metadata.go
+++ b/collector/internal/vendors/opencode/metadata.go
@@ -13,7 +13,6 @@ import (
 )
 
 const (
-	newSessionWindow     = time.Minute
 	resumedSessionWindow = 3 * time.Minute
 )
 
@@ -229,7 +228,7 @@ func matchLiveSessions(processes []tuiProcess, candidates []liveCandidate) map[s
 		process tuiProcess, candidate liveCandidate,
 	) bool {
 		delta := candidate.createdAt - process.startedAt
-		return delta >= -time.Second.Milliseconds() && delta <= newSessionWindow.Milliseconds()
+		return delta >= -time.Second.Milliseconds()
 	})
 	matchUnique(processes, candidates, matchedProcesses, matchedSessions, func(
 		process tuiProcess, candidate liveCandidate,

--- a/collector/internal/vendors/opencode/source.go
+++ b/collector/internal/vendors/opencode/source.go
@@ -273,6 +273,7 @@ func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 	hasContext := false
 	activeDuration := int64(0)
 	busy := false
+	waiting := false
 	commits := []string{}
 	pullRequests := 0
 	fileEdits := session.NewFileEditSet()
@@ -366,7 +367,12 @@ func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 				}
 				if part.Tool != "task" &&
 					(part.State.Status == "pending" || part.State.Status == "running") {
-					busy = true
+					if part.Tool == "question" && part.State.Status == "running" &&
+						len(part.State.Input.Questions) > 0 {
+						waiting = true
+					} else {
+						busy = true
+					}
 				}
 				if part.Tool == "task" {
 					childID := part.State.Metadata.SessionID
@@ -567,6 +573,10 @@ func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 		status := "busy"
 		result.Status = &status
 	}
+	if waiting {
+		status := "waiting"
+		result.Status = &status
+	}
 	if summary != "" {
 		value := session.Truncate(summary, session.TruncateTextLimit)
 		result.Summary = &value
@@ -580,7 +590,7 @@ func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 			Session:    result,
 			ParentID:   row.parentID.String,
 			Name:       row.title,
-			InTurn:     busy,
+			InTurn:     busy || waiting,
 			SpawnTurns: spawnTurns,
 			Completed:  completed,
 			Commands:   commands.Labelled(),


### PR DESCRIPTION
## Context

OpenCode sessions with unanswered questions were shown as active instead of waiting for user input. Sessions could also appear inactive when their first activity occurred more than one minute after the TUI launched.

## Changes

- Show unanswered OpenCode questions as Waiting, while answered questions and other running tools retain their existing states.
- Propagate child waiting state to the root session and preserve it during live-status refinement.
- Keep uniquely matched OpenCode sessions live when first activity occurs after the previous one-minute launch window.

## Test

- `go test source.go types.go sqlite.go metadata.go waiting_test.go` — passed
- `go test collector.go helpers.go waiting_test.go` — passed
- `git diff --check origin/main...HEAD` — passed
- Manual: unanswered OpenCode question displayed Waiting on you.

### Screenshots

- [x] Session board — unanswered OpenCode question shown as Waiting
<img width="2762" height="1440" alt="Screenshot 2026-08-13 at 17 03 06" src="https://github.com/user-attachments/assets/ea237e0c-47c8-4b35-9a40-98d2302f1338" />
