### PR TITLE
feat(snapshot): define session snapshot v1 contract

### DIFF
--- a/collector/internal/collector/collector.go
+++ b/collector/internal/collector/collector.go
@@ -87,10 +87,20 @@ func List(since int64) ([]*session.Session, error) {
 }
 
 func applyActivityFallbacks(parsed []*vendors.ParsedSession) {
+	collectedAt := time.Now().UnixMilli()
 	for _, item := range parsed {
 		s := item.Session
 		if s.LastActivityTime == 0 && item.LogPath != "" {
 			s.LastActivityTime = session.FileModificationTime(item.LogPath)
+		}
+		// The export contract requires a positive start. Prefer last activity,
+		// then collection time when the source and its log provide no timestamp.
+		if s.StartedAt == 0 {
+			s.StartedAt = s.LastActivityTime
+			if s.StartedAt == 0 {
+				s.StartedAt = collectedAt
+				s.LastActivityTime = collectedAt
+			}
 		}
 	}
 }

--- a/collector/internal/collector/collector_test.go
+++ b/collector/internal/collector/collector_test.go
@@ -1,0 +1,41 @@
+package collector
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/centauri-ai/coslash/collector/internal/session"
+	"github.com/centauri-ai/coslash/collector/internal/vendors"
+)
+
+func TestApplyActivityFallbacksKeepsSessionsExportable(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "session.jsonl")
+	if err := os.WriteFile(logPath, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	modified := session.FileModificationTime(logPath)
+
+	untimed := &vendors.ParsedSession{Session: &session.Session{}, LogPath: logPath}
+	noLog := &vendors.ParsedSession{Session: &session.Session{LastActivityTime: 500}}
+	noTimingData := &vendors.ParsedSession{Session: &session.Session{}}
+	parsed := &vendors.ParsedSession{Session: &session.Session{StartedAt: 100, LastActivityTime: 900}}
+
+	applyActivityFallbacks([]*vendors.ParsedSession{untimed, noLog, noTimingData, parsed})
+
+	if untimed.Session.LastActivityTime != modified || untimed.Session.StartedAt != modified {
+		t.Fatalf("untimed session = start %d, activity %d; want %d for both",
+			untimed.Session.StartedAt, untimed.Session.LastActivityTime, modified)
+	}
+	if noLog.Session.StartedAt != 500 {
+		t.Fatalf("session without a log path = start %d; want 500", noLog.Session.StartedAt)
+	}
+	if noTimingData.Session.StartedAt <= 0 || noTimingData.Session.LastActivityTime != noTimingData.Session.StartedAt {
+		t.Fatalf("session without timing data = start %d, activity %d; want equal positive collection time",
+			noTimingData.Session.StartedAt, noTimingData.Session.LastActivityTime)
+	}
+	if parsed.Session.StartedAt != 100 || parsed.Session.LastActivityTime != 900 {
+		t.Fatalf("parsed timestamps were overwritten: start %d, activity %d",
+			parsed.Session.StartedAt, parsed.Session.LastActivityTime)
+	}
+}

--- a/collector/internal/session/session.go
+++ b/collector/internal/session/session.go
@@ -53,6 +53,7 @@ type Session struct {
 	Cost                float64                `json:"cost"`
 	UnpricedModels      []string               `json:"unpricedModels"`
 	Subagents           []Subagent             `json:"subagents"`
+	StartedAt           int64                  `json:"-"`
 	LastActivityTime    int64                  `json:"mtime"`
 	Entrypoint          *string                `json:"entrypoint"`
 	SessionDetails

--- a/collector/internal/vendors/claude/parse.go
+++ b/collector/internal/vendors/claude/parse.go
@@ -422,6 +422,7 @@ func (analysis *claudeSessionAnalysis) unifiedSession(filePath string) *session.
 		Branch:           analysis.branch,
 		Entrypoint:       analysis.entrypoint,
 		SessionDetails:   unifiedSessionDetails,
+		StartedAt:        analysis.timestamps.Earliest,
 		LastActivityTime: analysis.timestamps.Latest,
 		EditedFileCount:  len(analysis.editedFiles),
 		Tokens:           analysis.tokens,

--- a/collector/internal/vendors/codex/parse.go
+++ b/collector/internal/vendors/codex/parse.go
@@ -406,6 +406,7 @@ func (analysis *codexSessionAnalysis) unifiedSession(filePath string) *session.S
 		WorkingDirectory: analysis.workingDirectory,
 		Branch:           analysis.branch,
 		Entrypoint:       analysis.entrypoint,
+		StartedAt:        analysis.timestamps.Earliest,
 		LastActivityTime: analysis.timestamps.Latest,
 		EditedFileCount:  len(analysis.fileEdits.Edits),
 		SessionDetails:   unifiedSessionDetails,

--- a/collector/internal/vendors/opencode/parse.go
+++ b/collector/internal/vendors/opencode/parse.go
@@ -281,6 +281,7 @@ func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 		ID:               row.id,
 		WorkingDirectory: row.directory,
 		EditedFileCount:  editedFileCount,
+		StartedAt:        earliestMessageTime(messages),
 		LastActivityTime: row.updatedAt,
 		Tokens:           tokens,
 		Subagents:        []session.Subagent{},
@@ -316,6 +317,17 @@ func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 		parsed.StatusHint = &status
 	}
 	return parsedSession{transcript: parsed, tasks: tasks}, nil
