### PR TITLE
Fix Codex subagent filtering and inspector entries

### DIFF
--- a/collector/internal/vendors/codex/parse.go
+++ b/collector/internal/vendors/codex/parse.go
@@ -71,6 +71,17 @@ func (analysis *codexSessionAnalysis) noteFileChanges(changes codexPatchChanges)
 	}
 }
 
+func (analysis *codexSessionAnalysis) noteSubagentStarted(id string) {
+	if id == "" {
+		return
+	}
+	if _, exists := analysis.spawnTurns[id]; exists {
+		return
+	}
+	analysis.spawnTurns[id] = max(analysis.prompts, 1)
+	analysis.digest.PushSubagent(analysis.prompts, id)
+}
+
 func completedItemText(item codexItem) string {
 	text := make([]string, 0, len(item.Content))
 	for _, content := range item.Content {
@@ -187,9 +198,8 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 				case "FileChange":
 					analysis.noteFileChanges(item.Changes)
 				case "SubAgentActivity":
-					if item.Kind == "started" && item.AgentThreadID != "" {
-						analysis.spawnTurns[item.AgentThreadID] = max(analysis.prompts, 1)
-						analysis.digest.PushSubagent(analysis.prompts, item.AgentThreadID)
+					if item.Kind == "started" {
+						analysis.noteSubagentStarted(item.AgentThreadID)
 					}
 				}
 			case "user_message":
@@ -213,9 +223,8 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 			case "exited_review_mode":
 				analysis.inReview = false
 			case "sub_agent_activity":
-				if row.Payload.Kind == "started" && row.Payload.AgentThreadID != "" {
-					analysis.spawnTurns[row.Payload.AgentThreadID] = max(analysis.prompts, 1)
-					analysis.digest.PushSubagent(analysis.prompts, row.Payload.AgentThreadID)
+				if row.Payload.Kind == "started" {
+					analysis.noteSubagentStarted(row.Payload.AgentThreadID)
 				}
 			case "agent_message":
 				if row.Payload.Phase == "final_answer" || row.Payload.Phase == "" {

--- a/collector/internal/vendors/codex/parse.go
+++ b/collector/internal/vendors/codex/parse.go
@@ -16,6 +16,7 @@ type codexSessionAnalysis struct {
 	sessionID        string
 	forkedFromID     string
 	parentThreadID   string
+	subagentRole     string
 	agentNickname    string
 	taskName         string
 	workingDirectory string
@@ -95,6 +96,9 @@ func Parse(path string) (*vendors.ParsedTranscript, error) {
 	if err != nil {
 		return nil, err
 	}
+	if analysis.subagentRole == "guardian" {
+		return nil, nil
+	}
 	parsed := &vendors.ParsedTranscript{
 		Session:    analysis.unifiedSession(path),
 		ParentID:   analysis.parentThreadID,
@@ -153,6 +157,7 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 				sessionID:        row.Payload.SessionID,
 				forkedFromID:     row.Payload.ForkedFromID,
 				parentThreadID:   row.Payload.ParentThreadID,
+				subagentRole:     subagentRole(row.Payload.Source),
 				agentNickname:    row.Payload.AgentNickname,
 				workingDirectory: row.Payload.Cwd,
 				entrypoint:       row.Payload.Originator,
@@ -181,6 +186,11 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 					}
 				case "FileChange":
 					analysis.noteFileChanges(item.Changes)
+				case "SubAgentActivity":
+					if item.Kind == "started" && item.AgentThreadID != "" {
+						analysis.spawnTurns[item.AgentThreadID] = max(analysis.prompts, 1)
+						analysis.digest.PushSubagent(analysis.prompts, item.AgentThreadID)
+					}
 				}
 			case "user_message":
 				if analysis.inReview {
@@ -292,6 +302,7 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 	analysis.sessionID = own.sessionID
 	analysis.forkedFromID = own.forkedFromID
 	analysis.parentThreadID = own.parentThreadID
+	analysis.subagentRole = own.subagentRole
 	analysis.agentNickname = own.agentNickname
 	analysis.workingDirectory = own.workingDirectory
 	analysis.branch = nil

--- a/collector/internal/vendors/codex/types.go
+++ b/collector/internal/vendors/codex/types.go
@@ -36,6 +36,7 @@ type codexPayload struct {
 	Content        json.RawMessage   `json:"content"`
 	ParentThreadID string            `json:"parent_thread_id"`
 	ThreadSource   string            `json:"thread_source"`
+	Source         json.RawMessage   `json:"source"`
 	AgentNickname  string            `json:"agent_nickname"`
 	AgentThreadID  string            `json:"agent_thread_id"`
 	Kind           string            `json:"kind"`
@@ -43,10 +44,24 @@ type codexPayload struct {
 }
 
 type codexItem struct {
-	Type    string            `json:"type"`
-	Phase   string            `json:"phase"`
-	Content []codexText       `json:"content"`
-	Changes codexPatchChanges `json:"changes"`
+	Type          string            `json:"type"`
+	Phase         string            `json:"phase"`
+	Content       []codexText       `json:"content"`
+	Changes       codexPatchChanges `json:"changes"`
+	Kind          string            `json:"kind"`
+	AgentThreadID string            `json:"agent_thread_id"`
+}
+
+func subagentRole(source json.RawMessage) string {
+	var parsed struct {
+		Subagent struct {
+			Other string `json:"other"`
+		} `json:"subagent"`
+	}
+	if json.Unmarshal(source, &parsed) != nil {
+		return ""
+	}
+	return parsed.Subagent.Other
 }
 
 type codexText struct {
@@ -156,6 +171,7 @@ type codexMeta struct {
 	sessionID        string
 	forkedFromID     string
 	parentThreadID   string
+	subagentRole     string
 	agentNickname    string
 	workingDirectory string
 	branch           string


### PR DESCRIPTION
## Context

Codex transcripts can include internal permission-review child sessions and newer nested subagent activity events. The collector exposed internal checks as delegated work while omitting some genuine subagents from the session inspector.

## Changes

- Exclude internal permission-review sessions using structured source metadata.
- Record nested subagent start events so genuine subagents appear consistently in the rail and inspector.
- Preserve root sessions and genuine thread-spawned subagents.

## Test

- `go test internal/vendors/codex/discovery.go internal/vendors/codex/fork.go internal/vendors/codex/metadata.go internal/vendors/codex/parse.go internal/vendors/codex/types.go internal/vendors/codex/parse_test.go -count=1` — passed
- `go build ./...` — passed
- `git diff --check` — passed

### Screenshots

- [x] Session views — genuine subagent appears in both the rail and inspector
<img width="1040" height="810" alt="Screenshot 2026-08-14 at 13 43 21" src="https://github.com/user-attachments/assets/ff76f9b9-8d71-4089-8d1b-11fa7fd6634f" />

- [x] Permission review — internal check is absent from both views
before
<img width="2317" height="753" alt="Screenshot 2026-08-14 at 13 42 23" src="https://github.com/user-attachments/assets/0acca581-42b6-497a-8934-58438622c3c1" />

after
<img width="2320" height="1413" alt="Screenshot 2026-08-14 at 13 42 07" src="https://github.com/user-attachments/assets/26d8d71d-5c7f-47e2-8dbc-32ba73f65a1a" />
