### PR TITLE
Fix: Polish session inspector timeline and command display

### DIFF
--- a/frontend/src/pages/coslash/components/SessionInspector.tsx
+++ b/frontend/src/pages/coslash/components/SessionInspector.tsx
@@ -499,7 +499,9 @@ function DigestRow({ entry }: { entry: DigestEntry }) {
       <span className={cn('w-24 shrink-0 text-xs font-bold tracking-wide', meta.fg)}>{meta.label}</span>
       <div className="min-w-0 flex-1">
         <div className={cn('text-xs', { 'line-clamp-1': collapsible && !expanded })}>{entry.description}</div>
-        {entry.answer != null && <div className="pl-4 text-xs">{entry.answer}</div>}
+        {entry.answer != null && (
+          <div className="border-border text-muted-foreground border-l-2 pl-2 text-xs">{entry.answer}</div>
+        )}
         {collapsible && (
           <div
             className="text-brand flex cursor-pointer items-center gap-1 pt-1 text-xs"

--- a/frontend/src/pages/coslash/components/SessionInspector.tsx
+++ b/frontend/src/pages/coslash/components/SessionInspector.tsx
@@ -495,7 +495,7 @@ function DigestRow({ entry }: { entry: DigestEntry }) {
   const collapsible = entry.category === 'recap' && entry.description.length > 120;
 
   return (
-    <div className="flex items-baseline gap-2 border-b border-neutral-100 py-1">
+    <div className="border-border flex items-baseline gap-2 border-b py-1">
       <span className={cn('w-24 shrink-0 text-xs font-bold tracking-wide', meta.fg)}>{meta.label}</span>
       <div className="min-w-0 flex-1">
         <div className={cn('text-xs', { 'line-clamp-1': collapsible && !expanded })}>{entry.description}</div>
@@ -708,7 +708,7 @@ function CommitsAndTodos({ detail }: { detail: SessionDetail }) {
 }
 
 function CommandsSection({ detail }: { detail: SessionDetail }) {
-  const [open, setOpen] = useState(true);
+  const [open, setOpen] = useState(false);
   if (detail.commands.length === 0) return null;
 
   return (


### PR DESCRIPTION
## Context

The session inspector can become visually dense, especially when command output is expanded by default. Timeline answers also need clearer hierarchy, while fixed light-colored dividers appear overly bright in dark mode.

## Changes

- Collapse command history by default while retaining its disclosure control.
- Render question answers as muted, theme-aware blockquotes.
- Use the semantic border color for softer timeline dividers in dark mode.

## Test

- `npm test` — passed (10 tests)
- `npm run build` — passed
- `./node_modules/.bin/oxlint src/pages/coslash/components/SessionInspector.tsx` — passed
- `./node_modules/.bin/prettier --check src/pages/coslash/components/SessionInspector.tsx` — passed

### Screenshots

- [X] Session inspector — quoted question answer and collapsed command history
<img width="609" height="288" alt="Screenshot 2026-08-17 at 10 53 47 AM" src="https://github.com/user-attachments/assets/0f526884-0745-433e-b38d-7a52ea16dedd" />

- [X] Session inspector timeline — softened dark-mode dividers
<img width="615" height="622" alt="Screenshot 2026-08-17 at 10 53 37 AM" src="https://github.com/user-attachments/assets/8c56cd07-2880-4098-a040-f540795b4b3e" />