+}
+
+func earliestMessageTime(messages []storedMessage) int64 {
+	earliest := int64(0)
+	for _, message := range messages {
+		created := message.Time.Created
+		if created > 0 && (earliest == 0 || created < earliest) {
+			earliest = created
+		}
+	}
+	return earliest
 }
 
 func addCompletedToolEdits(cwd string, part *storedPart, edits *session.FileEditSet) bool {

--- a/collector/internal/vendors/opencode/parse_test.go
+++ b/collector/internal/vendors/opencode/parse_test.go
@@ -1,0 +1,15 @@
+package opencode
+
+import "testing"
+
+func TestEarliestMessageTimeIgnoresMissingTimestamps(t *testing.T) {
+	messages := make([]storedMessage, 4)
+	messages[0].Time.Created = 0
+	messages[1].Time.Created = 500
+	messages[2].Time.Created = 200
+	messages[3].Time.Created = -1
+
+	if got := earliestMessageTime(messages); got != 200 {
+		t.Fatalf("earliest message time = %d; want 200", got)
+	}
+}

--- a/collector/snapshot/v1/README.md
+++ b/collector/snapshot/v1/README.md
@@ -1,0 +1,61 @@
+# `session-snapshot/v1`
+
+This directory is the public, deployment-independent contract for session data
+that may leave a developer machine. Private collector models are not wire
+types; publishers must explicitly map into this contract.
+
+## Protocol
+
+- Schema version: `session-snapshot/v1`
+- Media type: `application/vnd.coslash.session-snapshot.v1+json`
+- Aggregate limit: 256 KiB of uncompressed canonical JSON
+- Breaking changes: publish a new version; never mutate the meaning of v1
+
+The envelope includes collector version, agent, source session ID, canonical
+session start in Unix milliseconds, repository identity, structural redaction
+and truncation records, and a SHA-256 content hash.
+
+`contentHash` is `sha256:` plus the lowercase digest of the canonical JSON with
+the `contentHash` member omitted. Canonical JSON uses the member order of the
+Go wire structs, UTF-8 `encoding/json` string escaping, no insignificant
+whitespace, no trailing newline, source order for meaningful lists, sorted
+model lists, and integer micro-USD costs. Publishers must use the exact byte
+slice returned by `snapshotv1.Marshal`.
+
+## Shape and budgets
+
+| Shape | Limit |
+| --- | ---: |
+| Collector version | 64 UTF-8 bytes |
+| Agent identifier | 64 lowercase ASCII characters; starts alphanumeric, then letters, digits, `_`, or `-` |
+| Source IDs | 512 UTF-8 bytes |
+| Canonical repository | 1,024 UTF-8 bytes |
+| Name | 512 UTF-8 bytes |
+| Summary and digest description/answer | 4 KiB each |
+| Repository-relative paths | 1 KiB each |
+| Branch and entrypoint | 512 UTF-8 bytes each |
+| Model names | 256 UTF-8 bytes each; 100 models |
+| Declared goal and first prompt | 16 KiB each |
+| Digest | 200 entries |
+| Todos | 200 entries; 2 KiB text each |
+| File edits | 2,000 entries |
+| Commit subjects | 200 entries; 2 KiB each |
+| Subagents | 100 entries; 8 KiB task/result each |
+| Human subagent command labels | 200 total; 512 bytes each |
+
+Text is normalized to LF and truncated only at a valid UTF-8 boundary. Metadata
+paths are RFC 6901 JSON Pointers that resolve against the exported payload.
+Changes to retained values use their exact path; omitted source values use the
+nearest retained container.
+
+## Validation and compatibility
+
+`Decode` rejects unknown fields, non-canonical JSON, bad hashes, negative
+counts, null collection fields, over-budget fields, unsafe paths, and oversized
+payloads. The JSON Schema mirrors the portable shape; UTF-8 byte limits and
+canonical hashing remain protocol checks because JSON Schema `maxLength`
+counts Unicode code points rather than encoded bytes.
+
+Adding or changing a wire field requires coordinated updates to the Go types,
+schema, documentation, and compatibility tests. Agent identifiers are
+intentionally extensible within v1. Unknown object fields remain rejected.

--- a/collector/snapshot/v1/boundary_test.go
+++ b/collector/snapshot/v1/boundary_test.go
@@ -1,0 +1,193 @@
+package snapshotv1
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestBoundedWireFieldsAcceptExactUTF8BytesAndRejectOneMore(t *testing.T) {
+	tests := []struct {
+		name   string
+		limit  int
+		assign func(*Snapshot, string)
+	}{
+		{"collector version", MaxCollectorVersionBytes, func(s *Snapshot, v string) { s.CollectorVersion = v }},
+		{"source session id", MaxIdentifierBytes, func(s *Snapshot, v string) { s.SourceSessionID = v }},
+		{"repository", MaxRepositoryBytes, func(s *Snapshot, v string) { s.Repository.Canonical = v }},
+		{"session name", MaxNameBytes, func(s *Snapshot, v string) { s.Session.Name = &v }},
+		{"session summary", MaxSummaryBytes, func(s *Snapshot, v string) { s.Session.Summary = &v }},
+		{"session status", 64, func(s *Snapshot, v string) { s.Session.Status = &v }},
+		{"working directory", MaxPathBytes, func(s *Snapshot, v string) { s.Session.WorkingDirectory = &v }},
+		{"branch", MaxBranchBytes, func(s *Snapshot, v string) { s.Session.Branch = &v }},
+		{"entrypoint", MaxEntrypointBytes, func(s *Snapshot, v string) { s.Session.Entrypoint = &v }},
+		{"session model", MaxModelBytes, func(s *Snapshot, v string) { s.Session.Model = &v }},
+		{"declared goal", MaxGoalBytes, func(s *Snapshot, v string) { s.Session.DeclaredGoal = &v }},
+		{"first prompt", MaxPromptBytes, func(s *Snapshot, v string) { s.Session.FirstPrompt = &v }},
+		{"usage model", MaxModelBytes, func(s *Snapshot, v string) { s.Session.Usage.Models = []ModelUsage{{Model: v}} }},
+		{"unpriced model", MaxModelBytes, func(s *Snapshot, v string) { s.Session.Usage.UnpricedModels = []string{v} }},
+		{"digest category", 64, func(s *Snapshot, v string) { s.Session.Digest = []Digest{{Category: v}} }},
+		{"digest description", MaxDigestTextBytes, func(s *Snapshot, v string) { s.Session.Digest = []Digest{{Category: "user", Description: v}} }},
+		{"digest answer", MaxDigestTextBytes, func(s *Snapshot, v string) { s.Session.Digest = []Digest{{Category: "user", Answer: &v}} }},
+		{"digest subagent id", MaxIdentifierBytes, func(s *Snapshot, v string) { s.Session.Digest = []Digest{{Category: "user", SubagentID: &v}} }},
+		{"todo text", MaxTodoTextBytes, func(s *Snapshot, v string) { s.Session.Todos = []Todo{{Text: v}} }},
+		{"file edit path", MaxPathBytes, func(s *Snapshot, v string) { s.Session.FileEdits = []FileEdit{{Path: v}} }},
+		{"commit subject", MaxCommitTextBytes, func(s *Snapshot, v string) { s.Session.Commits = []string{v} }},
+		{"git base branch", MaxBranchBytes, func(s *Snapshot, v string) { s.Session.Git = &GitDrift{BaseBranch: v} }},
+		{"subagent id", MaxIdentifierBytes, func(s *Snapshot, v string) {
+			a := validBoundarySubagent()
+			a.ID = v
+			s.Session.Subagents = []Subagent{a}
+		}},
+		{"subagent name", MaxNameBytes, func(s *Snapshot, v string) {
+			a := validBoundarySubagent()
+			a.Name = v
+			s.Session.Subagents = []Subagent{a}
+		}},
+		{"subagent model", MaxModelBytes, func(s *Snapshot, v string) {
+			a := validBoundarySubagent()
+			a.Model = &v
+			s.Session.Subagents = []Subagent{a}
+		}},
+		{"subagent status", 64, func(s *Snapshot, v string) {
+			a := validBoundarySubagent()
+			a.Status = v
+			s.Session.Subagents = []Subagent{a}
+		}},
+		{"subagent task", MaxSubagentTextBytes, func(s *Snapshot, v string) {
+			a := validBoundarySubagent()
+			a.Task = v
+			s.Session.Subagents = []Subagent{a}
+		}},
+		{"subagent result", MaxSubagentTextBytes, func(s *Snapshot, v string) {
+			a := validBoundarySubagent()
+			a.Result = v
+			s.Session.Subagents = []Subagent{a}
+		}},
+		{"command label", MaxCommandLabelBytes, func(s *Snapshot, v string) {
+			a := validBoundarySubagent()
+			a.CommandLabels = []string{v}
+			s.Session.Subagents = []Subagent{a}
+		}},
+		{"subagent usage model", MaxModelBytes, func(s *Snapshot, v string) {
+			a := validBoundarySubagent()
+			a.Usage = []ModelUsage{{Model: v}}
+			s.Session.Subagents = []Subagent{a}
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			exact := strings.Repeat("é", test.limit/2)
+			if len(exact) != test.limit {
+				t.Fatalf("test setup produced %d bytes; want %d", len(exact), test.limit)
+			}
+			valid := validSnapshot()
+			test.assign(&valid, exact)
+			if _, err := Marshal(valid); err != nil {
+				t.Fatalf("exact %d-byte UTF-8 value rejected: %v", test.limit, err)
+			}
+
+			over := validSnapshot()
+			test.assign(&over, exact+"x")
+			if _, err := Marshal(over); err == nil {
+				t.Fatalf("%d-byte value accepted; limit is %d", test.limit+1, test.limit)
+			}
+		})
+	}
+}
+
+func TestBoundedWireCollectionsAcceptExactLimitAndRejectOneMore(t *testing.T) {
+	tests := []struct {
+		name   string
+		limit  int
+		assign func(*Snapshot, int)
+	}{
+		{"usage models", MaxUsageModels, func(s *Snapshot, n int) { s.Session.Usage.Models = boundaryUsage(n) }},
+		{"unpriced models", MaxUnpricedModels, func(s *Snapshot, n int) { s.Session.Usage.UnpricedModels = boundaryStrings("u", n) }},
+		{"digest", MaxDigestItems, func(s *Snapshot, n int) {
+			s.Session.Digest = make([]Digest, n)
+			for i := range s.Session.Digest {
+				s.Session.Digest[i].Category = "x"
+			}
+		}},
+		{"todos", MaxTodoItems, func(s *Snapshot, n int) { s.Session.Todos = make([]Todo, n) }},
+		{"file edits", MaxFileEditItems, func(s *Snapshot, n int) {
+			s.Session.FileEdits = make([]FileEdit, n)
+			for i := range s.Session.FileEdits {
+				s.Session.FileEdits[i].Path = "x"
+			}
+		}},
+		{"commits", MaxCommitItems, func(s *Snapshot, n int) { s.Session.Commits = make([]string, n) }},
+		{"subagents", MaxSubagentItems, func(s *Snapshot, n int) {
+			s.Session.Subagents = make([]Subagent, n)
+			for i := range s.Session.Subagents {
+				s.Session.Subagents[i] = validBoundarySubagent()
+			}
+		}},
+		{"command labels", MaxCommandLabelItems, func(s *Snapshot, n int) {
+			a := validBoundarySubagent()
+			a.CommandLabels = make([]string, n)
+			for i := range a.CommandLabels {
+				a.CommandLabels[i] = "x"
+			}
+			s.Session.Subagents = []Subagent{a}
+		}},
+		{"subagent usage models", MaxUsageModels, func(s *Snapshot, n int) {
+			a := validBoundarySubagent()
+			a.Usage = boundaryUsage(n)
+			s.Session.Subagents = []Subagent{a}
+		}},
+		{"truncation metadata", 5000, func(s *Snapshot, n int) {
+			s.Truncation = make([]Truncation, n)
+			for i := range s.Truncation {
+				s.Truncation[i] = Truncation{Path: "/session", Reason: TruncationReasonTextBudget}
+			}
+		}},
+		{"redaction metadata", 5000, func(s *Snapshot, n int) {
+			s.Redactions = make([]Redaction, n)
+			for i := range s.Redactions {
+				s.Redactions[i] = Redaction{Path: "/session", Reason: "x"}
+			}
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			valid := validSnapshot()
+			test.assign(&valid, test.limit)
+			if _, err := Marshal(valid); err != nil {
+				t.Fatalf("exact item limit %d rejected: %v", test.limit, err)
+			}
+
+			over := validSnapshot()
+			test.assign(&over, test.limit+1)
+			if _, err := Marshal(over); err == nil {
+				t.Fatalf("%d items accepted; limit is %d", test.limit+1, test.limit)
+			}
+		})
+	}
+}
+
+func boundaryUsage(n int) []ModelUsage {
+	result := make([]ModelUsage, n)
+	for i := range result {
+		result[i].Model = fmt.Sprintf("m%05d", i)
+	}
+	return result
+}
+
+func boundaryStrings(prefix string, n int) []string {
+	result := make([]string, n)
+	for i := range result {
+		result[i] = fmt.Sprintf("%s%05d", prefix, i)
+	}
+	return result
+}
+
+func validBoundarySubagent() Subagent {
+	return Subagent{
+		ID: "child", Name: "worker", Status: "returned",
+		CommandLabels: []string{}, Usage: []ModelUsage{},
+	}
+}

--- a/collector/snapshot/v1/schema.json
+++ b/collector/snapshot/v1/schema.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coslash.ai/schemas/session-snapshot/v1.json",
+  "title": "coSlash session-snapshot/v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "mediaType", "collectorVersion", "agent", "sourceSessionId", "sessionStartedAtMs", "contentHash", "repository", "truncation", "redactions", "session"],
+  "properties": {
+    "schemaVersion": {"const": "session-snapshot/v1"},
+    "mediaType": {"const": "application/vnd.coslash.session-snapshot.v1+json"},
+    "collectorVersion": {"type": "string", "minLength": 1, "maxLength": 64, "x-maxUtf8Bytes": 64},
+    "agent": {"type": "string", "pattern": "^[a-z0-9][a-z0-9_-]{0,63}$", "maxLength": 64, "x-maxUtf8Bytes": 64},
+    "sourceSessionId": {"$ref": "#/$defs/id"},
+    "sessionStartedAtMs": {"type": "integer", "minimum": 1},
+    "contentHash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "repository": {"$ref": "#/$defs/repository"},
+    "truncation": {"type": "array", "maxItems": 5000, "items": {"$ref": "#/$defs/truncation"}},
+    "redactions": {"type": "array", "maxItems": 5000, "items": {"$ref": "#/$defs/redaction"}},
+    "session": {"$ref": "#/$defs/session"}
+  },
+  "$defs": {
+    "nonNegativeInteger": {"type": "integer", "minimum": 0},
+    "id": {"type": "string", "minLength": 1, "maxLength": 512, "x-maxUtf8Bytes": 512},
+    "model": {"type": "string", "minLength": 1, "maxLength": 256, "x-maxUtf8Bytes": 256},
+    "repository": {
+      "type": "object", "additionalProperties": false,
+      "required": ["canonical", "localOnly"],
+      "properties": {
+        "canonical": {"type": "string", "minLength": 1, "maxLength": 1024, "x-maxUtf8Bytes": 1024},
+        "localOnly": {"type": "boolean"}
+      }
+    },
+    "truncation": {
+      "type": "object", "additionalProperties": false,
+      "required": ["path", "reason"],
+      "properties": {
+        "path": {"type": "string", "pattern": "^(?:/(?:[^~]|~[01])*)+$"},
+        "reason": {"enum": ["text_budget", "item_budget", "aggregate_budget"]},
+        "originalBytes": {"$ref": "#/$defs/nonNegativeInteger"},
+        "exportedBytes": {"$ref": "#/$defs/nonNegativeInteger"},
+        "originalItems": {"$ref": "#/$defs/nonNegativeInteger"},
+        "exportedItems": {"$ref": "#/$defs/nonNegativeInteger"}
+      }
+    },
+    "redaction": {
+      "type": "object", "additionalProperties": false,
+      "required": ["path", "reason"],
+      "properties": {"path": {"type": "string", "pattern": "^(?:/(?:[^~]|~[01])*)+$"}, "reason": {"type": "string", "minLength": 1}}
+    },
+    "counts": {
+      "type": "object", "additionalProperties": false,
+      "required": ["editedFiles", "turns", "toolUses", "errors", "compactions", "commands", "pullRequests"],
+      "properties": {
+        "editedFiles": {"$ref": "#/$defs/nonNegativeInteger"}, "turns": {"$ref": "#/$defs/nonNegativeInteger"},
+        "toolUses": {"$ref": "#/$defs/nonNegativeInteger"}, "errors": {"$ref": "#/$defs/nonNegativeInteger"},
+        "compactions": {"$ref": "#/$defs/nonNegativeInteger"}, "commands": {"$ref": "#/$defs/nonNegativeInteger"},
+        "pullRequests": {"$ref": "#/$defs/nonNegativeInteger"}
+      }
+    },
+    "modelUsage": {
+      "type": "object", "additionalProperties": false,
+      "required": ["model", "inputTokens", "outputTokens", "cacheCreationInputTokens", "cacheCreation1hInputTokens", "cacheReadInputTokens", "estimatedCostMicroUsd"],
+      "properties": {
+        "model": {"$ref": "#/$defs/model"}, "inputTokens": {"$ref": "#/$defs/nonNegativeInteger"},
+        "outputTokens": {"$ref": "#/$defs/nonNegativeInteger"}, "cacheCreationInputTokens": {"$ref": "#/$defs/nonNegativeInteger"},
+        "cacheCreation1hInputTokens": {"$ref": "#/$defs/nonNegativeInteger"}, "cacheReadInputTokens": {"$ref": "#/$defs/nonNegativeInteger"},
+        "estimatedCostMicroUsd": {"$ref": "#/$defs/nonNegativeInteger"}
+      }
+    },
+    "usage": {
+      "type": "object", "additionalProperties": false,
+      "required": ["models", "estimatedCostMicroUsd", "unpricedModels"],
+      "properties": {
+        "models": {"type": "array", "maxItems": 100, "items": {"$ref": "#/$defs/modelUsage"}},
+        "estimatedCostMicroUsd": {"$ref": "#/$defs/nonNegativeInteger"},
+        "unpricedModels": {"type": "array", "maxItems": 100, "items": {"$ref": "#/$defs/model"}}
+      }
+    },
+    "digest": {
+      "type": "object", "additionalProperties": false,
+      "required": ["turn", "category", "description"],
+      "properties": {
+        "turn": {"$ref": "#/$defs/nonNegativeInteger"},
+        "category": {"type": "string", "minLength": 1, "maxLength": 64, "x-maxUtf8Bytes": 64},
+        "description": {"type": "string", "maxLength": 4096, "x-maxUtf8Bytes": 4096},
+        "answer": {"type": "string", "maxLength": 4096, "x-maxUtf8Bytes": 4096},
+        "subagentId": {"$ref": "#/$defs/id"}
+      }
+    },
+    "todo": {
+      "type": "object", "additionalProperties": false, "required": ["text", "done"],
+      "properties": {"text": {"type": "string", "maxLength": 2048, "x-maxUtf8Bytes": 2048}, "done": {"type": "boolean"}}
+    },
+    "fileEdit": {
+      "type": "object", "additionalProperties": false,
+      "required": ["path", "additions", "deletions", "edits", "isNew"],
+      "properties": {
+        "path": {"type": "string", "minLength": 1, "maxLength": 1024, "x-maxUtf8Bytes": 1024, "not": {"pattern": "(^/|/$|//|(^|/)\\.{1,2}(/|$)|\\\\)"}},
+        "additions": {"$ref": "#/$defs/nonNegativeInteger"}, "deletions": {"$ref": "#/$defs/nonNegativeInteger"},
+        "edits": {"$ref": "#/$defs/nonNegativeInteger"}, "isNew": {"type": "boolean"}
+      }
+    },
+    "git": {
+      "type": "object", "additionalProperties": false, "required": ["baseBranch", "ahead", "behind"],
+      "properties": {
+        "baseBranch": {"type": "string", "minLength": 1, "maxLength": 512, "x-maxUtf8Bytes": 512},
+        "ahead": {"$ref": "#/$defs/nonNegativeInteger"}, "behind": {"$ref": "#/$defs/nonNegativeInteger"}
+      }
+    },
+    "subagent": {
+      "type": "object", "additionalProperties": false,
+      "required": ["id", "name", "status", "task", "result", "toolUses", "commandLabels", "usage", "estimatedCostMicroUsd"],
+      "properties": {
+        "id": {"$ref": "#/$defs/id"}, "name": {"type": "string", "minLength": 1, "maxLength": 512, "x-maxUtf8Bytes": 512},
+        "model": {"$ref": "#/$defs/model"}, "status": {"type": "string", "minLength": 1, "maxLength": 64, "x-maxUtf8Bytes": 64},
+        "task": {"type": "string", "maxLength": 8192, "x-maxUtf8Bytes": 8192},
+        "result": {"type": "string", "maxLength": 8192, "x-maxUtf8Bytes": 8192},
+        "durationMs": {"$ref": "#/$defs/nonNegativeInteger"}, "spawnedAtTurn": {"$ref": "#/$defs/nonNegativeInteger"},
+        "toolUses": {"$ref": "#/$defs/nonNegativeInteger"},
+        "commandLabels": {"type": "array", "items": {"type": "string", "minLength": 1, "maxLength": 512, "x-maxUtf8Bytes": 512}},
+        "usage": {"type": "array", "maxItems": 100, "items": {"$ref": "#/$defs/modelUsage"}},
+        "estimatedCostMicroUsd": {"$ref": "#/$defs/nonNegativeInteger"}
+      }
+    },
+    "session": {
+      "type": "object", "additionalProperties": false,
+      "required": ["lastActivityAtMs", "counts", "usage", "digest", "todos", "fileEdits", "commits", "subagents"],
+      "properties": {
+        "name": {"type": "string", "maxLength": 512, "x-maxUtf8Bytes": 512},
+        "summary": {"type": "string", "maxLength": 4096, "x-maxUtf8Bytes": 4096},
+        "status": {"type": "string", "maxLength": 64, "x-maxUtf8Bytes": 64},
+        "cwd": {"type": "string", "minLength": 1, "maxLength": 1024, "x-maxUtf8Bytes": 1024, "anyOf": [{"const": "."}, {"not": {"pattern": "(^/|/$|//|(^|/)\\.{1,2}(/|$)|\\\\)"}}]},
+        "branch": {"type": "string", "maxLength": 512, "x-maxUtf8Bytes": 512},
+        "entrypoint": {"type": "string", "maxLength": 512, "x-maxUtf8Bytes": 512},
+        "durationMs": {"$ref": "#/$defs/nonNegativeInteger"}, "lastActivityAtMs": {"$ref": "#/$defs/nonNegativeInteger"},
+        "lastEditAtMs": {"$ref": "#/$defs/nonNegativeInteger"}, "model": {"$ref": "#/$defs/model"},
+        "contextTokens": {"$ref": "#/$defs/nonNegativeInteger"}, "contextWindow": {"$ref": "#/$defs/nonNegativeInteger"},
+        "declaredGoal": {"type": "string", "maxLength": 16384, "x-maxUtf8Bytes": 16384},
+        "firstPrompt": {"type": "string", "maxLength": 16384, "x-maxUtf8Bytes": 16384},
+        "counts": {"$ref": "#/$defs/counts"}, "usage": {"$ref": "#/$defs/usage"},
+        "digest": {"type": "array", "maxItems": 200, "items": {"$ref": "#/$defs/digest"}},
+        "todos": {"type": "array", "maxItems": 200, "items": {"$ref": "#/$defs/todo"}},
+        "fileEdits": {"type": "array", "maxItems": 2000, "items": {"$ref": "#/$defs/fileEdit"}},
+        "commits": {"type": "array", "maxItems": 200, "items": {"type": "string", "maxLength": 2048, "x-maxUtf8Bytes": 2048}},
+        "git": {"$ref": "#/$defs/git"},
+        "subagents": {"type": "array", "maxItems": 100, "items": {"$ref": "#/$defs/subagent"}}
+      }
+    }
+  }
+}

