### PR TITLE
Add OpenCode as a synthesis backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ For OpenCode, the model list offers the free OpenCode Zen models — defaulting 
 
 Settings live behind the top-right button and are stored machine-wide in `~/.coslash/settings.json` — synthesis backend and model, light or dark theme, and the terminal used for launches (Apple Terminal or iTerm2). See [`settings.schema.json`](settings.schema.json) for the file format.
 
+The dialog offers a short model list per backend, but the model is not restricted to it. Editing `settings.json` directly accepts any model the selected CLI can actually reach — including one served through an API proxy such as `ANTHROPIC_BASE_URL`, or a third-party provider — so long as that CLI is set up to resolve it.
+
 Transcripts are read-only; coSlash never modifies them. Cached summaries and temporary handoffs live under `~/.coslash`. The server is loopback-only and protects every API request with an access token minted at start.
 
 Read [Data and privacy](docs/data-and-privacy.md) before pointing coSlash at sensitive transcripts.

--- a/README.md
+++ b/README.md
@@ -183,9 +183,11 @@ Per-model token breakdowns including cache reads and writes, estimated cost at l
 
 Debriefs work without any model: goals, outcomes, timelines, and artifacts are derived deterministically from the transcript. Turning on synthesis sharpens them.
 
-When you enable it, coSlash passes a bounded set of derived facts — goal candidates, digest, todos, filenames, commits, and stats, capped at roughly 12 KB — through your local Claude Code or Codex CLI, using the account that CLI already has. Results are cached under `~/.coslash`. Only substantial sessions qualify (more than five turns, at least one compaction, or a large context), so short throwaway runs never cost you anything.
+When you enable it, coSlash passes a bounded set of derived facts — goal candidates, digest, todos, filenames, commits, and stats, capped at roughly 12 KB — through your local Claude Code, Codex, or OpenCode CLI, using the account that CLI already has. Results are cached under `~/.coslash`. Only substantial sessions qualify (more than five turns, at least one compaction, or a large context), so short throwaway runs never cost you anything.
 
 It is **off until you explicitly enable and save it**.
+
+For OpenCode, the model list offers the free OpenCode Zen models — defaulting to `opencode/deepseek-v4-flash-free`, run at its `high` reasoning variant — plus *Whichever model OpenCode is set to use*. That option passes no model, so OpenCode resolves one itself: the `model` key in `~/.config/opencode/opencode.jsonc` if set, otherwise the model last selected in the OpenCode CLI. It is the way to reach a paid provider, since OpenCode resolves those from ambient credentials and listing them runs to hundreds of entries — but note the model can then change as you switch models in the CLI, and a paid one will bill your account per debrief.
 
 <p align="center">
   <img src="docs/media/settings-synthesis.png" alt="Settings dialog with AI synthesis enabled, OpenCode selected, and What synthesis sends expanded" width="520">

--- a/README.md
+++ b/README.md
@@ -185,10 +185,9 @@ Debriefs work without any model: goals, outcomes, timelines, and artifacts are d
 
 When you enable it, coSlash passes a bounded set of derived facts — goal candidates, digest, todos, filenames, commits, and stats, capped at roughly 12 KB — through your local Claude Code, Codex, or OpenCode CLI, using the account that CLI already has. Results are cached under `~/.coslash`. Only substantial sessions qualify (more than five turns, at least one compaction, or a large context), so short throwaway runs never cost you anything.
 
-It is **off until you explicitly enable and save it**.
-
 For OpenCode, the model list offers the free OpenCode Zen models — defaulting to `opencode/deepseek-v4-flash-free`, run at its `high` reasoning variant — plus *Whichever model OpenCode is set to use*. That option passes no model, so OpenCode resolves one itself: the `model` key in `~/.config/opencode/opencode.jsonc` if set, otherwise the model last selected in the OpenCode CLI. It is the way to reach a paid provider, since OpenCode resolves those from ambient credentials and listing them runs to hundreds of entries — but note the model can then change as you switch models in the CLI, and a paid one will bill your account per debrief.
 
+It is **off until you explicitly enable and save it**.
 <p align="center">
   <img src="docs/media/settings-synthesis.png" alt="Settings dialog with AI synthesis enabled, OpenCode selected, and What synthesis sends expanded" width="520">
 </p>

