### PR TITLE
feat(collector): capture canonical session start times

### DIFF
--- a/collector/internal/collector/collector.go
+++ b/collector/internal/collector/collector.go
@@ -87,10 +87,20 @@ func List(since int64) ([]*session.Session, error) {
 }
 
 func applyActivityFallbacks(parsed []*vendors.ParsedSession) {
+	collectedAt := time.Now().UnixMilli()
 	for _, item := range parsed {
 		s := item.Session
 		if s.LastActivityTime == 0 && item.LogPath != "" {
 			s.LastActivityTime = session.FileModificationTime(item.LogPath)
+		}
+		// The export contract requires a positive start. Prefer last activity,
+		// then collection time when the source and its log provide no timestamp.
+		if s.StartedAt == 0 {
+			s.StartedAt = s.LastActivityTime
+			if s.StartedAt == 0 {
+				s.StartedAt = collectedAt
+				s.LastActivityTime = collectedAt
+			}
 		}
 	}
 }

--- a/collector/internal/collector/collector_test.go
+++ b/collector/internal/collector/collector_test.go
@@ -1,0 +1,41 @@
+package collector
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/centauri-ai/coslash/collector/internal/session"
+	"github.com/centauri-ai/coslash/collector/internal/vendors"
+)
+
+func TestApplyActivityFallbacksKeepsSessionsExportable(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "session.jsonl")
+	if err := os.WriteFile(logPath, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	modified := session.FileModificationTime(logPath)
+
+	untimed := &vendors.ParsedSession{Session: &session.Session{}, LogPath: logPath}
+	noLog := &vendors.ParsedSession{Session: &session.Session{LastActivityTime: 500}}
+	noTimingData := &vendors.ParsedSession{Session: &session.Session{}}
+	parsed := &vendors.ParsedSession{Session: &session.Session{StartedAt: 100, LastActivityTime: 900}}
+
+	applyActivityFallbacks([]*vendors.ParsedSession{untimed, noLog, noTimingData, parsed})
+
+	if untimed.Session.LastActivityTime != modified || untimed.Session.StartedAt != modified {
+		t.Fatalf("untimed session = start %d, activity %d; want %d for both",
+			untimed.Session.StartedAt, untimed.Session.LastActivityTime, modified)
+	}
+	if noLog.Session.StartedAt != 500 {
+		t.Fatalf("session without a log path = start %d; want 500", noLog.Session.StartedAt)
+	}
+	if noTimingData.Session.StartedAt <= 0 || noTimingData.Session.LastActivityTime != noTimingData.Session.StartedAt {
+		t.Fatalf("session without timing data = start %d, activity %d; want equal positive collection time",
+			noTimingData.Session.StartedAt, noTimingData.Session.LastActivityTime)
+	}
+	if parsed.Session.StartedAt != 100 || parsed.Session.LastActivityTime != 900 {
+		t.Fatalf("parsed timestamps were overwritten: start %d, activity %d",
+			parsed.Session.StartedAt, parsed.Session.LastActivityTime)
+	}
+}