--- a/collector/snapshot/v1/snapshot.go
+++ b/collector/snapshot/v1/snapshot.go
@@ -618,8 +618,16 @@ func jsonPointerResolves(value any, pointer string) bool {
 				return false
 			}
 		case []any:
+			if segment == "" || len(segment) > 1 && segment[0] == '0' {
+				return false
+			}
+			for i := range len(segment) {
+				if segment[i] < '0' || segment[i] > '9' {
+					return false
+				}
+			}
 			index, err := strconv.Atoi(segment)
-			if err != nil || index < 0 || index >= len(current) {
+			if err != nil || index >= len(current) {
 				return false
 			}
 			value = current[index]

--- a/collector/snapshot/v1/snapshot.go
+++ b/collector/snapshot/v1/snapshot.go
@@ -1,0 +1,662 @@
+// Package snapshotv1 defines the portable session-snapshot/v1 wire contract.
+//
+// Keep this package independent from collector internals. Publishers map their
+// local model into these types; consumers may validate fixtures without
+// importing parser or UI implementation details.
+package snapshotv1
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"slices"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	SchemaVersion                   = "session-snapshot/v1"
+	MediaType                       = "application/vnd.coslash.session-snapshot.v1+json"
+	MaxPayloadBytes                 = 256 * 1024
+	MaxCollectorVersionBytes        = 64
+	MaxAgentBytes                   = 64
+	MaxIdentifierBytes              = 512
+	MaxRepositoryBytes              = 1024
+	MaxNameBytes                    = 512
+	MaxSummaryBytes                 = 4 * 1024
+	MaxPathBytes                    = 1024
+	MaxBranchBytes                  = 512
+	MaxEntrypointBytes              = 512
+	MaxModelBytes                   = 256
+	MaxGoalBytes                    = 16 * 1024
+	MaxPromptBytes                  = 16 * 1024
+	MaxDigestItems                  = 200
+	MaxDigestTextBytes              = 4 * 1024
+	MaxTodoItems                    = 200
+	MaxTodoTextBytes                = 2 * 1024
+	MaxFileEditItems                = 2000
+	MaxCommitItems                  = 200
+	MaxCommitTextBytes              = 2 * 1024
+	MaxSubagentItems                = 100
+	MaxSubagentTextBytes            = 8 * 1024
+	MaxCommandLabelItems            = 200
+	MaxCommandLabelBytes            = 512
+	MaxUnpricedModels               = 100
+	MaxUsageModels                  = 100
+	TruncationReasonTextBudget      = "text_budget"
+	TruncationReasonItemBudget      = "item_budget"
+	TruncationReasonAggregateBudget = "aggregate_budget"
+)
+
+type Snapshot struct {
+	SchemaVersion      string       `json:"schemaVersion"`
+	MediaType          string       `json:"mediaType"`
+	CollectorVersion   string       `json:"collectorVersion"`
+	Agent              string       `json:"agent"`
+	SourceSessionID    string       `json:"sourceSessionId"`
+	SessionStartedAtMs int64        `json:"sessionStartedAtMs"`
+	ContentHash        string       `json:"contentHash,omitempty"`
+	Repository         Repository   `json:"repository"`
+	Truncation         []Truncation `json:"truncation"`
+	Redactions         []Redaction  `json:"redactions"`
+	Session            Session      `json:"session"`
+}
+
+type Repository struct {
+	Canonical string `json:"canonical"`
+	LocalOnly bool   `json:"localOnly"`
+}
+
+type Truncation struct {
+	Path          string `json:"path"`
+	Reason        string `json:"reason"`
+	OriginalBytes *int   `json:"originalBytes,omitempty"`
+	ExportedBytes *int   `json:"exportedBytes,omitempty"`
+	OriginalItems *int   `json:"originalItems,omitempty"`
+	ExportedItems *int   `json:"exportedItems,omitempty"`
+}
+
+type Redaction struct {
+	Path   string `json:"path"`
+	Reason string `json:"reason"`
+}
+
+type Session struct {
+	Name             *string    `json:"name,omitempty"`
+	Summary          *string    `json:"summary,omitempty"`
+	Status           *string    `json:"status,omitempty"`
+	WorkingDirectory *string    `json:"cwd,omitempty"`
+	Branch           *string    `json:"branch,omitempty"`
+	Entrypoint       *string    `json:"entrypoint,omitempty"`
+	DurationMs       *int       `json:"durationMs,omitempty"`
+	LastActivityAtMs int64      `json:"lastActivityAtMs"`
+	LastEditAtMs     *int64     `json:"lastEditAtMs,omitempty"`
+	Model            *string    `json:"model,omitempty"`
+	ContextTokens    *int       `json:"contextTokens,omitempty"`
+	ContextWindow    *int       `json:"contextWindow,omitempty"`
+	DeclaredGoal     *string    `json:"declaredGoal,omitempty"`
+	FirstPrompt      *string    `json:"firstPrompt,omitempty"`
+	Counts           Counts     `json:"counts"`
+	Usage            Usage      `json:"usage"`
+	Digest           []Digest   `json:"digest"`
+	Todos            []Todo     `json:"todos"`
+	FileEdits        []FileEdit `json:"fileEdits"`
+	Commits          []string   `json:"commits"`
+	Git              *GitDrift  `json:"git,omitempty"`
+	Subagents        []Subagent `json:"subagents"`
+}
+
+type Counts struct {
+	EditedFiles  int `json:"editedFiles"`
+	Turns        int `json:"turns"`
+	ToolUses     int `json:"toolUses"`
+	Errors       int `json:"errors"`
+	Compactions  int `json:"compactions"`
+	Commands     int `json:"commands"`
+	PullRequests int `json:"pullRequests"`
+}
+
+type Usage struct {
+	Models                []ModelUsage `json:"models"`
+	EstimatedCostMicroUSD int64        `json:"estimatedCostMicroUsd"`
+	UnpricedModels        []string     `json:"unpricedModels"`
+}
+
+type ModelUsage struct {
+	Model                      string `json:"model"`
+	InputTokens                int    `json:"inputTokens"`
+	OutputTokens               int    `json:"outputTokens"`
+	CacheCreationInputTokens   int    `json:"cacheCreationInputTokens"`
+	CacheCreation1hInputTokens int    `json:"cacheCreation1hInputTokens"`
+	CacheReadInputTokens       int    `json:"cacheReadInputTokens"`
+	EstimatedCostMicroUSD      int64  `json:"estimatedCostMicroUsd"`
+}
+
+type Digest struct {
+	Turn        int     `json:"turn"`
+	Category    string  `json:"category"`
+	Description string  `json:"description"`
+	Answer      *string `json:"answer,omitempty"`
+	SubagentID  *string `json:"subagentId,omitempty"`
+}
+
+type Todo struct {
+	Text string `json:"text"`
+	Done bool   `json:"done"`
+}
+
+type FileEdit struct {
+	Path      string `json:"path"`
+	Additions int    `json:"additions"`
+	Deletions int    `json:"deletions"`
+	Edits     int    `json:"edits"`
+	IsNew     bool   `json:"isNew"`
+}
+
+type GitDrift struct {
+	BaseBranch string `json:"baseBranch"`
+	Ahead      int    `json:"ahead"`
+	Behind     int    `json:"behind"`
+}
+
+type Subagent struct {
+	ID                    string       `json:"id"`
+	Name                  string       `json:"name"`
+	Model                 *string      `json:"model,omitempty"`
+	Status                string       `json:"status"`
+	Task                  string       `json:"task"`
+	Result                string       `json:"result"`
+	DurationMs            *int         `json:"durationMs,omitempty"`
+	SpawnedAtTurn         *int         `json:"spawnedAtTurn,omitempty"`
+	ToolUses              int          `json:"toolUses"`
+	CommandLabels         []string     `json:"commandLabels"`
+	Usage                 []ModelUsage `json:"usage"`
+	EstimatedCostMicroUSD int64        `json:"estimatedCostMicroUsd"`
+}
+
+// Marshal creates the canonical wire bytes and freezes ContentHash. Object
+// member order is the struct order above, maps are forbidden from the wire
+// types, strings use encoding/json escaping, and no insignificant whitespace
+// or trailing newline is emitted.
+func Marshal(snapshot Snapshot) ([]byte, error) {
+	data, err := canonicalBytes(snapshot)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > MaxPayloadBytes {
+		return nil, fmt.Errorf("snapshot is %d bytes; maximum is %d: %w", len(data), MaxPayloadBytes, ErrOversized)
+	}
+	return data, nil
+}
+
+// Size returns the canonical payload size without returning content bytes or
+// applying the aggregate ceiling. It exists for approved, content-free corpus
+// measurement; Marshal remains the only API that returns uploadable bytes.
+func Size(snapshot Snapshot) (int, error) {
+	data, err := canonicalBytes(snapshot)
+	if err != nil {
+		return 0, err
+	}
+	return len(data), nil
+}
+
+func canonicalBytes(snapshot Snapshot) ([]byte, error) {
+	snapshot.ContentHash = ""
+	if err := Validate(snapshot, false); err != nil {
+		return nil, err
+	}
+	unsigned, err := json.Marshal(snapshot)
+	if err != nil {
+		return nil, fmt.Errorf("marshal unsigned snapshot: %w", err)
+	}
+	sum := sha256.Sum256(unsigned)
+	snapshot.ContentHash = "sha256:" + hex.EncodeToString(sum[:])
+	data, err := json.Marshal(snapshot)
+	if err != nil {
+		return nil, fmt.Errorf("marshal snapshot: %w", err)
+	}
+	return data, nil
+}
+
+// Decode accepts canonical v1 bytes only, rejects unknown fields, and verifies
+// both the content hash and aggregate size.
+func Decode(data []byte) (Snapshot, error) {
+	if len(data) > MaxPayloadBytes {
+		return Snapshot{}, fmt.Errorf("snapshot is %d bytes; maximum is %d: %w", len(data), MaxPayloadBytes, ErrOversized)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var snapshot Snapshot
+	if err := decoder.Decode(&snapshot); err != nil {
+		return Snapshot{}, fmt.Errorf("decode snapshot: %w", err)
+	}
+	if err := ensureEOF(decoder); err != nil {
+		return Snapshot{}, err
+	}
+	if err := Validate(snapshot, true); err != nil {
+		return Snapshot{}, err
+	}
+	providedHash := snapshot.ContentHash
+	snapshot.ContentHash = ""
+	unsigned, err := json.Marshal(snapshot)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("marshal unsigned snapshot: %w", err)
+	}
+	sum := sha256.Sum256(unsigned)
+	wantHash := "sha256:" + hex.EncodeToString(sum[:])
+	if providedHash != wantHash {
+		return Snapshot{}, fmt.Errorf("contentHash does not match canonical payload: %w", ErrBadHash)
+	}
+	snapshot.ContentHash = providedHash
+	canonical, err := json.Marshal(snapshot)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("marshal canonical snapshot: %w", err)
+	}
+	if !bytes.Equal(data, canonical) {
+		return Snapshot{}, ErrNonCanonical
+	}
+	return snapshot, nil
+}
+
+var (
+	ErrBadHash      = errors.New("invalid content hash")
+	ErrNonCanonical = errors.New("snapshot JSON is not canonical")
+	ErrOversized    = errors.New("snapshot exceeds aggregate limit")
+)
+
+func Validate(s Snapshot, requireHash bool) error {
+	if s.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("schemaVersion must be %q", SchemaVersion)
+	}
+	if s.MediaType != MediaType {
+		return fmt.Errorf("mediaType must be %q", MediaType)
+	}
+	if err := boundedRequired("collectorVersion", s.CollectorVersion, MaxCollectorVersionBytes); err != nil {
+		return err
+	}
+	if !validAgent(s.Agent) {
+		return fmt.Errorf("agent must be a lowercase identifier of at most %d bytes", MaxAgentBytes)
+	}
+	if err := boundedRequired("sourceSessionId", s.SourceSessionID, MaxIdentifierBytes); err != nil {
+		return err
+	}
+	if s.SessionStartedAtMs <= 0 {
+		return fmt.Errorf("sessionStartedAtMs must be positive")
+	}
+	if requireHash && (len(s.ContentHash) != 71 || !strings.HasPrefix(s.ContentHash, "sha256:")) {
+		return fmt.Errorf("contentHash must be sha256 plus 64 lowercase hexadecimal characters: %w", ErrBadHash)
+	}
+	if requireHash {
+		if _, err := hex.DecodeString(strings.TrimPrefix(s.ContentHash, "sha256:")); err != nil || strings.ToLower(s.ContentHash) != s.ContentHash {
+			return ErrBadHash
+		}
+	}
+	if err := boundedRequired("repository.canonical", s.Repository.Canonical, MaxRepositoryBytes); err != nil {
+		return err
+	}
+	if s.Truncation == nil || s.Redactions == nil {
+		return fmt.Errorf("truncation and redactions must be arrays")
+	}
+	if len(s.Truncation) > 5000 || len(s.Redactions) > 5000 {
+		return fmt.Errorf("metadata arrays exceed limit")
+	}
+	for _, item := range s.Truncation {
+		if !validJSONPointer(item.Path) {
+			return fmt.Errorf("truncation path must be a JSON pointer")
+		}
+		if item.Reason != TruncationReasonTextBudget && item.Reason != TruncationReasonItemBudget && item.Reason != TruncationReasonAggregateBudget {
+			return fmt.Errorf("unknown truncation reason")
+		}
+		if item.OriginalBytes != nil && *item.OriginalBytes < 0 ||
+			item.ExportedBytes != nil && *item.ExportedBytes < 0 ||
+			item.OriginalItems != nil && *item.OriginalItems < 0 ||
+			item.ExportedItems != nil && *item.ExportedItems < 0 {
+			return fmt.Errorf("truncation counters must be non-negative")
+		}
+	}
+	for _, item := range s.Redactions {
+		if !validJSONPointer(item.Path) {
+			return fmt.Errorf("redaction path must be a JSON pointer")
+		}
+		if item.Reason == "" {
+			return fmt.Errorf("redaction reason is required")
+		}
+	}
+	if err := validateSession(s.Session); err != nil {
+		return err
+	}
+	if s.SessionStartedAtMs > s.Session.LastActivityAtMs {
+		return fmt.Errorf("sessionStartedAtMs must not exceed session.lastActivityAtMs")
+	}
+	return validateMetadataTargets(s)
+}
+
+func validateSession(s Session) error {
+	fields := []struct {
+		name  string
+		value *string
+		limit int
+	}{
+		{"name", s.Name, MaxNameBytes},
+		{"summary", s.Summary, MaxSummaryBytes},
+		{"status", s.Status, 64},
+		{"cwd", s.WorkingDirectory, MaxPathBytes},
+		{"branch", s.Branch, MaxBranchBytes},
+		{"entrypoint", s.Entrypoint, MaxEntrypointBytes},
+		{"declaredGoal", s.DeclaredGoal, MaxGoalBytes},
+		{"firstPrompt", s.FirstPrompt, MaxPromptBytes},
+	}
+	for _, field := range fields {
+		if field.value != nil {
+			if err := bounded("session."+field.name, *field.value, field.limit); err != nil {
+				return err
+			}
+		}
+	}
+	if s.Model != nil {
+		if err := boundedRequired("session.model", *s.Model, MaxModelBytes); err != nil {
+			return err
+		}
+	}
+	if s.WorkingDirectory != nil && *s.WorkingDirectory != "." && !validRelativePath(*s.WorkingDirectory) {
+		return fmt.Errorf("session.cwd must be repository-relative")
+	}
+	if s.LastActivityAtMs < 0 {
+		return fmt.Errorf("session.lastActivityAtMs must be non-negative")
+	}
+	counts := []struct {
+		name  string
+		value int
+	}{
+		{"editedFiles", s.Counts.EditedFiles},
+		{"turns", s.Counts.Turns},
+		{"toolUses", s.Counts.ToolUses},
+		{"errors", s.Counts.Errors},
+		{"compactions", s.Counts.Compactions},
+		{"commands", s.Counts.Commands},
+		{"pullRequests", s.Counts.PullRequests},
+	}
+	for _, count := range counts {
+		if count.value < 0 {
+			return fmt.Errorf("session.counts.%s must be non-negative", count.name)
+		}
+	}
+	if s.DurationMs != nil && *s.DurationMs < 0 {
+		return fmt.Errorf("session.durationMs must be non-negative")
+	}
+	if s.LastEditAtMs != nil && *s.LastEditAtMs < 0 {
+		return fmt.Errorf("session.lastEditAtMs must be non-negative")
+	}
+	if s.ContextTokens != nil && *s.ContextTokens < 0 {
+		return fmt.Errorf("session.contextTokens must be non-negative")
+	}
+	if s.ContextWindow != nil && *s.ContextWindow < 0 {
+		return fmt.Errorf("session.contextWindow must be non-negative")
+	}
+	if s.Usage.EstimatedCostMicroUSD < 0 {
+		return fmt.Errorf("session usage cost must be non-negative")
+	}
+	if s.Usage.Models == nil || s.Usage.UnpricedModels == nil || s.Digest == nil || s.Todos == nil || s.FileEdits == nil || s.Commits == nil || s.Subagents == nil {
+		return fmt.Errorf("collection fields must be arrays, not null")
+	}
+	if len(s.Usage.Models) > MaxUsageModels || len(s.Usage.UnpricedModels) > MaxUnpricedModels || len(s.Digest) > MaxDigestItems || len(s.Todos) > MaxTodoItems || len(s.FileEdits) > MaxFileEditItems || len(s.Commits) > MaxCommitItems || len(s.Subagents) > MaxSubagentItems {
+		return fmt.Errorf("session collection exceeds item budget")
+	}
+	if !sortedUniqueUsage(s.Usage.Models) || !sortedUniqueStrings(s.Usage.UnpricedModels) {
+		return fmt.Errorf("usage model lists must be sorted and unique")
+	}
+	for _, usage := range s.Usage.Models {
+		if err := validateUsage(usage); err != nil {
+			return err
+		}
+	}
+	for i, model := range s.Usage.UnpricedModels {
+		if err := boundedRequired(fmt.Sprintf("session.usage.unpricedModels[%d]", i), model, MaxModelBytes); err != nil {
+			return err
+		}
+	}
+	for i, digest := range s.Digest {
+		if digest.Turn < 0 {
+			return fmt.Errorf("session.digest[%d].turn must be non-negative", i)
+		}
+		if err := boundedRequired(fmt.Sprintf("session.digest[%d].category", i), digest.Category, 64); err != nil {
+			return err
+		}
+		if err := bounded(fmt.Sprintf("session.digest[%d].description", i), digest.Description, MaxDigestTextBytes); err != nil {
+			return err
+		}
+		if digest.Answer != nil {
+			if err := bounded(fmt.Sprintf("session.digest[%d].answer", i), *digest.Answer, MaxDigestTextBytes); err != nil {
+				return err
+			}
+		}
+		if digest.SubagentID != nil {
+			if err := boundedRequired(fmt.Sprintf("session.digest[%d].subagentId", i), *digest.SubagentID, MaxIdentifierBytes); err != nil {
+				return err
+			}
+		}
+	}
+	for i, todo := range s.Todos {
+		if err := bounded(fmt.Sprintf("session.todos[%d].text", i), todo.Text, MaxTodoTextBytes); err != nil {
+			return err
+		}
+	}
+	for _, edit := range s.FileEdits {
+		if !validRelativePath(edit.Path) || len(edit.Path) > MaxPathBytes || edit.Additions < 0 || edit.Deletions < 0 || edit.Edits < 0 {
+			return fmt.Errorf("invalid repository-relative file edit")
+		}
+	}
+	for i, commit := range s.Commits {
+		if err := bounded(fmt.Sprintf("session.commits[%d]", i), commit, MaxCommitTextBytes); err != nil {
+			return err
+		}
+	}
+	if s.Git != nil {
+		if err := boundedRequired("session.git.baseBranch", s.Git.BaseBranch, MaxBranchBytes); err != nil {
+			return err
+		}
+		if s.Git.Ahead < 0 || s.Git.Behind < 0 {
+			return fmt.Errorf("git drift counts must be non-negative")
+		}
+	}
+	commandLabels := 0
+	for i, subagent := range s.Subagents {
+		if subagent.ToolUses < 0 || subagent.EstimatedCostMicroUSD < 0 || subagent.CommandLabels == nil || subagent.Usage == nil {
+			return fmt.Errorf("invalid subagent")
+		}
+		if err := boundedRequired(fmt.Sprintf("session.subagents[%d].id", i), subagent.ID, MaxIdentifierBytes); err != nil {
+			return err
+		}
+		if err := boundedRequired(fmt.Sprintf("session.subagents[%d].name", i), subagent.Name, MaxNameBytes); err != nil {
+			return err
+		}
+		if subagent.Model != nil {
+			if err := boundedRequired(fmt.Sprintf("session.subagents[%d].model", i), *subagent.Model, MaxModelBytes); err != nil {
+				return err
+			}
+		}
+		if err := boundedRequired(fmt.Sprintf("session.subagents[%d].status", i), subagent.Status, 64); err != nil {
+			return err
+		}
+		if err := bounded(fmt.Sprintf("session.subagents[%d].task", i), subagent.Task, MaxSubagentTextBytes); err != nil {
+			return err
+		}
+		if err := bounded(fmt.Sprintf("session.subagents[%d].result", i), subagent.Result, MaxSubagentTextBytes); err != nil {
+			return err
+		}
+		if subagent.DurationMs != nil && *subagent.DurationMs < 0 {
+			return fmt.Errorf("subagent duration must be non-negative")
+		}
+		if subagent.SpawnedAtTurn != nil && *subagent.SpawnedAtTurn < 0 {
+			return fmt.Errorf("subagent spawn turn must be non-negative")
+		}
+		commandLabels += len(subagent.CommandLabels)
+		for j, label := range subagent.CommandLabels {
+			if err := boundedRequired(fmt.Sprintf("session.subagents[%d].commandLabels[%d]", i, j), label, MaxCommandLabelBytes); err != nil {
+				return err
+			}
+		}
+		if len(subagent.Usage) > MaxUsageModels || !sortedUniqueUsage(subagent.Usage) {
+			return fmt.Errorf("subagent usage must be sorted and unique")
+		}
+		for _, usage := range subagent.Usage {
+			if err := validateUsage(usage); err != nil {
+				return err
+			}
+		}
+	}
+	if commandLabels > MaxCommandLabelItems {
+		return fmt.Errorf("subagent command labels exceed item budget")
+	}
+	return nil
+}
+
+func validateUsage(u ModelUsage) error {
+	if boundedRequired("usage.model", u.Model, MaxModelBytes) != nil || u.InputTokens < 0 || u.OutputTokens < 0 || u.CacheCreationInputTokens < 0 || u.CacheCreation1hInputTokens < 0 || u.CacheReadInputTokens < 0 || u.EstimatedCostMicroUSD < 0 {
+		return fmt.Errorf("model usage fields must be non-negative and model is required")
+	}
+	return nil
+}
+
+func boundedRequired(name, value string, maxBytes int) error {
+	if value == "" {
+		return fmt.Errorf("%s is required", name)
+	}
+	if !utf8.ValidString(value) || len(value) > maxBytes {
+		return fmt.Errorf("%s exceeds its UTF-8 byte budget", name)
+	}
+	return nil
+}
+
+func bounded(name, value string, maxBytes int) error {
+	if !utf8.ValidString(value) || len(value) > maxBytes {
+		return fmt.Errorf("%s exceeds its UTF-8 byte budget", name)
+	}
+	return nil
+}
+
+func validRelativePath(path string) bool {
+	if path == "" || strings.HasPrefix(path, "/") || strings.Contains(path, "\\") {
+		return false
+	}
+	for _, part := range strings.Split(path, "/") {
+		if part == "." || part == ".." || part == "" {
+			return false
+		}
+	}
+	return true
+}
+
+func validAgent(value string) bool {
+	if value == "" || len(value) > MaxAgentBytes {
+		return false
+	}
+	for i := range len(value) {
+		char := value[i]
+		if (char < 'a' || char > 'z') && (char < '0' || char > '9') && char != '-' && char != '_' {
+			return false
+		}
+		if i == 0 && (char == '-' || char == '_') {
+			return false
+		}
+	}
+	return true
+}
+
+func validJSONPointer(path string) bool {
+	if !strings.HasPrefix(path, "/") || !utf8.ValidString(path) {
+		return false
+	}
+	for i := 0; i < len(path); i++ {
+		if path[i] != '~' {
+			continue
+		}
+		if i+1 >= len(path) || (path[i+1] != '0' && path[i+1] != '1') {
+			return false
+		}
+		i++
+	}
+	return true
+}
+
+func validateMetadataTargets(snapshot Snapshot) error {
+	data, err := json.Marshal(snapshot)
+	if err != nil {
+		return err
+	}
+	var document any
+	if err := json.Unmarshal(data, &document); err != nil {
+		return err
+	}
+	for _, item := range snapshot.Truncation {
+		if !jsonPointerResolves(document, item.Path) {
+			return fmt.Errorf("truncation path does not resolve: %s", item.Path)
+		}
+	}
+	for _, item := range snapshot.Redactions {
+		if !jsonPointerResolves(document, item.Path) {
+			return fmt.Errorf("redaction path does not resolve: %s", item.Path)
+		}
+	}
+	return nil
+}
+
+func jsonPointerResolves(value any, pointer string) bool {
+	for _, encoded := range strings.Split(strings.TrimPrefix(pointer, "/"), "/") {
+		segment := strings.ReplaceAll(strings.ReplaceAll(encoded, "~1", "/"), "~0", "~")
+		switch current := value.(type) {
+		case map[string]any:
+			var ok bool
+			value, ok = current[segment]
+			if !ok {
+				return false
+			}
+		case []any:
+			index, err := strconv.Atoi(segment)
+			if err != nil || index < 0 || index >= len(current) {
+				return false
+			}
+			value = current[index]
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func sortedUniqueStrings(values []string) bool {
+	return slices.IsSorted(values) && len(slices.Compact(slices.Clone(values))) == len(values)
+}
+
+func sortedUniqueUsage(values []ModelUsage) bool {
+	for i := range values {
+		if i > 0 && values[i-1].Model >= values[i].Model {
+			return false
+		}
+	}
+	return true
+}
+
+func ensureEOF(decoder *json.Decoder) error {
+	var extra any
+	if err := decoder.Decode(&extra); err == nil {
+		return fmt.Errorf("snapshot contains multiple JSON values")
+	} else if !errors.Is(err, io.EOF) {
+		return fmt.Errorf("decode trailing data: %w", err)
+	}
+	return nil
+}
+
+// CostMicroUSD freezes a floating-point local estimate at the wire boundary.
+func CostMicroUSD(dollars float64) (int64, error) {
+	if math.IsNaN(dollars) || math.IsInf(dollars, 0) || dollars < 0 || dollars >= float64(math.MaxInt64)/1_000_000 {
+		return 0, fmt.Errorf("estimated cost is not a finite non-negative value")
+	}
+	return int64(math.Round(dollars * 1_000_000)), nil
+}

--- a/collector/snapshot/v1/snapshot_test.go
+++ b/collector/snapshot/v1/snapshot_test.go
@@ -169,6 +169,25 @@ func TestMetadataPathsRequireJSONPointerEscaping(t *testing.T) {
 	}
 }
 
+func TestMetadataArrayIndicesUseCanonicalJSONPointerSyntax(t *testing.T) {
+	snapshot := validSnapshot()
+	snapshot.Session.Digest = []Digest{{Category: "user"}, {Category: "assistant"}}
+
+	for _, path := range []string{"/session/digest/0", "/session/digest/1"} {
+		snapshot.Redactions = []Redaction{{Path: path, Reason: "test"}}
+		if _, err := Marshal(snapshot); err != nil {
+			t.Fatalf("canonical array pointer %q rejected: %v", path, err)
+		}
+	}
+
+	for _, path := range []string{"/session/digest/01", "/session/digest/+1"} {
+		snapshot.Redactions = []Redaction{{Path: path, Reason: "test"}}
+		if _, err := Marshal(snapshot); err == nil {
+			t.Fatalf("non-canonical array pointer %q accepted", path)
+		}
+	}
+}
+
 func TestTruncationCountersMustBeNonNegative(t *testing.T) {
 	negative := -1
 	tests := []struct {

--- a/collector/snapshot/v1/snapshot_test.go
+++ b/collector/snapshot/v1/snapshot_test.go
@@ -1,0 +1,218 @@
+package snapshotv1
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestMarshalAndDecodeCanonicalSnapshot(t *testing.T) {
+	snapshot := validSnapshot()
+	first, err := Marshal(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := Marshal(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatal("canonical bytes changed between identical marshals")
+	}
+	if bytes.HasSuffix(first, []byte("\n")) || bytes.Contains(first, []byte("  \"")) {
+		t.Fatal("canonical JSON contains formatting whitespace")
+	}
+	decoded, err := Decode(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(decoded.ContentHash, "sha256:") {
+		t.Fatalf("missing frozen hash: %q", decoded.ContentHash)
+	}
+}
+
+func TestDecodeRejectsUnknownFieldsBadHashAndNonCanonicalBytes(t *testing.T) {
+	data, err := Marshal(validSnapshot())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	unknown := bytes.Replace(data, []byte(`"schemaVersion"`), []byte(`"unknown":true,"schemaVersion"`), 1)
+	if _, err := Decode(unknown); err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("unknown field error = %v", err)
+	}
+
+	badHash := append([]byte(nil), data...)
+	index := bytes.Index(badHash, []byte("sha256:")) + len("sha256:")
+	badHash[index] = 'f'
+	if data[index] == 'f' {
+		badHash[index] = 'e'
+	}
+	if _, err := Decode(badHash); !errors.Is(err, ErrBadHash) {
+		t.Fatalf("bad hash error = %v", err)
+	}
+
+	nonCanonical := append(append([]byte(nil), data...), '\n')
+	if _, err := Decode(nonCanonical); !errors.Is(err, ErrNonCanonical) {
+		t.Fatalf("non-canonical error = %v", err)
+	}
+}
+
+func TestMarshalRejectsAggregateOverflow(t *testing.T) {
+	snapshot := validSnapshot()
+	snapshot.Session.FileEdits = make([]FileEdit, MaxFileEditItems)
+	for i := range snapshot.Session.FileEdits {
+		snapshot.Session.FileEdits[i] = FileEdit{Path: strings.Repeat("x", MaxPathBytes-8) + string(rune('a'+i%26)), Edits: 1}
+	}
+	_, err := Marshal(snapshot)
+	if !errors.Is(err, ErrOversized) {
+		t.Fatalf("overflow error = %v", err)
+	}
+}
+
+func TestCostMicroUSDFreezesEstimate(t *testing.T) {
+	got, err := CostMicroUSD(1.2345678)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 1_234_568 {
+		t.Fatalf("cost = %d", got)
+	}
+	if _, err := CostMicroUSD(-1); err == nil {
+		t.Fatal("negative cost accepted")
+	}
+	if _, err := CostMicroUSD(float64(^uint64(0)>>1) / 1_000_000); err == nil {
+		t.Fatal("overflow boundary accepted")
+	}
+}
+
+func TestOptionalModelAndWorkingDirectoryMatchSchemaConstraints(t *testing.T) {
+	empty := ""
+	snapshot := validSnapshot()
+	snapshot.Session.Model = &empty
+	if _, err := Marshal(snapshot); err == nil {
+		t.Fatal("empty session model accepted")
+	}
+
+	snapshot = validSnapshot()
+	snapshot.Session.WorkingDirectory = &empty
+	if _, err := Marshal(snapshot); err == nil {
+		t.Fatal("empty working directory accepted")
+	}
+}
+
+func TestSessionStartMustNotExceedLastActivity(t *testing.T) {
+	snapshot := validSnapshot()
+	snapshot.SessionStartedAtMs = snapshot.Session.LastActivityAtMs + 1
+	if _, err := Marshal(snapshot); err == nil {
+		t.Fatal("session start after last activity accepted")
+	}
+}
+
+func TestRelativePathsRejectNonCanonicalSegments(t *testing.T) {
+	snapshot := validSnapshot()
+	root := "."
+	snapshot.Session.WorkingDirectory = &root
+	if _, err := Marshal(snapshot); err != nil {
+		t.Fatalf("repository-root cwd rejected: %v", err)
+	}
+
+	for _, path := range []string{"a/./b", "a/../b"} {
+		snapshot := validSnapshot()
+		snapshot.Session.WorkingDirectory = &path
+		if _, err := Marshal(snapshot); err == nil {
+			t.Fatalf("non-canonical path %q accepted", path)
+		}
+	}
+
+	snapshot = validSnapshot()
+	snapshot.Session.FileEdits = []FileEdit{{Path: "."}}
+	if _, err := Marshal(snapshot); err == nil {
+		t.Fatal("repository-root file edit accepted")
+	}
+}
+
+func TestAgentIdentifierIsExtensibleAndBounded(t *testing.T) {
+	for _, agent := range []string{"codex", "future-agent", strings.Repeat("a", MaxAgentBytes)} {
+		snapshot := validSnapshot()
+		snapshot.Agent = agent
+		if _, err := Marshal(snapshot); err != nil {
+			t.Fatalf("agent %q rejected: %v", agent, err)
+		}
+	}
+	for _, agent := range []string{"", "-future", "FutureAgent", "future/agent", strings.Repeat("a", MaxAgentBytes+1)} {
+		snapshot := validSnapshot()
+		snapshot.Agent = agent
+		if _, err := Marshal(snapshot); err == nil {
+			t.Fatalf("agent %q accepted", agent)
+		}
+	}
+}
+
+func TestMetadataPathsRequireJSONPointerEscaping(t *testing.T) {
+	for _, path := range []string{"not-a-pointer", "/bad~", "/bad~2escape"} {
+		snapshot := validSnapshot()
+		snapshot.Redactions = []Redaction{{Path: path, Reason: "test"}}
+		if _, err := Marshal(snapshot); err == nil {
+			t.Fatalf("path %q accepted", path)
+		}
+	}
+	snapshot := validSnapshot()
+	snapshot.Redactions = []Redaction{{Path: "/session", Reason: "test"}}
+	if _, err := Marshal(snapshot); err != nil {
+		t.Fatalf("resolving pointer rejected: %v", err)
+	}
+	snapshot.Redactions = []Redaction{{Path: "/session/missing", Reason: "test"}}
+	if _, err := Marshal(snapshot); err == nil {
+		t.Fatal("non-resolving pointer accepted")
+	}
+}
+
+func TestTruncationCountersMustBeNonNegative(t *testing.T) {
+	negative := -1
+	tests := []struct {
+		name string
+		set  func(*Truncation)
+	}{
+		{"original bytes", func(item *Truncation) { item.OriginalBytes = &negative }},
+		{"exported bytes", func(item *Truncation) { item.ExportedBytes = &negative }},
+		{"original items", func(item *Truncation) { item.OriginalItems = &negative }},
+		{"exported items", func(item *Truncation) { item.ExportedItems = &negative }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			snapshot := validSnapshot()
+			item := Truncation{Path: "/session", Reason: TruncationReasonTextBudget}
+			test.set(&item)
+			snapshot.Truncation = []Truncation{item}
+			if _, err := Marshal(snapshot); err == nil {
+				t.Fatal("negative truncation counter accepted")
+			}
+		})
+	}
+}
+
+func validSnapshot() Snapshot {
+	return Snapshot{
+		SchemaVersion:      SchemaVersion,
+		MediaType:          MediaType,
+		CollectorVersion:   "0.1.0",
+		Agent:              "codex",
+		SourceSessionID:    "session-1",
+		SessionStartedAtMs: 1_700_000_000_000,
+		Repository:         Repository{Canonical: "github.com/centauri-ai/coslash"},
+		Truncation:         []Truncation{},
+		Redactions:         []Redaction{},
+		Session: Session{
+			LastActivityAtMs: 1_700_000_001_000,
+			Counts:           Counts{},
+			Usage:            Usage{Models: []ModelUsage{}, UnpricedModels: []string{}},
+			Digest:           []Digest{},
+			Todos:            []Todo{},
+			FileEdits:        []FileEdit{},
+			Commits:          []string{},
+			Subagents:        []Subagent{},
+		},
+	}
+}


### PR DESCRIPTION
## Summary

Define the public `session-snapshot/v1` wire contract, canonical JSON encoding, validation, hashing, and JSON Schema.

## Why this is separate

Reviewers can evaluate the protocol without also auditing private collector mapping, redaction, or payload fitting. The package has no dependency on collector internals.

## Changes

- add explicit v1 envelope and session wire types;
- freeze canonical JSON member order and SHA-256 content hashing;
- enforce the 256 KiB aggregate ceiling and per-field byte/item limits;
- reject unknown fields, non-canonical bytes, unsafe relative paths, invalid metadata pointers, negative counters, and inverted timestamps;
- publish a matching JSON Schema and boundary tests.

## Review guide

Read `snapshot.go` and `README.md` first, compare `schema.json` with the Go validator, then review the exact-limit tests. This PR does not map or export local sessions.

## Verification

- `go test ./...`
- `go vet ./...`
- `jq empty collector/snapshot/v1/schema.json`

## Stack

This is PR 2 of 5 for ENG-1340. Its base is PR 1.

| Order | PR | Scope |
| ---: | --- | --- |
| 1 | [#83](https://github.com/centauri-ai/coslash/pull/83) | Canonical session start |
| 2 | [#84](https://github.com/centauri-ai/coslash/pull/84) | Public v1 contract |
| 3 | [#85](https://github.com/centauri-ai/coslash/pull/85) | Private-to-wire export boundary |
| 4 | [#86](https://github.com/centauri-ai/coslash/pull/86) | Aggregate payload fitting |
| 5 | [#87](https://github.com/centauri-ai/coslash/pull/87) | Fixtures, measurement, and docs |

## Rollout

This only publishes a new versioned contract package; no caller uses it until the next PR.