--- a/collector/cmd/coslash/api.go
+++ b/collector/cmd/coslash/api.go
@@ -263,7 +263,7 @@ func openCodeModels() []settings.ModelOption {
 	}}
 	preferred := false
 	for _, id := range opencode.SynthesisModels() {
-		if !settings.ValidSynthesisModel(settings.BackendOpenCode, id) {
+		if !settings.ValidSynthesisModel(id) {
 			continue
 		}
 		option := settings.ModelOption{ID: id, Label: id}

--- a/collector/cmd/coslash/api.go
+++ b/collector/cmd/coslash/api.go
@@ -266,7 +266,7 @@ func openCodeModels() []settings.ModelOption {
 	}}
 	preferred := false
 	for _, id := range opencode.SynthesisModels() {
-		if !settings.ValidOpenCodeModel(id) {
+		if !settings.ValidSynthesisModel(settings.BackendOpenCode, id) {
 			continue
 		}
 		option := settings.ModelOption{ID: id, Label: id}

--- a/collector/cmd/coslash/api.go
+++ b/collector/cmd/coslash/api.go
@@ -18,6 +18,7 @@ import (
 	"github.com/centauri-ai/coslash/collector/internal/sessionpreview"
 	"github.com/centauri-ai/coslash/collector/internal/settings"
 	"github.com/centauri-ai/coslash/collector/internal/synthesis"
+	"github.com/centauri-ai/coslash/collector/internal/vendors/opencode"
 )
 
 // /api/sessions → complete session records, optionally limited by an
@@ -232,11 +233,15 @@ func writeSettings(w http.ResponseWriter, state settings.State) {
 	}
 	for _, option := range settings.BackendOptions() {
 		_, err := exec.LookPath(settings.BackendExecutable(option.ID))
+		available := err == nil
+		if option.ID == settings.BackendOpenCode && available {
+			option.Models = openCodeModels()
+		}
 		response.Options.SynthesisBackends = append(
 			response.Options.SynthesisBackends,
 			availableBackend{
 				BackendOption: option,
-				Available:     err == nil,
+				Available:     available,
 			},
 		)
 	}
@@ -247,6 +252,33 @@ func writeSettings(w http.ResponseWriter, state settings.State) {
 		})
 	}
 	writeJSON(w, response)
+}
+
+// openCodeModels offers the user's own OpenCode model plus the free Zen
+// models. Paid providers are reachable through the default rather than listed,
+// since OpenCode resolves them from ambient credentials and the list runs to
+// hundreds. Every id here passes settings.Validate, so the picker cannot
+// produce a 400 on save.
+func openCodeModels() []settings.ModelOption {
+	models := []settings.ModelOption{{
+		ID:    settings.OpenCodeDefaultModel,
+		Label: "Whichever model OpenCode is set to use",
+	}}
+	preferred := false
+	for _, id := range opencode.SynthesisModels() {
+		if !settings.ValidOpenCodeModel(id) {
+			continue
+		}
+		option := settings.ModelOption{ID: id, Label: id}
+		if id == settings.OpenCodeSynthesisModel {
+			option.Default = true
+			preferred = true
+		}
+		models = append(models, option)
+	}
+	// Fall back to OpenCode's own model when the preferred one is retired.
+	models[0].Default = !preferred
+	return models
 }
 
 func handleSaveSettings(

--- a/collector/cmd/coslash/api.go
+++ b/collector/cmd/coslash/api.go
@@ -254,11 +254,8 @@ func writeSettings(w http.ResponseWriter, state settings.State) {
 	writeJSON(w, response)
 }
 
-// openCodeModels offers the user's own OpenCode model plus the free Zen
-// models. Paid providers are reachable through the default rather than listed,
-// since OpenCode resolves them from ambient credentials and the list runs to
-// hundreds. Every id here passes settings.Validate, so the picker cannot
-// produce a 400 on save.
+// Paid providers are reached through OpenCodeDefaultModel rather than listed:
+// OpenCode resolves them from ambient credentials, running to hundreds of ids.
 func openCodeModels() []settings.ModelOption {
 	models := []settings.ModelOption{{
 		ID:    settings.OpenCodeDefaultModel,

--- a/collector/cmd/coslash/main.go
+++ b/collector/cmd/coslash/main.go
@@ -90,6 +90,9 @@ func main() {
 		log.Printf("initialize synthesis cache: %v", err)
 		mgr.SetRunner(nil)
 	}
+	if err := synthesis.CleanupOpenCodeScratch(); err != nil {
+		log.Printf("sweep OpenCode scratch directories: %v", err)
+	}
 	go mgr.Run(context.Background(), func() ([]*session.Session, error) {
 		now := time.Now()
 		today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())

--- a/collector/internal/settings/settings.go
+++ b/collector/internal/settings/settings.go
@@ -31,6 +31,9 @@ const (
 	// The default Codex model, which the runner runs at high reasoning effort.
 	CodexSynthesisModel = "gpt-5.6-luna"
 
+	// The default Claude model, likewise run at high reasoning effort.
+	ClaudeSynthesisModel = "claude-haiku-4-5"
+
 	TerminalApple = "terminal"
 	TerminalITerm = "iterm2"
 )

--- a/collector/internal/settings/settings.go
+++ b/collector/internal/settings/settings.go
@@ -21,14 +21,11 @@ const (
 	BackendCodex    = "codex_exec"
 	BackendOpenCode = "opencode"
 
-	// OpenCodeDefaultModel passes no model, leaving OpenCode to resolve one:
-	// its configured model key, or failing that the model last selected in
-	// the CLI. That second case can change between runs.
+	// Passes no model, leaving OpenCode to resolve one: its configured model
+	// key, else the model last selected in the CLI, which varies between runs.
 	OpenCodeDefaultModel = "default"
 
-	// OpenCodeSynthesisModel is the free model coSlash prefers for OpenCode
-	// synthesis. It is the one free model with a reasoning variant worth
-	// turning up, which the runner does.
+	// The one free model with a reasoning variant, which the runner turns up.
 	OpenCodeSynthesisModel = "opencode/deepseek-v4-flash-free"
 
 	TerminalApple = "terminal"
@@ -137,8 +134,7 @@ func BackendOptions() []BackendOption {
 			},
 		},
 		{
-			// OpenCode models come from the user's own providers, so the
-			// caller fills these in from the CLI rather than a fixed list.
+			// Filled in from the CLI; OpenCode models depend on the user's providers.
 			ID:     BackendOpenCode,
 			Label:  "OpenCode CLI",
 			Models: []ModelOption{},
@@ -146,17 +142,11 @@ func BackendOptions() []BackendOption {
 	}
 }
 
-// modelPattern accepts bare ids like claude-haiku-4-5 and namespaced ones like
-// openrouter/anthropic/claude-haiku-4-5. The models a CLI can reach depend on
-// the user's own account, provider config, and any API proxy such as
-// ANTHROPIC_BASE_URL, so settings.json may name a model the picker does not
-// list. The leading character must not be "-", or the CLI would read the value
-// as another flag.
+// A leading "-" is excluded, or the CLI would read the value as another flag.
 var modelPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:/-]*$`)
 
-// ValidSynthesisModel checks the shape of a model id, not membership of a
-// fixed list. BackendOptions drives the picker; this guards what the runner
-// will hand to the CLI.
+// ValidSynthesisModel checks shape, not membership of a fixed list: an API
+// proxy such as ANTHROPIC_BASE_URL can serve models the picker never lists.
 func ValidSynthesisModel(backend, model string) bool {
 	if backend == BackendOpenCode && model == OpenCodeDefaultModel {
 		return true

--- a/collector/internal/settings/settings.go
+++ b/collector/internal/settings/settings.go
@@ -150,10 +150,7 @@ var modelPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:/-]*$`)
 
 // ValidSynthesisModel checks shape, not membership of a fixed list: an API
 // proxy such as ANTHROPIC_BASE_URL can serve models the picker never lists.
-func ValidSynthesisModel(backend, model string) bool {
-	if backend == BackendOpenCode && model == OpenCodeDefaultModel {
-		return true
-	}
+func ValidSynthesisModel(model string) bool {
 	return len(model) <= 200 && modelPattern.MatchString(model)
 }
 
@@ -194,7 +191,7 @@ func Validate(config Config) error {
 	if !known {
 		return fmt.Errorf("unsupported synthesis backend %q", config.Synthesis.Backend)
 	}
-	if !ValidSynthesisModel(config.Synthesis.Backend, config.Synthesis.Model) {
+	if !ValidSynthesisModel(config.Synthesis.Model) {
 		return fmt.Errorf("model %q is not a valid model id", config.Synthesis.Model)
 	}
 	if config.Appearance.Theme != "light" && config.Appearance.Theme != "dark" {

--- a/collector/internal/settings/settings.go
+++ b/collector/internal/settings/settings.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sync"
 )
 
@@ -16,8 +17,19 @@ const (
 	SchemaURL = "https://raw.githubusercontent.com/centauri-ai/coslash/main/settings.schema.json"
 	Version   = 1
 
-	BackendClaude = "claude-cli"
-	BackendCodex  = "codex_exec"
+	BackendClaude   = "claude-cli"
+	BackendCodex    = "codex_exec"
+	BackendOpenCode = "opencode"
+
+	// OpenCodeDefaultModel passes no model, leaving OpenCode to resolve one:
+	// its configured model key, or failing that the model last selected in
+	// the CLI. That second case can change between runs.
+	OpenCodeDefaultModel = "default"
+
+	// OpenCodeSynthesisModel is the free model coSlash prefers for OpenCode
+	// synthesis. It is the one free model with a reasoning variant worth
+	// turning up, which the runner does.
+	OpenCodeSynthesisModel = "opencode/deepseek-v4-flash-free"
 
 	TerminalApple = "terminal"
 	TerminalITerm = "iterm2"
@@ -124,7 +136,26 @@ func BackendOptions() []BackendOption {
 				{ID: "gpt-5.6-sol", Label: "GPT-5.6 Sol"},
 			},
 		},
+		{
+			// OpenCode models come from the user's own providers, so the
+			// caller fills these in from the CLI rather than a fixed list.
+			ID:     BackendOpenCode,
+			Label:  "OpenCode CLI",
+			Models: []ModelOption{},
+		},
 	}
+}
+
+// openCodeModelPattern matches "provider/model". Routed providers add
+// segments, as in openrouter/anthropic/claude-haiku-4-5. It stays permissive
+// so any provider the user types remains valid.
+var openCodeModelPattern = regexp.MustCompile(`^[A-Za-z0-9._:-]+(/[A-Za-z0-9._:-]+)+$`)
+
+func ValidOpenCodeModel(model string) bool {
+	if model == OpenCodeDefaultModel {
+		return true
+	}
+	return len(model) <= 200 && openCodeModelPattern.MatchString(model)
 }
 
 func TerminalOptions() []TerminalOption {
@@ -140,6 +171,8 @@ func BackendExecutable(backend string) string {
 		return "claude"
 	case BackendCodex:
 		return "codex"
+	case BackendOpenCode:
+		return "opencode"
 	default:
 		return ""
 	}
@@ -163,15 +196,21 @@ func Validate(config Config) error {
 	if backend == nil {
 		return fmt.Errorf("unsupported synthesis backend %q", config.Synthesis.Backend)
 	}
-	modelSupported := false
-	for _, option := range backend.Models {
-		if option.ID == config.Synthesis.Model {
-			modelSupported = true
-			break
+	if backend.ID == BackendOpenCode {
+		if !ValidOpenCodeModel(config.Synthesis.Model) {
+			return fmt.Errorf("model %q is not a provider/model id", config.Synthesis.Model)
 		}
-	}
-	if !modelSupported {
-		return fmt.Errorf("model %q is not supported by %q", config.Synthesis.Model, backend.ID)
+	} else {
+		modelSupported := false
+		for _, option := range backend.Models {
+			if option.ID == config.Synthesis.Model {
+				modelSupported = true
+				break
+			}
+		}
+		if !modelSupported {
+			return fmt.Errorf("model %q is not supported by %q", config.Synthesis.Model, backend.ID)
+		}
 	}
 	if config.Appearance.Theme != "light" && config.Appearance.Theme != "dark" {
 		return fmt.Errorf("unsupported theme %q", config.Appearance.Theme)

--- a/collector/internal/settings/settings.go
+++ b/collector/internal/settings/settings.go
@@ -146,16 +146,22 @@ func BackendOptions() []BackendOption {
 	}
 }
 
-// openCodeModelPattern matches "provider/model". Routed providers add
-// segments, as in openrouter/anthropic/claude-haiku-4-5. It stays permissive
-// so any provider the user types remains valid.
-var openCodeModelPattern = regexp.MustCompile(`^[A-Za-z0-9._:-]+(/[A-Za-z0-9._:-]+)+$`)
+// modelPattern accepts bare ids like claude-haiku-4-5 and namespaced ones like
+// openrouter/anthropic/claude-haiku-4-5. The models a CLI can reach depend on
+// the user's own account, provider config, and any API proxy such as
+// ANTHROPIC_BASE_URL, so settings.json may name a model the picker does not
+// list. The leading character must not be "-", or the CLI would read the value
+// as another flag.
+var modelPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:/-]*$`)
 
-func ValidOpenCodeModel(model string) bool {
-	if model == OpenCodeDefaultModel {
+// ValidSynthesisModel checks the shape of a model id, not membership of a
+// fixed list. BackendOptions drives the picker; this guards what the runner
+// will hand to the CLI.
+func ValidSynthesisModel(backend, model string) bool {
+	if backend == BackendOpenCode && model == OpenCodeDefaultModel {
 		return true
 	}
-	return len(model) <= 200 && openCodeModelPattern.MatchString(model)
+	return len(model) <= 200 && modelPattern.MatchString(model)
 }
 
 func TerminalOptions() []TerminalOption {
@@ -185,32 +191,18 @@ func Validate(config Config) error {
 	if config.Version != Version {
 		return fmt.Errorf("unsupported settings version %d", config.Version)
 	}
-	var backend *BackendOption
+	known := false
 	for _, option := range BackendOptions() {
 		if option.ID == config.Synthesis.Backend {
-			selected := option
-			backend = &selected
+			known = true
 			break
 		}
 	}
-	if backend == nil {
+	if !known {
 		return fmt.Errorf("unsupported synthesis backend %q", config.Synthesis.Backend)
 	}
-	if backend.ID == BackendOpenCode {
-		if !ValidOpenCodeModel(config.Synthesis.Model) {
-			return fmt.Errorf("model %q is not a provider/model id", config.Synthesis.Model)
-		}
-	} else {
-		modelSupported := false
-		for _, option := range backend.Models {
-			if option.ID == config.Synthesis.Model {
-				modelSupported = true
-				break
-			}
-		}
-		if !modelSupported {
-			return fmt.Errorf("model %q is not supported by %q", config.Synthesis.Model, backend.ID)
-		}
+	if !ValidSynthesisModel(config.Synthesis.Backend, config.Synthesis.Model) {
+		return fmt.Errorf("model %q is not a valid model id", config.Synthesis.Model)
 	}
 	if config.Appearance.Theme != "light" && config.Appearance.Theme != "dark" {
 		return fmt.Errorf("unsupported theme %q", config.Appearance.Theme)

--- a/collector/internal/settings/settings.go
+++ b/collector/internal/settings/settings.go
@@ -25,14 +25,11 @@ const (
 	// key, else the model last selected in the CLI, which varies between runs.
 	OpenCodeDefaultModel = "default"
 
-	// The one free model with a reasoning variant, which the runner turns up.
+	// Each backend's own default model, which the runner turns up to high
+	// reasoning effort. Changing one of these ids moves that flag with it.
 	OpenCodeSynthesisModel = "opencode/deepseek-v4-flash-free"
-
-	// The default Codex model, which the runner runs at high reasoning effort.
-	CodexSynthesisModel = "gpt-5.6-luna"
-
-	// The default Claude model, likewise run at high reasoning effort.
-	ClaudeSynthesisModel = "claude-haiku-4-5"
+	CodexSynthesisModel    = "gpt-5.6-luna"
+	ClaudeSynthesisModel   = "claude-haiku-4-5"
 
 	TerminalApple = "terminal"
 	TerminalITerm = "iterm2"

--- a/collector/internal/settings/settings.go
+++ b/collector/internal/settings/settings.go
@@ -28,6 +28,9 @@ const (
 	// The one free model with a reasoning variant, which the runner turns up.
 	OpenCodeSynthesisModel = "opencode/deepseek-v4-flash-free"
 
+	// The default Codex model, which the runner runs at high reasoning effort.
+	CodexSynthesisModel = "gpt-5.6-luna"
+
 	TerminalApple = "terminal"
 	TerminalITerm = "iterm2"
 )

--- a/collector/internal/synthesis/opencode.go
+++ b/collector/internal/synthesis/opencode.go
@@ -5,6 +5,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -14,12 +16,26 @@ import (
 
 const openCodeConfigContent = `{"permission":"deny","autoupdate":false}`
 
-func openCodeEnv() []string {
+// OpenCode instances that overlap in time deadlock during initialization when
+// they share a database, and the manager runs up to four at once, so each run
+// gets its own directory to hold one.
+func openCodeScratchDir() (string, error) {
+	if err := os.MkdirAll(SynthesisCwd(), 0o700); err != nil {
+		return "", fmt.Errorf("create synthesis directory: %w", err)
+	}
+	directory, err := os.MkdirTemp(SynthesisCwd(), ".opencode-*")
+	if err != nil {
+		return "", fmt.Errorf("create OpenCode scratch directory: %w", err)
+	}
+	return directory, nil
+}
+
+func openCodeEnv(scratchDir string) []string {
 	return []string{
 		"OPENCODE_CONFIG_CONTENT=" + openCodeConfigContent,
 		// OpenCode has no ephemeral mode, so its runs go to a scratch database
 		// rather than the one holding the user's own sessions.
-		"OPENCODE_DB=" + filepath.Join(SynthesisCwd(), "opencode.db"),
+		"OPENCODE_DB=" + filepath.Join(scratchDir, "opencode.db"),
 		"OPENCODE_DISABLE_PROJECT_CONFIG=1",
 		"OPENCODE_DISABLE_AUTOUPDATE=1",
 		"OPENCODE_DISABLE_SHARE=1",
@@ -91,7 +107,7 @@ func parseOpenCodeStream(data []byte) (string, error) {
 
 // OpenCode cannot enforce an output schema, so prose around the object is tolerated.
 func parseOpenCodeSynthesis(text string) (session.SessionSynthesis, error) {
-	synthesis, err := parseSynthesis([]byte(text))
+	synthesis, err := parseOpenCodeObject(text)
 	if err == nil {
 		return synthesis, nil
 	}
@@ -99,7 +115,51 @@ func parseOpenCodeSynthesis(text string) (session.SessionSynthesis, error) {
 	if object == "" {
 		return session.SessionSynthesis{}, err
 	}
-	return parseSynthesis([]byte(object))
+	return parseOpenCodeObject(object)
+}
+
+func parseOpenCodeObject(text string) (session.SessionSynthesis, error) {
+	if err := requireSynthesisFields([]byte(stripJSONFence(text))); err != nil {
+		return session.SessionSynthesis{}, err
+	}
+	return parseSynthesis([]byte(text))
+}
+
+// The schema only reaches OpenCode as prompt text, so the fields it marks
+// required are checked here rather than by the CLI.
+func requireSynthesisFields(data []byte) error {
+	var fields struct {
+		Goals        []*string `json:"goals"`
+		Outcome      *string   `json:"outcome"`
+		KeyDecisions []*string `json:"keyDecisions"`
+		NextStep     *string   `json:"nextStep"`
+	}
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return fmt.Errorf("decode synthesis result: %w", err)
+	}
+	if len(fields.Goals) == 0 {
+		return errors.New("synthesis result has no goals")
+	}
+	for _, goal := range fields.Goals {
+		if goal == nil {
+			return errors.New("synthesis result has a null goal")
+		}
+	}
+	if fields.Outcome == nil {
+		return errors.New("synthesis result has no outcome")
+	}
+	if fields.KeyDecisions == nil {
+		return errors.New("synthesis result has no key decisions")
+	}
+	for _, decision := range fields.KeyDecisions {
+		if decision == nil {
+			return errors.New("synthesis result has a null key decision")
+		}
+	}
+	if fields.NextStep == nil {
+		return errors.New("synthesis result has no next step")
+	}
+	return nil
 }
 
 func extractJSONObject(value string) string {

--- a/collector/internal/synthesis/opencode.go
+++ b/collector/internal/synthesis/opencode.go
@@ -30,7 +30,6 @@ func openCodeEnv() []string {
 	}
 }
 
-// openCodeEvent is one line of the --format json stream.
 type openCodeEvent struct {
 	Type      string `json:"type"`
 	SessionID string `json:"sessionID"`
@@ -41,8 +40,6 @@ type openCodeEvent struct {
 	} `json:"part"`
 }
 
-// parseOpenCodeStream reduces the newline-delimited event stream to the
-// assistant text and the session id the run wrote to the OpenCode database.
 func parseOpenCodeStream(data []byte) (string, string, error) {
 	scanner := bufio.NewScanner(bytes.NewReader(data))
 	// Tool events dwarf the default 64K token limit.
@@ -97,8 +94,7 @@ func parseOpenCodeStream(data []byte) (string, string, error) {
 	return strings.Join(parts, "\n"), sessionID, nil
 }
 
-// parseOpenCodeSynthesis tolerates prose around the object because OpenCode
-// cannot enforce an output schema.
+// OpenCode cannot enforce an output schema, so prose around the object is tolerated.
 func parseOpenCodeSynthesis(text string) (session.SessionSynthesis, error) {
 	synthesis, err := parseSynthesis([]byte(text))
 	if err == nil {
@@ -111,7 +107,6 @@ func parseOpenCodeSynthesis(text string) (session.SessionSynthesis, error) {
 	return parseSynthesis([]byte(object))
 }
 
-// extractJSONObject returns the first balanced top-level object in value.
 func extractJSONObject(value string) string {
 	start := strings.IndexByte(value, '{')
 	if start < 0 {
@@ -144,7 +139,6 @@ func extractJSONObject(value string) string {
 	return ""
 }
 
-// deleteOpenCodeSession drops the row the run left in the OpenCode database.
 // Failures are ignored so cleanup never fails an otherwise good synthesis.
 func deleteOpenCodeSession(ctx context.Context, id string) {
 	deleteCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)

--- a/collector/internal/synthesis/opencode.go
+++ b/collector/internal/synthesis/opencode.go
@@ -3,14 +3,11 @@ package synthesis
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
-	"os"
-	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/centauri-ai/coslash/collector/internal/session"
 )
@@ -20,6 +17,9 @@ const openCodeConfigContent = `{"permission":"deny","autoupdate":false}`
 func openCodeEnv() []string {
 	return []string{
 		"OPENCODE_CONFIG_CONTENT=" + openCodeConfigContent,
+		// OpenCode has no ephemeral mode, so its runs go to a scratch database
+		// rather than the one holding the user's own sessions.
+		"OPENCODE_DB=" + filepath.Join(SynthesisCwd(), "opencode.db"),
 		"OPENCODE_DISABLE_PROJECT_CONFIG=1",
 		"OPENCODE_DISABLE_AUTOUPDATE=1",
 		"OPENCODE_DISABLE_SHARE=1",
@@ -31,21 +31,19 @@ func openCodeEnv() []string {
 }
 
 type openCodeEvent struct {
-	Type      string `json:"type"`
-	SessionID string `json:"sessionID"`
-	Part      struct {
+	Type string `json:"type"`
+	Part struct {
 		ID   string `json:"id"`
 		Type string `json:"type"`
 		Text string `json:"text"`
 	} `json:"part"`
 }
 
-func parseOpenCodeStream(data []byte) (string, string, error) {
+func parseOpenCodeStream(data []byte) (string, error) {
 	scanner := bufio.NewScanner(bytes.NewReader(data))
 	// Tool events dwarf the default 64K token limit.
 	scanner.Buffer(make([]byte, 0, 64<<10), 4<<20)
 
-	sessionID := ""
 	events := 0
 	failed := false
 	order := []string{}
@@ -61,9 +59,6 @@ func parseOpenCodeStream(data []byte) (string, string, error) {
 			continue
 		}
 		events++
-		if sessionID == "" {
-			sessionID = event.SessionID
-		}
 		switch event.Type {
 		case "error":
 			failed = true
@@ -80,10 +75,10 @@ func parseOpenCodeStream(data []byte) (string, string, error) {
 		}
 	}
 	if events == 0 {
-		return "", sessionID, errors.New("OpenCode produced no synthesis output")
+		return "", errors.New("OpenCode produced no synthesis output")
 	}
 	if failed {
-		return "", sessionID, errors.New("OpenCode reported an error during synthesis")
+		return "", errors.New("OpenCode reported an error during synthesis")
 	}
 	parts := make([]string, 0, len(order))
 	for _, key := range order {
@@ -91,7 +86,7 @@ func parseOpenCodeStream(data []byte) (string, string, error) {
 			parts = append(parts, text)
 		}
 	}
-	return strings.Join(parts, "\n"), sessionID, nil
+	return strings.Join(parts, "\n"), nil
 }
 
 // OpenCode cannot enforce an output schema, so prose around the object is tolerated.
@@ -137,14 +132,4 @@ func extractJSONObject(value string) string {
 		}
 	}
 	return ""
-}
-
-// Failures are ignored so cleanup never fails an otherwise good synthesis.
-func deleteOpenCodeSession(ctx context.Context, id string) {
-	deleteCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
-	defer cancel()
-	cmd := exec.CommandContext(deleteCtx, "opencode", "session", "delete", id)
-	cmd.Dir = SynthesisCwd()
-	cmd.Env = append(os.Environ(), openCodeEnv()...)
-	_ = cmd.Run()
 }

--- a/collector/internal/synthesis/opencode.go
+++ b/collector/internal/synthesis/opencode.go
@@ -16,9 +16,10 @@ import (
 
 const openCodeConfigContent = `{"permission":"deny","autoupdate":false}`
 
-// OpenCode instances that overlap in time deadlock during initialization when
-// they share a database, and the manager runs up to four at once, so each run
-// gets its own directory to hold one.
+// OpenCode has no ephemeral mode, so its runs go to a scratch database rather
+// than the one holding the user's own sessions. One per run, not one shared:
+// instances that overlap in time deadlock during init on a shared database,
+// and the manager runs up to four at once.
 func openCodeScratchDir() (string, error) {
 	if err := os.MkdirAll(SynthesisCwd(), 0o700); err != nil {
 		return "", fmt.Errorf("create synthesis directory: %w", err)
@@ -33,8 +34,6 @@ func openCodeScratchDir() (string, error) {
 func openCodeEnv(scratchDir string) []string {
 	return []string{
 		"OPENCODE_CONFIG_CONTENT=" + openCodeConfigContent,
-		// OpenCode has no ephemeral mode, so its runs go to a scratch database
-		// rather than the one holding the user's own sessions.
 		"OPENCODE_DB=" + filepath.Join(scratchDir, "opencode.db"),
 		"OPENCODE_DISABLE_PROJECT_CONFIG=1",
 		"OPENCODE_DISABLE_AUTOUPDATE=1",
@@ -125,8 +124,6 @@ func parseOpenCodeObject(text string) (session.SessionSynthesis, error) {
 	return parseSynthesis([]byte(text))
 }
 
-// The schema only reaches OpenCode as prompt text, so the fields it marks
-// required are checked here rather than by the CLI.
 func requireSynthesisFields(data []byte) error {
 	var fields struct {
 		Goals        []*string `json:"goals"`

--- a/collector/internal/synthesis/opencode.go
+++ b/collector/internal/synthesis/opencode.go
@@ -6,15 +6,24 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/centauri-ai/coslash/collector/internal/session"
 )
 
 const openCodeConfigContent = `{"permission":"deny","autoupdate":false}`
+
+const (
+	openCodeScratchPrefix = ".opencode-"
+	// Well past the 90s run timeout, so a sweep cannot take a live run's
+	// directory from a second collector started on another port.
+	OpenCodeScratchMaxAge = time.Hour
+)
 
 // OpenCode has no ephemeral mode, so its runs go to a scratch database rather
 // than the one holding the user's own sessions. One per run, not one shared:
@@ -24,11 +33,39 @@ func openCodeScratchDir() (string, error) {
 	if err := os.MkdirAll(SynthesisCwd(), 0o700); err != nil {
 		return "", fmt.Errorf("create synthesis directory: %w", err)
 	}
-	directory, err := os.MkdirTemp(SynthesisCwd(), ".opencode-*")
+	directory, err := os.MkdirTemp(SynthesisCwd(), openCodeScratchPrefix+"*")
 	if err != nil {
 		return "", fmt.Errorf("create OpenCode scratch directory: %w", err)
 	}
 	return directory, nil
+}
+
+// A crash or SIGKILL skips the defer that removes a run's directory, and that
+// database holds the run's request and response, so abandoned ones are swept
+// rather than kept indefinitely.
+func CleanupOpenCodeScratch() error {
+	entries, err := os.ReadDir(SynthesisCwd())
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	cutoff := time.Now().Add(-OpenCodeScratchMaxAge)
+	for _, entry := range entries {
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), openCodeScratchPrefix) {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil || info.ModTime().After(cutoff) {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(SynthesisCwd(), entry.Name())); err != nil &&
+			!errors.Is(err, fs.ErrNotExist) {
+			return err
+		}
+	}
+	return nil
 }
 
 func openCodeEnv(scratchDir string) []string {
@@ -164,29 +201,9 @@ func extractJSONObject(value string) string {
 	if start < 0 {
 		return ""
 	}
-	depth := 0
-	inString := false
-	escaped := false
-	for index := start; index < len(value); index++ {
-		char := value[index]
-		if escaped {
-			escaped = false
-			continue
-		}
-		switch {
-		case char == '\\' && inString:
-			escaped = true
-		case char == '"':
-			inString = !inString
-		case inString:
-		case char == '{':
-			depth++
-		case char == '}':
-			depth--
-			if depth == 0 {
-				return value[start : index+1]
-			}
-		}
+	var object json.RawMessage
+	if err := json.NewDecoder(strings.NewReader(value[start:])).Decode(&object); err != nil {
+		return ""
 	}
-	return ""
+	return string(object)
 }

--- a/collector/internal/synthesis/opencode.go
+++ b/collector/internal/synthesis/opencode.go
@@ -1,0 +1,156 @@
+package synthesis
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/centauri-ai/coslash/collector/internal/session"
+)
+
+const openCodeConfigContent = `{"permission":"deny","autoupdate":false}`
+
+func openCodeEnv() []string {
+	return []string{
+		"OPENCODE_CONFIG_CONTENT=" + openCodeConfigContent,
+		"OPENCODE_DISABLE_PROJECT_CONFIG=1",
+		"OPENCODE_DISABLE_AUTOUPDATE=1",
+		"OPENCODE_DISABLE_SHARE=1",
+		"OPENCODE_DISABLE_MODELS_FETCH=1",
+		// OpenCode reads PWD before cwd, which exec.Cmd does not update.
+		"PWD=" + SynthesisCwd(),
+		"NO_COLOR=1",
+	}
+}
+
+// openCodeEvent is one line of the --format json stream.
+type openCodeEvent struct {
+	Type      string `json:"type"`
+	SessionID string `json:"sessionID"`
+	Part      struct {
+		ID   string `json:"id"`
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"part"`
+}
+
+// parseOpenCodeStream reduces the newline-delimited event stream to the
+// assistant text and the session id the run wrote to the OpenCode database.
+func parseOpenCodeStream(data []byte) (string, string, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	// Tool events dwarf the default 64K token limit.
+	scanner.Buffer(make([]byte, 0, 64<<10), 4<<20)
+
+	sessionID := ""
+	events := 0
+	failed := false
+	order := []string{}
+	texts := map[string]string{}
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var event openCodeEvent
+		// A stray banner or notice must not discard a good run.
+		if err := json.Unmarshal(line, &event); err != nil {
+			continue
+		}
+		events++
+		if sessionID == "" {
+			sessionID = event.SessionID
+		}
+		switch event.Type {
+		case "error":
+			failed = true
+		case "text":
+			// Parts arrive as snapshots, so the newest text per part wins.
+			key := event.Part.ID
+			if key == "" {
+				key = strconv.Itoa(len(order))
+			}
+			if _, seen := texts[key]; !seen {
+				order = append(order, key)
+			}
+			texts[key] = event.Part.Text
+		}
+	}
+	if events == 0 {
+		return "", sessionID, errors.New("OpenCode produced no synthesis output")
+	}
+	if failed {
+		return "", sessionID, errors.New("OpenCode reported an error during synthesis")
+	}
+	parts := make([]string, 0, len(order))
+	for _, key := range order {
+		if text := strings.TrimSpace(texts[key]); text != "" {
+			parts = append(parts, text)
+		}
+	}
+	return strings.Join(parts, "\n"), sessionID, nil
+}
+
+// parseOpenCodeSynthesis tolerates prose around the object because OpenCode
+// cannot enforce an output schema.
+func parseOpenCodeSynthesis(text string) (session.SessionSynthesis, error) {
+	synthesis, err := parseSynthesis([]byte(text))
+	if err == nil {
+		return synthesis, nil
+	}
+	object := extractJSONObject(text)
+	if object == "" {
+		return session.SessionSynthesis{}, err
+	}
+	return parseSynthesis([]byte(object))
+}
+
+// extractJSONObject returns the first balanced top-level object in value.
+func extractJSONObject(value string) string {
+	start := strings.IndexByte(value, '{')
+	if start < 0 {
+		return ""
+	}
+	depth := 0
+	inString := false
+	escaped := false
+	for index := start; index < len(value); index++ {
+		char := value[index]
+		if escaped {
+			escaped = false
+			continue
+		}
+		switch {
+		case char == '\\' && inString:
+			escaped = true
+		case char == '"':
+			inString = !inString
+		case inString:
+		case char == '{':
+			depth++
+		case char == '}':
+			depth--
+			if depth == 0 {
+				return value[start : index+1]
+			}
+		}
+	}
+	return ""
+}
+
+// deleteOpenCodeSession drops the row the run left in the OpenCode database.
+// Failures are ignored so cleanup never fails an otherwise good synthesis.
+func deleteOpenCodeSession(ctx context.Context, id string) {
+	deleteCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(deleteCtx, "opencode", "session", "delete", id)
+	cmd.Dir = SynthesisCwd()
+	cmd.Env = append(os.Environ(), openCodeEnv()...)
+	_ = cmd.Run()
+}

--- a/collector/internal/synthesis/opencode_test.go
+++ b/collector/internal/synthesis/opencode_test.go
@@ -1,0 +1,41 @@
+package synthesis
+
+import "testing"
+
+func TestParseOpenCodeSynthesisRejectsIncompleteObject(t *testing.T) {
+	cases := map[string]string{
+		"missing every other field": `{"outcome":"done"}`,
+		"missing nextStep":          `{"goals":["ship"],"outcome":"done","keyDecisions":[]}`,
+		"empty goals":               `{"goals":[],"outcome":"done","keyDecisions":[],"nextStep":"land it"}`,
+		"null goals":                `{"goals":null,"outcome":"done","keyDecisions":[],"nextStep":"land it"}`,
+	}
+	for name, text := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parseOpenCodeSynthesis(text); err == nil {
+				t.Fatalf("parseOpenCodeSynthesis(%s) succeeded, want an error", text)
+			}
+		})
+	}
+}
+
+func TestParseOpenCodeSynthesisAcceptsCompleteObject(t *testing.T) {
+	cases := map[string]string{
+		"bare object":  `{"goals":["ship the fix"],"outcome":"done","keyDecisions":[],"nextStep":"land it"}`,
+		"fenced":       "```json\n{\"goals\":[\"ship the fix\"],\"outcome\":\"done\",\"keyDecisions\":[],\"nextStep\":\"land it\"}\n```",
+		"around prose": `Here you go: {"goals":["ship the fix"],"outcome":"done","keyDecisions":[],"nextStep":"land it"} hope that helps.`,
+	}
+	for name, text := range cases {
+		t.Run(name, func(t *testing.T) {
+			synthesis, err := parseOpenCodeSynthesis(text)
+			if err != nil {
+				t.Fatalf("parseOpenCodeSynthesis(%s): %v", text, err)
+			}
+			if len(synthesis.Goals) != 1 || synthesis.Goals[0] != "ship the fix" {
+				t.Fatalf("goals = %v, want [ship the fix]", synthesis.Goals)
+			}
+			if synthesis.NextStep != "land it" {
+				t.Fatalf("nextStep = %q, want %q", synthesis.NextStep, "land it")
+			}
+		})
+	}
+}

--- a/collector/internal/synthesis/opencode_test.go
+++ b/collector/internal/synthesis/opencode_test.go
@@ -1,6 +1,11 @@
 package synthesis
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
 
 func TestParseOpenCodeSynthesisRejectsIncompleteObject(t *testing.T) {
 	cases := map[string]string{
@@ -37,5 +42,61 @@ func TestParseOpenCodeSynthesisAcceptsCompleteObject(t *testing.T) {
 				t.Fatalf("nextStep = %q, want %q", synthesis.NextStep, "land it")
 			}
 		})
+	}
+}
+
+func TestExtractJSONObject(t *testing.T) {
+	cases := []struct{ name, input, want string }{
+		{"nested objects", `x {"a":{"b":{"c":1}}} y`, `{"a":{"b":{"c":1}}}`},
+		{"brace inside string", `{"a":"} not the end","b":1}`, `{"a":"} not the end","b":1}`},
+		{"escaped quote before brace", `{"a":"say \"}\" now","b":2}`, `{"a":"say \"}\" now","b":2}`},
+		{"stops after first value", `{"a":1} {"b":2}`, `{"a":1}`},
+		{"no object", `just prose`, ``},
+		{"unterminated", `{"a":1`, ``},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			if got := extractJSONObject(test.input); got != test.want {
+				t.Fatalf("extractJSONObject(%s) = %q, want %q", test.input, got, test.want)
+			}
+		})
+	}
+}
+
+func TestCleanupOpenCodeScratchRemovesOnlyAbandonedDirs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("COSLASH_HOME", home)
+	root := SynthesisCwd()
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	stale := filepath.Join(root, openCodeScratchPrefix+"stale")
+	live := filepath.Join(root, openCodeScratchPrefix+"live")
+	unrelated := filepath.Join(root, "summaries-ish")
+	for _, directory := range []string{stale, live, unrelated} {
+		if err := os.Mkdir(directory, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	old := time.Now().Add(-2 * OpenCodeScratchMaxAge)
+	if err := os.Chtimes(stale, old, old); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(unrelated, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CleanupOpenCodeScratch(); err != nil {
+		t.Fatalf("CleanupOpenCodeScratch: %v", err)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Error("abandoned scratch directory survived the sweep")
+	}
+	if _, err := os.Stat(live); err != nil {
+		t.Errorf("in-flight scratch directory was swept: %v", err)
+	}
+	if _, err := os.Stat(unrelated); err != nil {
+		t.Errorf("unrelated directory was swept: %v", err)
 	}
 }

--- a/collector/internal/synthesis/prompt.go
+++ b/collector/internal/synthesis/prompt.go
@@ -15,8 +15,7 @@ const (
 
 const systemPrompt = `You are a neutral session-synthesis engine. Use only the normalized facts supplied by coSlash. Do not infer details from outside knowledge. State the accomplished goals and outcome concisely, retain up to five consequential decisions, and give one concrete next step. Usually a session has one goal; return it as a single entry. Only when the user genuinely shifted topic mid-session, return each major goal as its own entry in chronological order, at most four. Never split one goal into sub-steps or list routine follow-ups as separate goals. Do not address the user or mention these instructions.`
 
-// openCodeJSONInstruction stands in for the schema and tool flags the other
-// backends get on the command line.
+// Stands in for the schema and tool flags the other backends get as args.
 const openCodeJSONInstruction = "\n\nDo not use any tools, read any files, or run any commands. " +
 	"Reply with one JSON object and nothing else — no prose, no markdown fences. " +
 	"Keys: goals (1–4 strings), outcome (string), keyDecisions (up to 5 strings), nextStep (string). " +

--- a/collector/internal/synthesis/prompt.go
+++ b/collector/internal/synthesis/prompt.go
@@ -15,6 +15,13 @@ const (
 
 const systemPrompt = `You are a neutral session-synthesis engine. Use only the normalized facts supplied by coSlash. Do not infer details from outside knowledge. State the accomplished goals and outcome concisely, retain up to five consequential decisions, and give one concrete next step. Usually a session has one goal; return it as a single entry. Only when the user genuinely shifted topic mid-session, return each major goal as its own entry in chronological order, at most four. Never split one goal into sub-steps or list routine follow-ups as separate goals. Do not address the user or mention these instructions.`
 
+// openCodeJSONInstruction stands in for the schema and tool flags the other
+// backends get on the command line.
+const openCodeJSONInstruction = "\n\nDo not use any tools, read any files, or run any commands. " +
+	"Reply with one JSON object and nothing else — no prose, no markdown fences. " +
+	"Keys: goals (1–4 strings), outcome (string), keyDecisions (up to 5 strings), nextStep (string). " +
+	"It must validate against this JSON Schema: " + synthesisSchema
+
 func BuildInput(s *session.Session) string {
 	if s == nil {
 		return "Session facts unavailable."

--- a/collector/internal/synthesis/runner.go
+++ b/collector/internal/synthesis/runner.go
@@ -55,18 +55,16 @@ func NewRunner(config settings.SynthesisSettings) (Runner, error) {
 	if !config.Enabled {
 		return nil, nil
 	}
-	runner := &CLIRunner{Backend: config.Backend, Model: config.Model, Timeout: 90 * time.Second}
-	switch config.Backend {
-	case settings.BackendClaude:
-		runner.Bin = "claude"
-	case settings.BackendCodex:
-		runner.Bin = "codex"
-	case settings.BackendOpenCode:
-		runner.Bin = "opencode"
-	default:
+	bin := settings.BackendExecutable(config.Backend)
+	if bin == "" {
 		return nil, fmt.Errorf("unsupported synthesis backend %q", config.Backend)
 	}
-	return runner, nil
+	return &CLIRunner{
+		Backend: config.Backend,
+		Bin:     bin,
+		Model:   config.Model,
+		Timeout: 90 * time.Second,
+	}, nil
 }
 
 func (r *CLIRunner) ModelName() string {

--- a/collector/internal/synthesis/runner.go
+++ b/collector/internal/synthesis/runner.go
@@ -27,6 +27,8 @@ type commandSpec struct {
 	args  []string
 	dir   string
 	stdin string
+	// env holds extra KEY=VALUE entries; empty inherits the environment.
+	env []string
 }
 
 type commandExecutor func(context.Context, commandSpec) ([]byte, error)
@@ -35,6 +37,9 @@ func executeCommand(ctx context.Context, spec commandSpec) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, spec.bin, spec.args...)
 	cmd.Dir = spec.dir
 	cmd.Stdin = strings.NewReader(spec.stdin)
+	if len(spec.env) > 0 {
+		cmd.Env = append(os.Environ(), spec.env...)
+	}
 	return cmd.Output()
 }
 
@@ -56,6 +61,8 @@ func NewRunner(config settings.SynthesisSettings) (Runner, error) {
 		runner.Bin = "claude"
 	case settings.BackendCodex:
 		runner.Bin = "codex"
+	case settings.BackendOpenCode:
+		runner.Bin = "opencode"
 	default:
 		return nil, fmt.Errorf("unsupported synthesis backend %q", config.Backend)
 	}
@@ -69,8 +76,16 @@ func (r *CLIRunner) ModelName() string {
 func (r *CLIRunner) Run(ctx context.Context, input string) (session.SessionSynthesis, error) {
 	var label string
 	var args []string
+	var env []string
 	var parse func([]byte) (session.SessionSynthesis, error)
 	var schemaPath string
+	// OpenCode has no ephemeral mode, so its run is deleted afterwards.
+	var openCodeSessionID string
+	defer func() {
+		if openCodeSessionID != "" {
+			deleteOpenCodeSession(ctx, openCodeSessionID)
+		}
+	}()
 	switch r.Backend {
 	case settings.BackendClaude:
 		label = "Claude Code"
@@ -106,6 +121,32 @@ func (r *CLIRunner) Run(ctx context.Context, input string) (session.SessionSynth
 			"--color", "never",
 			systemPrompt,
 		}
+	case settings.BackendOpenCode:
+		label = "OpenCode"
+		parse = func(data []byte) (session.SessionSynthesis, error) {
+			text, id, err := parseOpenCodeStream(data)
+			openCodeSessionID = id
+			if err != nil {
+				return session.SessionSynthesis{}, err
+			}
+			return parseOpenCodeSynthesis(text)
+		}
+		// OpenCode has no system prompt or schema flag, so the instructions
+		// ride along with the message and the shape is described in prose.
+		args = []string{"run", "--dir", SynthesisCwd()}
+		// Omitting --model lets OpenCode use its own configured model.
+		if r.Model != settings.OpenCodeDefaultModel {
+			args = append(args, "--model", r.Model)
+		}
+		if r.Model == settings.OpenCodeSynthesisModel {
+			args = append(args, "--variant", "high")
+		}
+		args = append(args,
+			"--format", "json",
+			"--pure",
+			systemPrompt+openCodeJSONInstruction,
+		)
+		env = openCodeEnv()
 	default:
 		return session.SessionSynthesis{}, fmt.Errorf("unsupported synthesis backend %q", r.Backend)
 	}
@@ -120,6 +161,7 @@ func (r *CLIRunner) Run(ctx context.Context, input string) (session.SessionSynth
 		args:  args,
 		dir:   SynthesisCwd(),
 		stdin: input,
+		env:   env,
 	})
 	if runCtx.Err() != nil {
 		return session.SessionSynthesis{}, fmt.Errorf("%s synthesis timed out: %w", label, runCtx.Err())

--- a/collector/internal/synthesis/runner.go
+++ b/collector/internal/synthesis/runner.go
@@ -129,6 +129,11 @@ func (r *CLIRunner) Run(ctx context.Context, input string) (session.SessionSynth
 			}
 			return parseOpenCodeSynthesis(text)
 		}
+		scratchDir, err := openCodeScratchDir()
+		if err != nil {
+			return session.SessionSynthesis{}, err
+		}
+		defer os.RemoveAll(scratchDir)
 		// OpenCode has no system-prompt or schema flag, so both ride along
 		// with the message.
 		args = []string{"run", "--dir", SynthesisCwd()}
@@ -143,7 +148,7 @@ func (r *CLIRunner) Run(ctx context.Context, input string) (session.SessionSynth
 			"--pure",
 			systemPrompt+openCodeJSONInstruction,
 		)
-		env = openCodeEnv()
+		env = openCodeEnv(scratchDir)
 	default:
 		return session.SessionSynthesis{}, fmt.Errorf("unsupported synthesis backend %q", r.Backend)
 	}

--- a/collector/internal/synthesis/runner.go
+++ b/collector/internal/synthesis/runner.go
@@ -79,13 +79,6 @@ func (r *CLIRunner) Run(ctx context.Context, input string) (session.SessionSynth
 	var env []string
 	var parse func([]byte) (session.SessionSynthesis, error)
 	var schemaPath string
-	// OpenCode has no ephemeral mode, so its run is deleted afterwards.
-	var openCodeSessionID string
-	defer func() {
-		if openCodeSessionID != "" {
-			deleteOpenCodeSession(ctx, openCodeSessionID)
-		}
-	}()
 	switch r.Backend {
 	case settings.BackendClaude:
 		label = "Claude Code"
@@ -124,8 +117,7 @@ func (r *CLIRunner) Run(ctx context.Context, input string) (session.SessionSynth
 	case settings.BackendOpenCode:
 		label = "OpenCode"
 		parse = func(data []byte) (session.SessionSynthesis, error) {
-			text, id, err := parseOpenCodeStream(data)
-			openCodeSessionID = id
+			text, err := parseOpenCodeStream(data)
 			if err != nil {
 				return session.SessionSynthesis{}, err
 			}

--- a/collector/internal/synthesis/runner.go
+++ b/collector/internal/synthesis/runner.go
@@ -131,10 +131,9 @@ func (r *CLIRunner) Run(ctx context.Context, input string) (session.SessionSynth
 			}
 			return parseOpenCodeSynthesis(text)
 		}
-		// OpenCode has no system prompt or schema flag, so the instructions
-		// ride along with the message and the shape is described in prose.
+		// OpenCode has no system-prompt or schema flag, so both ride along
+		// with the message.
 		args = []string{"run", "--dir", SynthesisCwd()}
-		// Omitting --model lets OpenCode use its own configured model.
 		if r.Model != settings.OpenCodeDefaultModel {
 			args = append(args, "--model", r.Model)
 		}
@@ -259,7 +258,8 @@ func normalize(synthesis *session.SessionSynthesis) error {
 	synthesis.Goals = dedupedLimited(synthesis.Goals, 4, func(goal string) string {
 		return concise(goal, 200)
 	})
-	synthesis.Outcome = concise(synthesis.Outcome, 200)
+	// The inspector shows the outcome in full, so it is only whitespace-collapsed.
+	synthesis.Outcome = strings.Join(strings.Fields(synthesis.Outcome), " ")
 	synthesis.NextStep = concise(synthesis.NextStep, 200)
 	synthesis.KeyDecisions = dedupedLimited(synthesis.KeyDecisions, 5, func(decision string) string {
 		return session.Truncate(strings.TrimSpace(decision), 140)

--- a/collector/internal/synthesis/runner.go
+++ b/collector/internal/synthesis/runner.go
@@ -93,6 +93,9 @@ func (r *CLIRunner) Run(ctx context.Context, input string) (session.SessionSynth
 			"--safe-mode",
 			"--no-session-persistence",
 		}
+		if r.Model == settings.ClaudeSynthesisModel {
+			args = append(args, "--effort", "high")
+		}
 	case settings.BackendCodex:
 		label = "Codex"
 		parse = parseSynthesis

--- a/collector/internal/synthesis/runner.go
+++ b/collector/internal/synthesis/runner.go
@@ -261,7 +261,6 @@ func normalize(synthesis *session.SessionSynthesis) error {
 	synthesis.Goals = dedupedLimited(synthesis.Goals, 4, func(goal string) string {
 		return concise(goal, 200)
 	})
-	// The inspector shows the outcome in full, so it is only whitespace-collapsed.
 	synthesis.Outcome = strings.Join(strings.Fields(synthesis.Outcome), " ")
 	synthesis.NextStep = concise(synthesis.NextStep, 200)
 	synthesis.KeyDecisions = dedupedLimited(synthesis.KeyDecisions, 5, func(decision string) string {

--- a/collector/internal/synthesis/runner.go
+++ b/collector/internal/synthesis/runner.go
@@ -112,8 +112,11 @@ func (r *CLIRunner) Run(ctx context.Context, input string) (session.SessionSynth
 			"--model", r.Model,
 			"--output-schema", schemaPath,
 			"--color", "never",
-			systemPrompt,
 		}
+		if r.Model == settings.CodexSynthesisModel {
+			args = append(args, "-c", "model_reasoning_effort=high")
+		}
+		args = append(args, systemPrompt)
 	case settings.BackendOpenCode:
 		label = "OpenCode"
 		parse = func(data []byte) (session.SessionSynthesis, error) {

--- a/collector/internal/vendors/opencode/models.go
+++ b/collector/internal/vendors/opencode/models.go
@@ -24,8 +24,8 @@ var modelsCache struct {
 	loaded time.Time
 }
 
-// SynthesisModels lists the OpenCode Zen models that cost nothing to run, so
-// the picker cannot bill the user for a model they did not name. Results are
+// SynthesisModels lists the live OpenCode Zen models that cost nothing to run,
+// so the picker cannot bill the user for a model they did not name. Results are
 // cached because the CLI call costs about a second and settings are polled.
 func SynthesisModels() []string {
 	modelsCache.mu.Lock()
@@ -49,12 +49,13 @@ type verboseModel struct {
 			Text bool `json:"text"`
 		} `json:"output"`
 	} `json:"capabilities"`
+	Status string `json:"status"`
 }
 
 func loadModels() []string {
 	ctx, cancel := context.WithTimeout(context.Background(), modelTimeout)
 	defer cancel()
-	output, err := exec.CommandContext(ctx, "opencode", "models", "--verbose").Output()
+	output, err := exec.CommandContext(ctx, "opencode", "models", "opencode", "--verbose").Output()
 	if err != nil {
 		return []string{}
 	}
@@ -98,5 +99,6 @@ func freeZenModel(name, body string) bool {
 	if err := json.Unmarshal([]byte(body), &model); err != nil {
 		return false
 	}
-	return model.Cost.Input == 0 && model.Cost.Output == 0 && model.Capabilities.Output.Text
+	return model.Status != "deprecated" && model.Cost.Input == 0 && model.Cost.Output == 0 &&
+		model.Capabilities.Output.Text
 }

--- a/collector/internal/vendors/opencode/models.go
+++ b/collector/internal/vendors/opencode/models.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -51,10 +52,29 @@ type verboseModel struct {
 	Status string `json:"status"`
 }
 
+// Opening Settings reaches this probe, so it must not inherit the collector's
+// working directory: OpenCode loads project plugins and config from there, and
+// starting coSlash in an untrusted checkout would run repository code. It runs
+// from an empty directory instead, with `--pure` for external plugins and PWD
+// set because OpenCode reads it before cwd. The global config is left alone,
+// since enumerating models needs its providers.
 func loadModels() []string {
+	directory, err := os.MkdirTemp("", "coslash-models-*")
+	if err != nil {
+		return []string{}
+	}
+	defer os.RemoveAll(directory)
 	ctx, cancel := context.WithTimeout(context.Background(), modelTimeout)
 	defer cancel()
-	output, err := exec.CommandContext(ctx, "opencode", "models", "opencode", "--verbose").Output()
+	cmd := exec.CommandContext(ctx, "opencode", "models", "opencode", "--verbose", "--pure")
+	cmd.Dir = directory
+	cmd.Env = append(os.Environ(),
+		"OPENCODE_DISABLE_PROJECT_CONFIG=1",
+		"OPENCODE_DISABLE_AUTOUPDATE=1",
+		"PWD="+directory,
+		"NO_COLOR=1",
+	)
+	output, err := cmd.Output()
 	if err != nil {
 		return []string{}
 	}

--- a/collector/internal/vendors/opencode/models.go
+++ b/collector/internal/vendors/opencode/models.go
@@ -24,15 +24,13 @@ var modelsCache struct {
 	loaded time.Time
 }
 
-// SynthesisModels lists the OpenCode Zen models that cost nothing to run.
-// Paid providers are left out because synthesis should never bill the user
-// without them naming the model; they reach those through their own OpenCode
-// default instead. The result is cached because the CLI call costs about a
-// second and the settings endpoint is polled.
+// SynthesisModels lists the OpenCode Zen models that cost nothing to run, so
+// the picker cannot bill the user for a model they did not name. Results are
+// cached because the CLI call costs about a second and settings are polled.
 func SynthesisModels() []string {
 	modelsCache.mu.Lock()
 	defer modelsCache.mu.Unlock()
-	// An empty result is cached too, so a broken CLI is only paid for once.
+	// Empty results are cached too, so a broken CLI is only paid for once.
 	if !modelsCache.loaded.IsZero() && time.Since(modelsCache.loaded) < modelsTTL {
 		return modelsCache.models
 	}
@@ -41,7 +39,6 @@ func SynthesisModels() []string {
 	return modelsCache.models
 }
 
-// verboseModel is the subset of `opencode models --verbose` we read.
 type verboseModel struct {
 	Cost struct {
 		Input  float64 `json:"input"`

--- a/collector/internal/vendors/opencode/models.go
+++ b/collector/internal/vendors/opencode/models.go
@@ -1,0 +1,105 @@
+package opencode
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	modelsTTL    = 10 * time.Minute
+	modelsLimit  = 50
+	zenPrefix    = "opencode/"
+	modelTimeout = 10 * time.Second
+)
+
+var modelsCache struct {
+	mu     sync.Mutex
+	models []string
+	loaded time.Time
+}
+
+// SynthesisModels lists the OpenCode Zen models that cost nothing to run.
+// Paid providers are left out because synthesis should never bill the user
+// without them naming the model; they reach those through their own OpenCode
+// default instead. The result is cached because the CLI call costs about a
+// second and the settings endpoint is polled.
+func SynthesisModels() []string {
+	modelsCache.mu.Lock()
+	defer modelsCache.mu.Unlock()
+	// An empty result is cached too, so a broken CLI is only paid for once.
+	if !modelsCache.loaded.IsZero() && time.Since(modelsCache.loaded) < modelsTTL {
+		return modelsCache.models
+	}
+	modelsCache.models = loadModels()
+	modelsCache.loaded = time.Now()
+	return modelsCache.models
+}
+
+// verboseModel is the subset of `opencode models --verbose` we read.
+type verboseModel struct {
+	Cost struct {
+		Input  float64 `json:"input"`
+		Output float64 `json:"output"`
+	} `json:"cost"`
+	Capabilities struct {
+		Output struct {
+			Text bool `json:"text"`
+		} `json:"output"`
+	} `json:"capabilities"`
+}
+
+func loadModels() []string {
+	ctx, cancel := context.WithTimeout(context.Background(), modelTimeout)
+	defer cancel()
+	output, err := exec.CommandContext(ctx, "opencode", "models", "--verbose").Output()
+	if err != nil {
+		return []string{}
+	}
+	return parseVerboseModels(output)
+}
+
+// parseVerboseModels reads the CLI's "provider/id" header lines followed by a
+// pretty-printed object whose closing brace sits in the first column.
+func parseVerboseModels(output []byte) []string {
+	models := []string{}
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	scanner.Buffer(make([]byte, 0, 64<<10), 1<<20)
+	name := ""
+	var body []string
+	for scanner.Scan() && len(models) < modelsLimit {
+		line := scanner.Text()
+		switch {
+		case body != nil:
+			body = append(body, line)
+			if line != "}" {
+				continue
+			}
+			if freeZenModel(name, strings.Join(body, "\n")) {
+				models = append(models, name)
+			}
+			name, body = "", nil
+		case line == "{" && name != "":
+			body = []string{line}
+		default:
+			name = strings.TrimSpace(line)
+		}
+	}
+	return models
+}
+
+func freeZenModel(name, body string) bool {
+	if !strings.HasPrefix(name, zenPrefix) {
+		return false
+	}
+	var model verboseModel
+	if err := json.Unmarshal([]byte(body), &model); err != nil {
+		return false
+	}
+	return model.Cost.Input == 0 && model.Cost.Output == 0 && model.Capabilities.Output.Text
+}

--- a/collector/internal/vendors/opencode/models.go
+++ b/collector/internal/vendors/opencode/models.go
@@ -24,9 +24,8 @@ var modelsCache struct {
 	loaded time.Time
 }
 
-// SynthesisModels lists the live OpenCode Zen models that cost nothing to run,
-// so the picker cannot bill the user for a model they did not name. Results are
-// cached because the CLI call costs about a second and settings are polled.
+// SynthesisModels lists the free OpenCode Zen models, so the picker cannot
+// bill the user for a model they did not name.
 func SynthesisModels() []string {
 	modelsCache.mu.Lock()
 	defer modelsCache.mu.Unlock()
@@ -62,8 +61,8 @@ func loadModels() []string {
 	return parseVerboseModels(output)
 }
 
-// parseVerboseModels reads the CLI's "provider/id" header lines followed by a
-// pretty-printed object whose closing brace sits in the first column.
+// The CLI prints a "provider/id" header, then a pretty-printed object whose
+// closing brace sits in the first column.
 func parseVerboseModels(output []byte) []string {
 	models := []string{}
 	scanner := bufio.NewScanner(bytes.NewReader(output))

--- a/docs/data-and-privacy.md
+++ b/docs/data-and-privacy.md
@@ -17,7 +17,7 @@ coSlash reads, but does not modify:
 | `settings.json` | Synthesis, appearance, and terminal preferences. |
 | `token` | Access token for the current server process. |
 | `summaries/` | Cached synthesis results. |
-| `synthesis/` | Temporary synthesis files. |
+| `synthesis/` | Temporary synthesis files and the OpenCode scratch database. |
 | `sys-prompts/` | Temporary handoffs for fresh sessions. |
 
 coSlash creates the storage directory with mode `0700` and persistent files with mode `0600`. Programs running as your macOS user can still read them.
@@ -26,7 +26,7 @@ coSlash creates the storage directory with mode `0700` and persistent files with
 
 The collector does not upload data itself. If you enable synthesis, it passes a bounded set of session facts—such as prompts or recaps, todos, filenames, commands, and commit text—to your selected local Claude Code, Codex, or OpenCode CLI. That CLI sends the request using its existing authentication, so the selected provider's settings and terms apply.
 
-OpenCode has no ephemeral mode, so coSlash runs it in `~/.coslash/synthesis` and deletes the session it records afterwards. A run that times out can leave one behind; coSlash hides those sessions, and `opencode session delete` removes them.
+OpenCode has no ephemeral mode, so coSlash points it at a scratch database under `~/.coslash/synthesis`. Synthesis runs never enter your own OpenCode history.
 
 Resume and Start fresh launch your installed agent CLI. Its later network and data behavior is governed by that tool.
 

--- a/docs/data-and-privacy.md
+++ b/docs/data-and-privacy.md
@@ -24,7 +24,9 @@ coSlash creates the storage directory with mode `0700` and persistent files with
 
 ## Outbound data
 
-The collector does not upload data itself. If you enable synthesis, it passes a bounded set of session facts—such as prompts or recaps, todos, filenames, commands, and commit text—to your selected local Claude Code or Codex CLI. That CLI sends the request using its existing authentication, so the selected provider's settings and terms apply.
+The collector does not upload data itself. If you enable synthesis, it passes a bounded set of session facts—such as prompts or recaps, todos, filenames, commands, and commit text—to your selected local Claude Code, Codex, or OpenCode CLI. That CLI sends the request using its existing authentication, so the selected provider's settings and terms apply.
+
+OpenCode has no ephemeral mode, so coSlash runs it in `~/.coslash/synthesis` and deletes the session it records afterwards. A run that times out can leave one behind; coSlash hides those sessions, and `opencode session delete` removes them.
 
 Resume and Start fresh launch your installed agent CLI. Its later network and data behavior is governed by that tool.
 

--- a/docs/data-and-privacy.md
+++ b/docs/data-and-privacy.md
@@ -26,7 +26,7 @@ coSlash creates the storage directory with mode `0700` and persistent files with
 
 The collector does not upload data itself. If you enable synthesis, it passes a bounded set of session facts—such as prompts or recaps, todos, filenames, commands, and commit text—to your selected local Claude Code, Codex, or OpenCode CLI. That CLI sends the request using its existing authentication, so the selected provider's settings and terms apply.
 
-OpenCode has no ephemeral mode, so coSlash points it at a scratch database under `~/.coslash/synthesis`. Synthesis runs never enter your own OpenCode history.
+OpenCode has no ephemeral mode, so coSlash points each run at its own scratch database under `~/.coslash/synthesis`, discarded once the run ends. Synthesis runs never enter your own OpenCode history.
 
 Resume and Start fresh launch your installed agent CLI. Its later network and data behavior is governed by that tool.
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -447,9 +447,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -467,9 +464,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -487,9 +481,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -507,9 +498,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -527,9 +515,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -547,9 +532,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -567,9 +549,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -587,9 +566,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2256,9 +2232,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2276,9 +2249,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2296,9 +2266,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2316,9 +2283,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2336,9 +2300,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2356,9 +2317,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2566,9 +2524,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2586,9 +2541,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2606,9 +2558,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2626,9 +2575,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3826,9 +3772,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -4692,9 +4638,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4716,9 +4659,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4740,9 +4680,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4764,9 +4701,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/frontend/src/pages/coslash/components/SettingsDialog.tsx
+++ b/frontend/src/pages/coslash/components/SettingsDialog.tsx
@@ -103,7 +103,6 @@ function backendName(option: BackendOption): string {
   return option.label.replace(/ CLI$/, '');
 }
 
-// Sentinel model that defers to OpenCode's own configured model.
 const OPENCODE_DEFAULT_MODEL = 'default';
 
 const BACKEND_BINARY: Record<string, string> = {

--- a/frontend/src/pages/coslash/components/SettingsDialog.tsx
+++ b/frontend/src/pages/coslash/components/SettingsDialog.tsx
@@ -103,6 +103,15 @@ function backendName(option: BackendOption): string {
   return option.label.replace(/ CLI$/, '');
 }
 
+// Sentinel model that defers to OpenCode's own configured model.
+const OPENCODE_DEFAULT_MODEL = 'default';
+
+const BACKEND_BINARY: Record<string, string> = {
+  'claude-cli': 'claude',
+  'codex_exec': 'codex',
+  'opencode': 'opencode',
+};
+
 function BackendChoice({
   option,
   selected,
@@ -118,11 +127,7 @@ function BackendChoice({
       type="button"
       disabled={!option.available}
       aria-pressed={selected}
-      title={
-        option.available
-          ? name
-          : `The ${option.id === 'codex_exec' ? 'codex' : 'claude'} CLI was not found on PATH`
-      }
+      title={option.available ? name : `The ${BACKEND_BINARY[option.id] ?? option.id} CLI is not available`}
       onClick={onSelect}
       className={cn(
         'border-border bg-background text-foreground focus-visible:ring-ring flex cursor-pointer items-center justify-between gap-2 rounded-xl border px-3 py-3 text-left transition-shadow outline-none focus-visible:ring-3',
@@ -137,6 +142,7 @@ function BackendChoice({
           className={cn('size-2 rounded-full', {
             'bg-claude': option.id === 'claude-cli',
             'bg-codex': option.id === 'codex_exec',
+            'bg-opencode': option.id === 'opencode',
           })}
         />
         <span className="text-[13px] font-semibold">{name}</span>
@@ -352,7 +358,7 @@ export function SettingsDialog({
                           >
                             {selectedBackend?.models.map((option) => (
                               <option key={option.id} value={option.id}>
-                                {option.id}
+                                {option.id === OPENCODE_DEFAULT_MODEL ? option.label : option.id}
                               </option>
                             ))}
                           </SelectControl>

--- a/settings.schema.json
+++ b/settings.schema.json
@@ -16,21 +16,15 @@
       "required": ["enabled", "backend", "model"],
       "properties": {
         "enabled": { "type": "boolean" },
-        "backend": { "enum": ["claude-cli", "codex_exec"] },
-        "model": {
-          "enum": [
-            "claude-haiku-4-5",
-            "claude-sonnet-5",
-            "claude-opus-5",
-            "gpt-5.6-luna",
-            "gpt-5.6-terra",
-            "gpt-5.6-sol"
-          ]
-        }
+        "backend": { "enum": ["claude-cli", "codex_exec", "opencode"] },
+        "model": { "type": "string", "minLength": 1, "maxLength": 200 }
       },
       "allOf": [
         {
-          "if": { "properties": { "backend": { "const": "claude-cli" } } },
+          "if": {
+            "properties": { "backend": { "const": "claude-cli" } },
+            "required": ["backend"]
+          },
           "then": {
             "properties": {
               "model": {
@@ -40,10 +34,26 @@
           }
         },
         {
-          "if": { "properties": { "backend": { "const": "codex_exec" } } },
+          "if": {
+            "properties": { "backend": { "const": "codex_exec" } },
+            "required": ["backend"]
+          },
           "then": {
             "properties": {
               "model": { "enum": ["gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol"] }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "backend": { "const": "opencode" } },
+            "required": ["backend"]
+          },
+          "then": {
+            "properties": {
+              "model": {
+                "pattern": "^(default|[A-Za-z0-9._:-]+(/[A-Za-z0-9._:-]+)+)$"
+              }
             }
           }
         }

--- a/settings.schema.json
+++ b/settings.schema.json
@@ -17,47 +17,20 @@
       "properties": {
         "enabled": { "type": "boolean" },
         "backend": { "enum": ["claude-cli", "codex_exec", "opencode"] },
-        "model": { "type": "string", "minLength": 1, "maxLength": 200 }
-      },
-      "allOf": [
-        {
-          "if": {
-            "properties": { "backend": { "const": "claude-cli" } },
-            "required": ["backend"]
-          },
-          "then": {
-            "properties": {
-              "model": {
-                "enum": ["claude-haiku-4-5", "claude-sonnet-5", "claude-opus-5"]
-              }
-            }
-          }
-        },
-        {
-          "if": {
-            "properties": { "backend": { "const": "codex_exec" } },
-            "required": ["backend"]
-          },
-          "then": {
-            "properties": {
-              "model": { "enum": ["gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol"] }
-            }
-          }
-        },
-        {
-          "if": {
-            "properties": { "backend": { "const": "opencode" } },
-            "required": ["backend"]
-          },
-          "then": {
-            "properties": {
-              "model": {
-                "pattern": "^(default|[A-Za-z0-9._:-]+(/[A-Za-z0-9._:-]+)+)$"
-              }
-            }
-          }
+        "model": {
+          "description": "Model id passed to the selected CLI. Settings offers a short list per backend, but any model that CLI can reach is accepted, including models served through an API proxy or a third-party provider. For the opencode backend, \"default\" passes no model and lets OpenCode resolve one.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._:/-]*$",
+          "examples": [
+            "claude-haiku-4-5",
+            "gpt-5.6-luna",
+            "opencode/deepseek-v4-flash-free",
+            "default"
+          ]
         }
-      ]
+      }
     },
     "appearance": {
       "type": "object",


### PR DESCRIPTION
## Context

Session debriefs could only run through the Claude Code or Codex CLIs. With
neither installed, synthesis could not be enabled at all — the Settings dialog
left it off because no backend reported as available. OpenCode was already a
first-class read source, so the gap was only on the invoke side.

## Changes

- **OpenCode as a third synthesis backend** — detected on PATH like the others.
  - Offers the free OpenCode Zen models, plus *Whichever model OpenCode is set to use*.
  - That list comes from `opencode models opencode --verbose`, cached for ten minutes
    and filtered to zero-cost models that OpenCode has not deprecated.
  - The probe runs from an empty directory with `--pure` and project config off.
    OpenCode loads project plugins from the working directory, so a probe inheriting
    the collector's cwd would run repository code on opening Settings. Global config
    is left intact, since enumerating models needs its providers.
  - It stays a probe rather than a read of the embedded price table: only 7 of the 27
    free models OpenCode has published are still live, that table carries no
    retirement signal, and it freezes at release while the free tier turns over in
    weeks.
  - Defaults to `opencode/deepseek-v4-flash-free`, run at its `high` reasoning variant.
  - That last option passes no `--model`, leaving OpenCode to resolve one itself:
    its configured model key, else the model last selected in the CLI.
  - Paid providers are reached that way rather than listed — OpenCode resolves them
    from ambient credentials, and the full list runs to hundreds of entries.
- **Compensating for flags OpenCode does not have**
  - No structured output → schema described in the prompt, reply parsed leniently,
    then checked for the fields the schema marks required. A partial object now
    fails into cooldown rather than being cached as a debrief.
  - No system-prompt flag → instructions ride along with the message.
  - No tool flags → tools denied through an injected config.
  - No ephemeral mode → each run gets its own scratch database under
    `~/.coslash/synthesis`, removed once the run ends, so runs never enter the
    user's own OpenCode history.
  - Per run rather than shared: OpenCode instances that overlap in time deadlock
    during init on a shared database, and the manager runs up to four at once.
  - A crash skips the cleanup, so directories older than an hour are swept at
    startup. The cutoff sits well past the 90s run timeout, so a second collector
    on `--port` cannot lose a live run's database to the sweep.
  - `--dir` passed explicitly, since OpenCode reads `PWD` before the process
    working directory.
- **Model validation relaxed to a shape check**, across all three backends.
  - The dropdown still offers the same curated options.
  - `settings.json` now accepts any model the chosen CLI can reach, including one
    behind an API proxy such as `ANTHROPIC_BASE_URL`.
  - Ids starting with `-` are rejected, so a value cannot be read as a CLI flag.
- **Each backend's default model runs at high reasoning effort.**
  - Codex: `-c model_reasoning_effort=high`; OpenCode: `--variant high`; Claude: `--effort high`.
  - Scoped to the default model on each backend, so an explicitly chosen model
    keeps the CLI's own default.
  - Note `--effort` works on `claude-haiku-4-5` through the CLI even though the
    Messages API rejects `output_config.effort` for that model.
- **Debrief outcomes are no longer truncated**, for every backend.
  - Previously capped at 200 characters with a trailing ellipsis; now only
    whitespace-collapsed. Goals, decisions, and next step keep their caps.

## Test

- Automated
  - `go build ./... && go vet ./... && go test ./...` — passed
  - Unit tests cover the OpenCode parse path: incomplete objects rejected
    (including `null` goals), bare, fenced, and prose-wrapped objects accepted.
  - Unit tests cover JSON framing (nesting, braces and escapes inside strings) and
    the scratch sweep (abandoned removed, in-flight and unrelated left alone).
  - `npm run build && npm test && npm run lint` — passed
- Manual
  - Real debriefs generated through all three backends: Claude, Codex, and OpenCode.
  - Reasoning-effort flags confirmed with logging shims on PATH — present for each
    backend's default model, absent for a non-default one.
  - Scratch database verified: after a full run, zero synthesis sessions in the
    user's OpenCode database and one in the scratch file. Verified before the
    database became per-run; concurrent runs not yet exercised by hand.
  - Probe isolation verified against OpenCode 1.18.18: a repo carrying a marker
    plugin in `.opencode/plugin` and `.opencode/plugins` executed it on the old
    invocation, and did not on the new one, which still returned the same 7 models.
  - Outcome verified untruncated end to end (512 and 685 characters, no ellipsis).
  - Validation matrix: curated and proxy-style ids accepted; flag-shaped and
    whitespace ids rejected.
  - Free-model list cross-checked against OpenCode's registry: the 7 models the CLI
    reports match filtering `models.opencode.ai/api.json` on zero cost and
    non-deprecated status, exactly.

### Screenshots

- [X] Settings dialog — synthesis on, three backend cards, OpenCode selected with the model dropdown open
<img width="667" height="817" alt="Screenshot 2026-08-17 at 5 10 21 PM" src="https://github.com/user-attachments/assets/2ef29074-ccea-4cf1-b01b-a781a99c1e5c" />

- [X] Session inspector — a DEBRIEF card generated by the OpenCode backend
<img width="793" height="162" alt="Screenshot 2026-08-17 at 5 11 57 PM" src="https://github.com/user-attachments/assets/7c283cef-609b-4329-985f-dbb5b8e6578b" />



