### PR TITLE
Show only surviving commits in session inspector

### DIFF
--- a/collector/internal/collector/collector.go
+++ b/collector/internal/collector/collector.go
@@ -297,6 +297,9 @@ func probeGitEnvironment(roots []*vendors.ParsedSession) {
 	wg.Wait()
 	for _, p := range roots {
 		s := p.Session
+		s.Commits = session.ReconcileCommits(
+			s.CommitLog, s.WorkingDirectory, s.Branch,
+		)
 		s.GitProbed = true // synthesis's lazy probe must not redo this
 		if s.WorkingDirectory == "" {
 			continue

--- a/collector/internal/collector/collector.go
+++ b/collector/internal/collector/collector.go
@@ -295,9 +295,10 @@ func probeGitEnvironment(roots []*vendors.ParsedSession) {
 		}()
 	}
 	wg.Wait()
+	reconcileCommits := session.NewCommitReconciler()
 	for _, p := range roots {
 		s := p.Session
-		s.Commits = session.ReconcileCommits(
+		s.Commits = reconcileCommits(
 			s.CommitLog, s.WorkingDirectory, s.Branch,
 		)
 		s.GitProbed = true // synthesis's lazy probe must not redo this

--- a/collector/internal/session/commits.go
+++ b/collector/internal/session/commits.go
@@ -103,11 +103,41 @@ type repositoryCommit struct {
 	subject string
 }
 
+// NewCommitReconciler caches repository history for one reconciliation pass.
+func NewCommitReconciler() func([]CommitObservation, string, *string) []string {
+	type cacheKey struct{ cwd, branch string }
+	type cachedHistory struct {
+		commits []repositoryCommit
+		ok      bool
+	}
+	histories := map[cacheKey]cachedHistory{}
+	return func(observations []CommitObservation, cwd string, branch *string) []string {
+		if len(observations) == 0 {
+			return []string{}
+		}
+		branchName := ""
+		if branch != nil {
+			branchName = strings.TrimSpace(*branch)
+		}
+		key := cacheKey{cwd: cwd, branch: branchName}
+		history, found := histories[key]
+		if !found {
+			history.commits, history.ok = repositoryHistory(cwd, branch)
+			histories[key] = history
+		}
+		return reconcileCommits(observations, history.commits, history.ok)
+	}
+}
+
 func ReconcileCommits(observations []CommitObservation, cwd string, branch *string) []string {
 	if len(observations) == 0 {
 		return []string{}
 	}
 	history, ok := repositoryHistory(cwd, branch)
+	return reconcileCommits(observations, history, ok)
+}
+
+func reconcileCommits(observations []CommitObservation, history []repositoryCommit, ok bool) []string {
 	if !ok {
 		return fallbackCommitMessages(observations)
 	}

--- a/collector/internal/session/commits.go
+++ b/collector/internal/session/commits.go
@@ -1,12 +1,13 @@
 package session
 
 import (
+	"os/exec"
 	"regexp"
 	"strings"
 )
 
-// git commit as a complete command word, excludes plumbing commands (i.e.  commit-tree)
-var gitCommitCommand = regexp.MustCompile(`(?:^|[\n;&|])\s*(?:rtk\s+)?git\s+commit(?:$|[\s;&|])`)
+// git commit as complete command words anywhere in a shell segment; excludes commit-tree.
+var gitCommitCommand = regexp.MustCompile(`(?:^|[\n;&|])[^\n;&|]*?(\bgit\s+commit)(?:$|[\s;&|])`)
 
 // -m, --message, or a combined short flag such as -am, single or double-quoted
 var commitMessage = regexp.MustCompile(`(?:--message|-[a-zA-Z]*m)[=\s]*(?:"([^"]+)"|'([^']+)')`)
@@ -16,30 +17,145 @@ var commitFileFlag = regexp.MustCompile(`(?:--file|-[a-zA-Z]*F)[=\s]+(\S+)`)
 
 var commitAmend = regexp.MustCompile(`--amend\b`)
 
+var commitHashToken = regexp.MustCompile(`(?:^|[^0-9a-fA-F])([0-9a-fA-F]{7,64})(?:$|[^0-9a-fA-F])`)
+
 // multilineBlockOpener matches the start of a shell here-document (<<EOF, <<'EOF', <<"EOF", <<-EOF)
 var multilineBlockOpener = regexp.MustCompile(`<<-?\s*['"]?(\w+)['"]?`)
 
-func CommitMessage(command string) (string, bool) {
-	matchIndices := gitCommitCommand.FindStringIndex(command)
-	if matchIndices == nil {
-		return "", false
+type CommitObservation struct {
+	Hash    string
+	Subject string
+	Amend   bool
+}
+
+func ParseCommitObservations(command, output string, succeeded bool) []CommitObservation {
+	invocations := commitInvocations(command)
+	hashes := commitOutputHashes(output)
+	if len(invocations) == len(hashes) {
+		for i := range invocations {
+			invocations[i].Hash = hashes[i]
+		}
+		return invocations
 	}
-	// only match after git commit command, discard everything before
-	tail := command[matchIndices[0]:]
-	if subject := commitSubject(tail); subject != "" {
-		return subject, true
+	if succeeded {
+		return invocations
 	}
-	// the flags of this invocation alone, so that a later `git commit --amend` in
-	// the same script cannot suppress the commit that this one creates. The match
-	// ends on the separator or space after `commit`, so keep that byte.
-	flags := command[matchIndices[1]-1:]
-	if end := strings.IndexAny(flags, ";&|\n"); end >= 0 {
-		flags = flags[:end]
+	return []CommitObservation{}
+}
+
+func commitOutputHashes(output string) []string {
+	hashes := []string{}
+	for _, match := range commitHashToken.FindAllStringSubmatch(output, -1) {
+		hashes = append(hashes, match[1])
 	}
-	if commitAmend.MatchString(flags) {
-		return "", false
+	return hashes
+}
+
+func commitInvocations(command string) []CommitObservation {
+	matches := gitCommitCommand.FindAllStringSubmatchIndex(command, -1)
+	observations := make([]CommitObservation, 0, len(matches))
+	for i, match := range matches {
+		end := len(command)
+		if i+1 < len(matches) {
+			end = matches[i+1][0]
+		}
+		invocation := command[match[2]:end]
+		subject := commitSubject(invocation)
+		if subject == "" {
+			subject = "(commit)"
+		}
+		observations = append(observations, CommitObservation{
+			Subject: subject,
+			Amend:   commitAmend.MatchString(invocation),
+		})
 	}
-	return "(commit)", true
+	return observations
+}
+
+type repositoryCommit struct {
+	hash    string
+	subject string
+}
+
+func ReconcileCommits(observations []CommitObservation, cwd string, branch *string) []string {
+	if len(observations) == 0 {
+		return []string{}
+	}
+	history, ok := repositoryHistory(cwd, branch)
+	if !ok {
+		return fallbackCommitMessages(observations)
+	}
+	resolved := make([]int, len(observations))
+	for i := range resolved {
+		resolved[i] = -1
+	}
+	used := make([]bool, len(history))
+	for i, observation := range observations {
+		if observation.Hash == "" {
+			continue
+		}
+		for j, commit := range history {
+			if !used[j] && strings.HasPrefix(commit.hash, observation.Hash) &&
+				(observation.Subject == "(commit)" || commit.subject == observation.Subject) {
+				resolved[i], used[j] = j, true
+				break
+			}
+		}
+	}
+	for i, observation := range observations {
+		if resolved[i] >= 0 {
+			continue
+		}
+		for j, commit := range history {
+			if !used[j] && commit.subject == observation.Subject {
+				resolved[i], used[j] = j, true
+				break
+			}
+		}
+	}
+	messages := []string{}
+	for _, index := range resolved {
+		if index >= 0 {
+			messages = append(messages, history[index].subject)
+		}
+	}
+	return messages
+}
+
+func repositoryHistory(cwd string, branch *string) ([]repositoryCommit, bool) {
+	if cwd == "" {
+		return nil, false
+	}
+	ref := "HEAD"
+	if branch != nil && strings.TrimSpace(*branch) != "" {
+		ref = strings.TrimSpace(*branch)
+	}
+	output, err := exec.Command(
+		"git", "-C", cwd, "log", "--format=%H%x00%s", ref, "--",
+	).Output()
+	if err != nil {
+		return nil, false
+	}
+	history := []repositoryCommit{}
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		hash, subject, found := strings.Cut(line, "\x00")
+		if found && hash != "" {
+			history = append(history, repositoryCommit{hash: hash, subject: subject})
+		}
+	}
+	return history, true
+}
+
+func fallbackCommitMessages(observations []CommitObservation) []string {
+	messages := []string{}
+	for _, observation := range observations {
+		if observation.Amend && len(messages) > 0 {
+			messages[len(messages)-1] = observation.Subject
+			continue
+		}
+		messages = append(messages, observation.Subject)
+	}
+	return messages
 }
 
 func commitSubject(command string) string {

--- a/collector/internal/session/commits.go
+++ b/collector/internal/session/commits.go
@@ -176,12 +176,16 @@ func commitSubject(command string) string {
 		return ""
 	}
 	match := commitMessage.FindStringSubmatch(command)
+	doubleQuoted := match[1] != ""
 	message := match[1] // double quote message
 	if message == "" {
 		message = match[2] // single quote message
 	}
 	if body, ok := unwrapMultilineMessage(message); ok {
-		message = body
+		return firstLine(body)
+	}
+	if doubleQuoted && strings.ContainsAny(message, "$`") {
+		return ""
 	}
 	return firstLine(message)
 }

--- a/collector/internal/session/commits.go
+++ b/collector/internal/session/commits.go
@@ -134,6 +134,10 @@ func repositoryHistory(cwd string, branch *string) ([]repositoryCommit, bool) {
 		"git", "-C", cwd, "log", "--format=%H%x00%s", ref, "--",
 	).Output()
 	if err != nil {
+		if !gitRefExists(cwd, ref) &&
+			exec.Command("git", "-C", cwd, "rev-parse", "--git-dir").Run() == nil {
+			return []repositoryCommit{}, true
+		}
 		return nil, false
 	}
 	history := []repositoryCommit{}

--- a/collector/internal/session/commits.go
+++ b/collector/internal/session/commits.go
@@ -6,8 +6,10 @@ import (
 	"strings"
 )
 
-// git commit as complete command words anywhere in a shell segment; excludes commit-tree.
-var gitCommitCommand = regexp.MustCompile(`(?:^|[\n;&|])[^\n;&|]*?(\bgit\s+commit)(?:$|[\s;&|])`)
+// git commit at shell command position; excludes commit-tree and argument text.
+var gitCommitCommand = regexp.MustCompile(
+	`(?:^|[\n;&|])[ \t]*(?:rtk[ \t]+)?(git[ \t]+commit)(?:$|[ \t][^\n;&|]*)`,
+)
 
 // -m, --message, or a combined short flag such as -am, single or double-quoted
 var commitMessage = regexp.MustCompile(`(?:--message|-[a-zA-Z]*m)[=\s]*(?:"([^"]+)"|'([^']+)')`)
@@ -52,14 +54,10 @@ func commitOutputHashes(output string) []string {
 }
 
 func commitInvocations(command string) []CommitObservation {
-	matches := gitCommitCommand.FindAllStringSubmatchIndex(command, -1)
+	matches := gitCommitCommand.FindAllStringSubmatchIndex(maskQuotedShellText(command), -1)
 	observations := make([]CommitObservation, 0, len(matches))
-	for i, match := range matches {
-		end := len(command)
-		if i+1 < len(matches) {
-			end = matches[i+1][0]
-		}
-		invocation := command[match[2]:end]
+	for _, match := range matches {
+		invocation := command[match[2]:match[1]]
 		subject := commitSubject(invocation)
 		if subject == "" {
 			subject = "(commit)"
@@ -70,6 +68,34 @@ func commitInvocations(command string) []CommitObservation {
 		})
 	}
 	return observations
+}
+
+func maskQuotedShellText(command string) string {
+	masked := []byte(command)
+	var quote byte
+	for i := 0; i < len(masked); i++ {
+		char := masked[i]
+		if quote != '\'' && char == '\\' {
+			masked[i] = ' '
+			i++
+			if i < len(masked) {
+				masked[i] = ' '
+			}
+			continue
+		}
+		if quote != 0 {
+			masked[i] = ' '
+			if char == quote {
+				quote = 0
+			}
+			continue
+		}
+		if char == '\'' || char == '"' {
+			quote = char
+			masked[i] = ' '
+		}
+	}
+	return string(masked)
 }
 
 type repositoryCommit struct {

--- a/collector/internal/session/session.go
+++ b/collector/internal/session/session.go
@@ -56,6 +56,7 @@ type Session struct {
 	StartedAt           int64                  `json:"-"`
 	LastActivityTime    int64                  `json:"mtime"`
 	Entrypoint          *string                `json:"entrypoint"`
+	CommitLog           []CommitObservation    `json:"-"`
 	SessionDetails
 }
 

--- a/collector/internal/sessionexport/allowlist_test.go
+++ b/collector/internal/sessionexport/allowlist_test.go
@@ -48,6 +48,7 @@ var census = map[string]decision{
 	"Compactions":      {true, "session.counts.compactions"},
 	"FirstPrompt":      {true, "bounded session.firstPrompt"},
 	"Commands":         {false, "raw commands never cross; only len() as session.counts.commands"},
+	"CommitLog":        {false, "local commit observations used for git reconciliation"},
 	"Commits":          {true, "bounded commit subjects"},
 	"PullRequests":     {true, "session.counts.pullRequests"},
 	"Todos":            {true, "bounded session.todos"},

--- a/collector/internal/vendors/claude/parse.go
+++ b/collector/internal/vendors/claude/parse.go
@@ -38,7 +38,7 @@ type claudeSessionAnalysis struct {
 	spawns                   map[string]vendors.SpawnState
 	editedFiles              map[string]struct{}
 	commands                 session.CommandLog
-	commits                  []string
+	commitLog                []session.CommitObservation
 	dedupedMessageTokenUsage map[string]messageUsage
 	tokens                   map[string]session.ModelTokens
 	fileEdits                *session.FileEditSet
@@ -100,6 +100,56 @@ func parse(path string) (*parsedSession, error) {
 	return &parsedSession{transcript: parsed, forkUsage: analysis.dedupedMessageTokenUsage}, nil
 }
 
+func commitObservationsByToolUse(rows []claudeSessionRecord) []session.CommitObservation {
+	commands := map[string]string{}
+	observations := []session.CommitObservation{}
+	for _, row := range rows {
+		if row.Message == nil {
+			continue
+		}
+		blocks, err := row.Message.contentBlocks()
+		if err != nil {
+			continue
+		}
+		for _, block := range blocks {
+			if block.Type == "tool_use" && block.ID != "" && block.Input.Command != "" {
+				commands[block.ID] = block.Input.Command
+				continue
+			}
+			if block.Type != "tool_result" || block.ToolUseID == "" {
+				continue
+			}
+			command, ok := commands[block.ToolUseID]
+			if !ok {
+				continue
+			}
+			observations = append(observations, session.ParseCommitObservations(
+				command, claudeToolOutput(block.Content), !block.IsError,
+			)...)
+			delete(commands, block.ToolUseID)
+		}
+	}
+	return observations
+}
+
+func claudeToolOutput(raw json.RawMessage) string {
+	var text string
+	if json.Unmarshal(raw, &text) == nil {
+		return text
+	}
+	var blocks []contentBlock
+	if json.Unmarshal(raw, &blocks) == nil {
+		parts := make([]string, 0, len(blocks))
+		for _, block := range blocks {
+			if block.Text != "" {
+				parts = append(parts, block.Text)
+			}
+		}
+		return strings.Join(parts, "\n")
+	}
+	return string(raw)
+}
+
 func analyzeClaudeSession(file string) (*claudeSessionAnalysis, error) {
 	rows, err := session.ParseJSONL[claudeSessionRecord](file)
 	if err != nil {
@@ -117,7 +167,7 @@ func analyzeClaudeSession(file string) (*claudeSessionAnalysis, error) {
 		tokens:                   map[string]session.ModelTokens{},
 		tasks:                    map[string]*taskEntry{},
 		fileEdits:                session.NewFileEditSet(),
-		commits:                  []string{},
+		commitLog:                commitObservationsByToolUse(rows),
 	}
 	pendingAssistantText := ""
 	pendingCommand := ""
@@ -279,9 +329,6 @@ func analyzeClaudeSession(file string) (*claudeSessionAnalysis, error) {
 				}
 				if block.Input.Command != "" {
 					analysis.commands.Note(block.Input.Command, block.Input.Description)
-					if message, ok := session.CommitMessage(block.Input.Command); ok {
-						analysis.commits = append(analysis.commits, message)
-					}
 				}
 			}
 			if row.Message.ID != "" && row.Message.Usage != nil &&
@@ -403,7 +450,7 @@ func (analysis *claudeSessionAnalysis) unifiedSession(filePath string) *session.
 		ToolUses:       analysis.toolUseCount,
 		Errors:         analysis.errors,
 		Commands:       analysis.commands.Raw(),
-		Commits:        analysis.commits,
+		Commits:        session.ReconcileCommits(analysis.commitLog, "", nil),
 		FileEdits:      analysis.fileEdits.Edits,
 		Digest:         analysis.digest.Entries(),
 		ContextTokens:  contextTokens(analysis.lastUsage),
@@ -426,6 +473,7 @@ func (analysis *claudeSessionAnalysis) unifiedSession(filePath string) *session.
 		WorkingDirectory: analysis.workingDirectory,
 		Branch:           analysis.branch,
 		Entrypoint:       analysis.entrypoint,
+		CommitLog:        analysis.commitLog,
 		SessionDetails:   unifiedSessionDetails,
 		StartedAt:        analysis.timestamps.Earliest,
 		LastActivityTime: analysis.timestamps.Latest,

--- a/collector/internal/vendors/codex/parse.go
+++ b/collector/internal/vendors/codex/parse.go
@@ -36,7 +36,7 @@ type codexSessionAnalysis struct {
 	spawns           map[string]vendors.SpawnState
 	tokenSamples     []codexTokenSample
 	commands         session.CommandLog
-	commits          []string
+	commitLog        []session.CommitObservation
 	pullRequests     int
 	fileEdits        *session.FileEditSet
 	digest           session.DigestLog
@@ -168,7 +168,7 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 	analysis := &codexSessionAnalysis{
 		spawns:    map[string]vendors.SpawnState{},
 		fileEdits: session.NewFileEditSet(),
-		commits:   []string{},
+		commitLog: commitObservationsByCall(rows),
 	}
 	for _, row := range rows {
 		var timestamp *int64
@@ -320,9 +320,6 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 				analysis.toolUseCount++
 				if command, ok := commandFrom(row.Payload); ok {
 					analysis.commands.Note(command, "")
-					if message, ok := session.CommitMessage(command); ok {
-						analysis.commits = append(analysis.commits, message)
-					}
 					if session.IsPullRequestCreate(command) {
 						analysis.pullRequests++
 					}
@@ -415,7 +412,7 @@ func (analysis *codexSessionAnalysis) unifiedSession(filePath string) *session.S
 		Compactions:  analysis.compactions,
 		Errors:       0, // Codex does not report exit code (may change in the future)
 		Commands:     analysis.commands.Raw(),
-		Commits:      analysis.commits,
+		Commits:      session.ReconcileCommits(analysis.commitLog, "", nil),
 		PullRequests: analysis.pullRequests,
 		FileEdits:    analysis.fileEdits.Edits,
 		Digest:       analysis.digest.Entries(),
@@ -432,6 +429,7 @@ func (analysis *codexSessionAnalysis) unifiedSession(filePath string) *session.S
 		WorkingDirectory: analysis.workingDirectory,
 		Branch:           analysis.branch,
 		Entrypoint:       analysis.entrypoint,
+		CommitLog:        analysis.commitLog,
 		StartedAt:        analysis.timestamps.Earliest,
 		LastActivityTime: analysis.timestamps.Latest,
 		EditedFileCount:  len(analysis.fileEdits.Edits),
@@ -694,6 +692,75 @@ func questionAnswersByCall(rows []codexRow) map[string]map[string]codexQuestionA
 		}
 	}
 	return answersByCall
+}
+
+type codexCommandResult struct {
+	output    string
+	succeeded bool
+}
+
+func commitObservationsByCall(rows []codexRow) []session.CommitObservation {
+	commands := map[string]string{}
+	observations := []session.CommitObservation{}
+	for _, row := range rows {
+		if row.Type != "response_item" || row.Payload.CallID == "" {
+			continue
+		}
+		if row.Payload.Type == "function_call" || row.Payload.Type == "custom_tool_call" {
+			if command, ok := commandFrom(row.Payload); ok {
+				commands[row.Payload.CallID] = command
+			}
+			continue
+		}
+		if row.Payload.Type != "function_call_output" && row.Payload.Type != "custom_tool_call_output" {
+			continue
+		}
+		command, ok := commands[row.Payload.CallID]
+		if !ok {
+			continue
+		}
+		result := decodeCodexCommandResult(row.Payload.Output)
+		observations = append(observations, session.ParseCommitObservations(
+			command, result.output, result.succeeded,
+		)...)
+		delete(commands, row.Payload.CallID)
+	}
+	return observations
+}
+
+func decodeCodexCommandResult(raw json.RawMessage) codexCommandResult {
+	var blocks []struct {
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(raw, &blocks) == nil && len(blocks) > 0 {
+		parts := make([]string, 0, len(blocks))
+		for _, block := range blocks {
+			if block.Text != "" {
+				parts = append(parts, block.Text)
+			}
+		}
+		return codexCommandResult{
+			output:    strings.Join(parts, "\n"),
+			succeeded: strings.HasPrefix(blocks[0].Text, "Script completed"),
+		}
+	}
+	body := string(raw)
+	var encoded string
+	if json.Unmarshal(raw, &encoded) == nil {
+		body = encoded
+	}
+	var decoded struct {
+		Output   string `json:"output"`
+		ExitCode *int   `json:"exit_code"`
+	}
+	if json.Unmarshal([]byte(body), &decoded) == nil &&
+		(decoded.Output != "" || decoded.ExitCode != nil) {
+		return codexCommandResult{
+			output:    decoded.Output,
+			succeeded: decoded.ExitCode != nil && *decoded.ExitCode == 0,
+		}
+	}
+	return codexCommandResult{output: body}
 }
 
 func questionAnswersFrom(output json.RawMessage) (map[string]codexQuestionAnswer, bool) {

--- a/collector/internal/vendors/opencode/parse.go
+++ b/collector/internal/vendors/opencode/parse.go
@@ -64,7 +64,7 @@ func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 	activeDuration := int64(0)
 	busy := false
 	waiting := false
-	commits := []string{}
+	commitLog := []session.CommitObservation{}
 	pullRequests := 0
 	fileEdits := session.NewFileEditSet()
 	patchEdits := session.NewFileEditSet()
@@ -193,10 +193,11 @@ func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 				}
 				if isShell && part.State.Status == "completed" && part.State.Input.Command != "" {
 					commands.Note(part.State.Input.Command, part.State.Title)
-					if part.State.Metadata.Exit == nil || *part.State.Metadata.Exit == 0 {
-						if message, ok := session.CommitMessage(part.State.Input.Command); ok {
-							commits = append(commits, message)
-						}
+					succeeded := part.State.Metadata.Exit == nil || *part.State.Metadata.Exit == 0
+					commitLog = append(commitLog, session.ParseCommitObservations(
+						part.State.Input.Command, part.State.Output, succeeded,
+					)...)
+					if succeeded {
 						if session.IsPullRequestCreate(part.State.Input.Command) {
 							pullRequests++
 						}
@@ -254,7 +255,7 @@ func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 		Errors:         errorsCount,
 		Compactions:    compactions,
 		Commands:       commands.Raw(),
-		Commits:        commits,
+		Commits:        session.ReconcileCommits(commitLog, "", nil),
 		PullRequests:   pullRequests,
 		Todos:          todos,
 		Digest:         digest.Entries(),
@@ -280,6 +281,7 @@ func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 		Agent:            vendors.AgentOpenCode,
 		ID:               row.id,
 		WorkingDirectory: row.directory,
+		CommitLog:        commitLog,
 		EditedFileCount:  editedFileCount,
 		StartedAt:        earliestMessageTime(messages),
 		LastActivityTime: row.updatedAt,

--- a/collector/internal/vendors/opencode/types.go
+++ b/collector/internal/vendors/opencode/types.go
@@ -53,6 +53,7 @@ type storedPart struct {
 	State     struct {
 		Status string `json:"status"`
 		Title  string `json:"title"`
+		Output string `json:"output"`
 		Input  struct {
 			Command      string           `json:"command"`
 			FilePath     string           `json:"filePath"`


### PR DESCRIPTION
## Context

Session commit lists were derived from observed commands, so amendments, resets, and rebases could leave obsolete rows while compound commands could omit valid commits. This change reconciles successful commit observations with the recorded branch’s surviving Git history, with a fallback when the repository is unavailable.

## Changes

- Capture commit operations and output hashes across OpenCode, Codex, and Claude.
- Remove superseded commits without collapsing distinct commits that share a subject.
- Exclude failed operations and preserve amend behavior when Git history is unavailable.

## Test

- `go test ./...` — passed
- Manual: verified amended OpenCode and Claude sessions report only surviving commits; exercised Codex success and failure records with native fixtures.

### Screenshots

- [x] Session Inspector — rewritten session showing only surviving commits

**before**
<img width="1161" height="1366" alt="Screenshot 2026-08-14 at 15 48 49" src="https://github.com/user-attachments/assets/d5c2025d-065c-48b4-9d8d-ccb8faf295fc" />

**after**
<img width="1158" height="1361" alt="Screenshot 2026-08-14 at 15 49 13" src="https://github.com/user-attachments/assets/7e180e60-1115-4a99-b2e6-4e3cae05b614" />