--- a/collector/internal/session/session.go
+++ b/collector/internal/session/session.go
@@ -53,6 +53,7 @@ type Session struct {
 	Cost                float64                `json:"cost"`
 	UnpricedModels      []string               `json:"unpricedModels"`
 	Subagents           []Subagent             `json:"subagents"`
+	StartedAt           int64                  `json:"-"`
 	LastActivityTime    int64                  `json:"mtime"`
 	Entrypoint          *string                `json:"entrypoint"`
 	SessionDetails

--- a/collector/internal/vendors/claude/parse.go
+++ b/collector/internal/vendors/claude/parse.go
@@ -422,6 +422,7 @@ func (analysis *claudeSessionAnalysis) unifiedSession(filePath string) *session.
 		Branch:           analysis.branch,
 		Entrypoint:       analysis.entrypoint,
 		SessionDetails:   unifiedSessionDetails,
+		StartedAt:        analysis.timestamps.Earliest,
 		LastActivityTime: analysis.timestamps.Latest,
 		EditedFileCount:  len(analysis.editedFiles),
 		Tokens:           analysis.tokens,

--- a/collector/internal/vendors/codex/parse.go
+++ b/collector/internal/vendors/codex/parse.go
@@ -406,6 +406,7 @@ func (analysis *codexSessionAnalysis) unifiedSession(filePath string) *session.S
 		WorkingDirectory: analysis.workingDirectory,
 		Branch:           analysis.branch,
 		Entrypoint:       analysis.entrypoint,
+		StartedAt:        analysis.timestamps.Earliest,
 		LastActivityTime: analysis.timestamps.Latest,
 		EditedFileCount:  len(analysis.fileEdits.Edits),
 		SessionDetails:   unifiedSessionDetails,

--- a/collector/internal/vendors/opencode/parse.go
+++ b/collector/internal/vendors/opencode/parse.go
@@ -281,6 +281,7 @@ func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 		ID:               row.id,
 		WorkingDirectory: row.directory,
 		EditedFileCount:  editedFileCount,
+		StartedAt:        earliestMessageTime(messages),
 		LastActivityTime: row.updatedAt,
 		Tokens:           tokens,
 		Subagents:        []session.Subagent{},
@@ -316,6 +317,17 @@ func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 		parsed.StatusHint = &status
 	}
 	return parsedSession{transcript: parsed, tasks: tasks}, nil
+}
+
+func earliestMessageTime(messages []storedMessage) int64 {
+	earliest := int64(0)
+	for _, message := range messages {
+		created := message.Time.Created
+		if created > 0 && (earliest == 0 || created < earliest) {
+			earliest = created
+		}
+	}
+	return earliest
 }
 
 func addCompletedToolEdits(cwd string, part *storedPart, edits *session.FileEditSet) bool {

--- a/collector/internal/vendors/opencode/parse_test.go
+++ b/collector/internal/vendors/opencode/parse_test.go
@@ -1,0 +1,15 @@
+package opencode
+
+import "testing"
+
+func TestEarliestMessageTimeIgnoresMissingTimestamps(t *testing.T) {
+	messages := make([]storedMessage, 4)
+	messages[0].Time.Created = 0
+	messages[1].Time.Created = 500
+	messages[2].Time.Created = 200
+	messages[3].Time.Created = -1
+
+	if got := earliestMessageTime(messages); got != 200 {
+		t.Fatalf("earliest message time = %d; want 200", got)
+	}
+}


### PR DESCRIPTION
## Summary

Capture one canonical session start time across Claude, Codex, and OpenCode sessions.

## Why this is separate

The snapshot envelope needs a stable, positive start timestamp, but timestamp collection is useful and reviewable independently of the export contract. This PR contains only local model and parser changes.

## Changes

- add `Session.StartedAt`;
- derive the earliest known timestamp in each vendor parser;
- derive OpenCode start time from valid message timestamps without requiring a new database column;
- fall back to collection time when neither session nor activity timestamps are available;
- keep start time at or before last activity.

## Review guide

Start with the `Session` field, then review each vendor's timestamp source and the collector fallback. No wire format or upload behavior is introduced here.

## Verification

- `go test ./...`
- `go vet ./...`

## Stack

This is PR 1 of 5 for ENG-1340. Merge the stack in table order.

| Order | PR | Scope |
| ---: | --- | --- |
| 1 | [#83](https://github.com/centauri-ai/coslash/pull/83) | Canonical session start |
| 2 | [#84](https://github.com/centauri-ai/coslash/pull/84) | Public v1 contract |
| 3 | [#85](https://github.com/centauri-ai/coslash/pull/85) | Private-to-wire export boundary |
| 4 | [#86](https://github.com/centauri-ai/coslash/pull/86) | Aggregate payload fitting |
| 5 | [#87](https://github.com/centauri-ai/coslash/pull/87) | Fixtures, measurement, and docs |

## Rollout

This is an additive internal-model change. It can merge and roll back independently before the snapshot exporter is enabled.
