### PR TITLE
feat(collector): add explicit session export boundary

### DIFF
--- a/collector/internal/session/probes.go
+++ b/collector/internal/session/probes.go
@@ -48,7 +48,7 @@ func CanonicalRepositoryName(cwd string) (string, bool) {
 	if err != nil {
 		return fallback, true
 	}
-	root := repositoryRoot(resolved)
+	root := RepositoryRoot(resolved)
 	if root == "" {
 		return fallback, true
 	}
@@ -114,7 +114,8 @@ func canonicalRemoteName(remote string) string {
 	return strings.ToLower(parsed.Host) + "/" + path
 }
 
-func repositoryRoot(cwd string) string {
+// RepositoryRoot returns the enclosing Git worktree root when one exists.
+func RepositoryRoot(cwd string) string {
 	info, err := os.Stat(cwd)
 	if err != nil || !info.IsDir() {
 		return ""

--- a/collector/internal/sessionexport/allowlist_test.go
+++ b/collector/internal/sessionexport/allowlist_test.go
@@ -1,0 +1,163 @@
+package sessionexport
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/centauri-ai/coslash/collector/internal/session"
+)
+
+// decision records why each local field does or does not cross the export
+// boundary. A field is exported only when Build maps it explicitly.
+type decision struct {
+	exported bool
+	reason   string
+}
+
+// census is the reviewed allow-list. Adding a field to session.Session or
+// session.SessionDetails fails TestLocalSessionFieldsHaveAnExportDecision
+// until it is recorded here, which keeps new local fields excluded by default.
+var census = map[string]decision{
+	// session.Session
+	"Agent":               {true, "envelope agent"},
+	"ID":                  {true, "envelope sourceSessionId"},
+	"Name":                {true, "bounded session.name"},
+	"Summary":             {true, "bounded session.summary"},
+	"Status":              {true, "bounded session.status"},
+	"WorkingDirectory":    {true, "session.cwd, repository-relative or omitted"},
+	"Branch":              {true, "bounded session.branch"},
+	"Repository":          {true, "repository.canonical"},
+	"RepositoryLocalOnly": {true, "repository.localOnly"},
+	"EditedFileCount":     {true, "session.counts.editedFiles"},
+	"DurationMs":          {true, "session.durationMs"},
+	"Tokens":              {true, "session.usage.models, sorted by model"},
+	"Cost":                {true, "session.usage.estimatedCostMicroUsd, frozen as integer"},
+	"UnpricedModels":      {true, "session.usage.unpricedModels"},
+	"Subagents":           {true, "bounded session.subagents facts"},
+	"StartedAt":           {true, "envelope sessionStartedAtMs"},
+	"LastActivityTime":    {true, "session.lastActivityAtMs"},
+	"Entrypoint":          {true, "bounded session.entrypoint"},
+
+	// session.SessionDetails
+	"Model":            {true, "session.model"},
+	"ContextTokens":    {true, "session.contextTokens"},
+	"ContextWindow":    {true, "session.contextWindow"},
+	"Turns":            {true, "session.counts.turns"},
+	"ToolUses":         {true, "session.counts.toolUses"},
+	"Errors":           {true, "session.counts.errors"},
+	"Compactions":      {true, "session.counts.compactions"},
+	"FirstPrompt":      {true, "bounded session.firstPrompt"},
+	"Commands":         {false, "raw commands never cross; only len() as session.counts.commands"},
+	"Commits":          {true, "bounded commit subjects"},
+	"PullRequests":     {true, "session.counts.pullRequests"},
+	"Todos":            {true, "bounded session.todos"},
+	"Digest":           {true, "bounded session.digest"},
+	"FileEdits":        {true, "session.fileEdits statistics with repository-relative paths"},
+	"Git":              {true, "session.git drift counts"},
+	"GitProbed":        {false, "local probe state"},
+	"LastEditAt":       {true, "session.lastEditAtMs"},
+	"Synthesis":        {false, "local synthesis output stays on the machine"},
+	"SynthesisPending": {false, "local synthesis state"},
+	"DeclaredGoal":     {true, "bounded session.declaredGoal"},
+	"CompactionSeed":   {false, "local parser state"},
+}
+
+var nestedCensus = map[reflect.Type]map[string]decision{
+	reflect.TypeOf(session.ModelTokens{}): {
+		"InputTokens":                {true, "model usage inputTokens"},
+		"OutputTokens":               {true, "model usage outputTokens"},
+		"CacheCreationInputTokens":   {true, "model usage cacheCreationInputTokens"},
+		"CacheCreation1hInputTokens": {true, "model usage cacheCreation1hInputTokens"},
+		"CacheReadInputTokens":       {true, "model usage cacheReadInputTokens"},
+		"Cost":                       {true, "model usage estimatedCostMicroUsd"},
+	},
+	reflect.TypeOf(session.Subagent{}): {
+		"ID":            {true, "subagent.id"},
+		"Name":          {true, "subagent.name"},
+		"Model":         {true, "subagent.model"},
+		"Status":        {true, "subagent.status"},
+		"Task":          {true, "bounded subagent.task"},
+		"Result":        {true, "bounded subagent.result"},
+		"DurationMs":    {true, "subagent.durationMs"},
+		"SpawnedAtTurn": {true, "subagent.spawnedAtTurn"},
+		"ToolUses":      {true, "subagent.toolUses"},
+		"Commands":      {true, "human labels only"},
+		"Tokens":        {true, "subagent.usage"},
+		"Cost":          {true, "subagent.estimatedCostMicroUsd"},
+	},
+	reflect.TypeOf(session.SubagentCommand{}): {
+		"Label":   {true, "bounded human command label"},
+		"Command": {false, "raw command never crosses"},
+	},
+	reflect.TypeOf(session.DigestEntry{}): {
+		"Turn":        {true, "digest.turn"},
+		"Category":    {true, "digest.category"},
+		"Description": {true, "bounded digest.description"},
+		"Answer":      {true, "bounded digest.answer"},
+		"SubagentID":  {true, "digest.subagentId"},
+		"SpawnKey":    {false, "local parser linkage"},
+	},
+	reflect.TypeOf(session.FileEdit{}): {
+		"Path":      {true, "proven repository-relative path"},
+		"Additions": {true, "fileEdit.additions"},
+		"Deletions": {true, "fileEdit.deletions"},
+		"Edits":     {true, "fileEdit.edits"},
+		"IsNew":     {true, "fileEdit.isNew"},
+		"changes":   {false, "raw file changes never cross"},
+	},
+	reflect.TypeOf(session.GitDrift{}): {
+		"BaseBranch": {true, "git.baseBranch"},
+		"Ahead":      {true, "git.ahead"},
+		"Behind":     {true, "git.behind"},
+	},
+	reflect.TypeOf(session.Todo{}): {
+		"Text": {true, "bounded todo.text"},
+		"Done": {true, "todo.done"},
+	},
+}
+
+func TestLocalSessionFieldsHaveAnExportDecision(t *testing.T) {
+	seen := map[string]bool{}
+	var walk func(reflect.Type)
+	walk = func(t reflect.Type) {
+		for i := range t.NumField() {
+			field := t.Field(i)
+			if field.Anonymous && field.Type.Kind() == reflect.Struct {
+				walk(field.Type)
+				continue
+			}
+			seen[field.Name] = true
+		}
+	}
+	walk(reflect.TypeOf(session.Session{}))
+
+	for name := range seen {
+		if _, ok := census[name]; !ok {
+			t.Errorf("local field %q has no export decision. Record it in census as "+
+				"excluded (default) or exported, and map it in Build before exporting it.", name)
+		}
+	}
+	for name := range census {
+		if !seen[name] {
+			t.Errorf("census records %q, which no longer exists on the local session model", name)
+		}
+	}
+}
+
+func TestNestedLocalFieldsHaveAnExportDecision(t *testing.T) {
+	for typ, decisions := range nestedCensus {
+		seen := make(map[string]bool, typ.NumField())
+		for i := range typ.NumField() {
+			name := typ.Field(i).Name
+			seen[name] = true
+			if _, ok := decisions[name]; !ok {
+				t.Errorf("local field %s.%s has no export decision", typ.Name(), name)
+			}
+		}
+		for name := range decisions {
+			if !seen[name] {
+				t.Errorf("nested census records %s.%s, which no longer exists", typ.Name(), name)
+			}
+		}
+	}
+}

--- a/collector/internal/sessionexport/snapshot.go
+++ b/collector/internal/sessionexport/snapshot.go
@@ -147,11 +147,18 @@ var credentialPatterns = []struct {
 	{regexp.MustCompile(`(?i)(\bauthorization\b\s*[:=]\s*'bearer\s+)[^']*(')`), `${1}[REDACTED]${2}`},
 	{regexp.MustCompile(`(?i)(\b(?:password|passwd|token|secret|api[_-]?key)\b\s*[:=]\s*")(?:\\.|[^"\\])*(")`), `${1}[REDACTED]${2}`},
 	{regexp.MustCompile(`(?i)(\b(?:password|passwd|token|secret|api[_-]?key)\b\s*[:=]\s*')[^']*(')`), `${1}[REDACTED]${2}`},
+	{regexp.MustCompile(`(?i)("authorization"\s*:\s*"bearer\s+)(?:\\.|[^"\\])*\\?\z`), `${1}[REDACTED]`},
+	{regexp.MustCompile(`(?i)("(?:password|passwd|token|secret|api[_-]?key)"\s*:\s*")(?:\\.|[^"\\])*\\?\z`), `${1}[REDACTED]`},
+	{regexp.MustCompile(`(?i)(\bauthorization\b\s*[:=]\s*"bearer\s+)(?:\\.|[^"\\])*\\?\z`), `${1}[REDACTED]`},
+	{regexp.MustCompile(`(?i)(\bauthorization\b\s*[:=]\s*'bearer\s+)[^']*\z`), `${1}[REDACTED]`},
+	{regexp.MustCompile(`(?i)(\b(?:password|passwd|token|secret|api[_-]?key)\b\s*[:=]\s*")(?:\\.|[^"\\])*\\?\z`), `${1}[REDACTED]`},
+	{regexp.MustCompile(`(?i)(\b(?:password|passwd|token|secret|api[_-]?key)\b\s*[:=]\s*')[^']*\z`), `${1}[REDACTED]`},
 	{regexp.MustCompile(`(?i)(authorization\s*[:=]\s*bearer\s+)[^\s"']+`), `${1}[REDACTED]`},
 	{regexp.MustCompile(`(?i)(\b(?:password|passwd|token|secret|api[_-]?key)\b\s*[:=]\s*)[^\s,;]+`), `${1}[REDACTED]`},
 	{regexp.MustCompile(`\b(?:gh[pousr]_[A-Za-z0-9_]{12,}|sk-[A-Za-z0-9_-]{12,}|AIza[0-9A-Za-z_-]{20,}|AKIA[0-9A-Z]{16})\b`), `[REDACTED]`},
 	{regexp.MustCompile(`(?i)([a-z][a-z0-9+.-]*://)[^/@\s]+@`), `${1}[REDACTED]@`},
 	{regexp.MustCompile(`(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----`), `[REDACTED PRIVATE KEY]`},
+	{regexp.MustCompile(`(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*\z`), `[REDACTED PRIVATE KEY]`},
 }
 
 type boundedText struct {

--- a/collector/internal/sessionexport/snapshot.go
+++ b/collector/internal/sessionexport/snapshot.go
@@ -1,0 +1,621 @@
+// Package sessionexport maps the private collector model into the public
+// session-snapshot/v1 allow-list. New fields on session.Session are excluded
+// until they are explicitly mapped here.
+package sessionexport
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/centauri-ai/coslash/collector/internal/session"
+	snapshotv1 "github.com/centauri-ai/coslash/collector/snapshot/v1"
+)
+
+const (
+	maxNameBytes         = snapshotv1.MaxNameBytes
+	maxSummaryBytes      = snapshotv1.MaxSummaryBytes
+	maxPathBytes         = snapshotv1.MaxPathBytes
+	maxBranchBytes       = snapshotv1.MaxBranchBytes
+	maxEntrypointBytes   = snapshotv1.MaxEntrypointBytes
+	maxModelBytes        = snapshotv1.MaxModelBytes
+	maxGoalBytes         = snapshotv1.MaxGoalBytes
+	maxPromptBytes       = snapshotv1.MaxPromptBytes
+	maxDigestItems       = snapshotv1.MaxDigestItems
+	maxDigestTextBytes   = snapshotv1.MaxDigestTextBytes
+	maxTodoItems         = snapshotv1.MaxTodoItems
+	maxTodoTextBytes     = snapshotv1.MaxTodoTextBytes
+	maxFileEditItems     = snapshotv1.MaxFileEditItems
+	maxCommitItems       = snapshotv1.MaxCommitItems
+	maxCommitTextBytes   = snapshotv1.MaxCommitTextBytes
+	maxSubagentItems     = snapshotv1.MaxSubagentItems
+	maxSubagentTextBytes = snapshotv1.MaxSubagentTextBytes
+	maxCommandLabelItems = snapshotv1.MaxCommandLabelItems
+	maxCommandLabelBytes = snapshotv1.MaxCommandLabelBytes
+	maxUnpricedModels    = snapshotv1.MaxUnpricedModels
+	maxIdentifierBytes   = snapshotv1.MaxIdentifierBytes
+	maxStatusBytes       = 64
+	maxCategoryBytes     = 64
+)
+
+// BuildOptions supplies facts intentionally kept outside the local Session
+// model. RepositoryRoot is needed to prove exported paths are relative.
+type BuildOptions struct {
+	CollectorVersion string
+	RepositoryRoot   string
+}
+
+// Marshal builds and serializes the exact bytes used by preview and upload.
+func Marshal(local session.Session, options BuildOptions) ([]byte, error) {
+	snapshot, err := Build(local, options)
+	if err != nil {
+		return nil, err
+	}
+	return snapshotv1.Marshal(snapshot)
+}
+
+func Build(local session.Session, options BuildOptions) (snapshotv1.Snapshot, error) {
+	if local.Repository == nil || strings.TrimSpace(*local.Repository) == "" {
+		return snapshotv1.Snapshot{}, fmt.Errorf("canonical repository identity is required")
+	}
+	b := builder{
+		root:       cleanRoot(options.RepositoryRoot),
+		cwd:        local.WorkingDirectory,
+		truncation: []snapshotv1.Truncation{},
+		redactions: []snapshotv1.Redaction{},
+	}
+	usage, err := b.usage(local.Tokens, local.Cost, local.UnpricedModels, "/session/usage")
+	if err != nil {
+		return snapshotv1.Snapshot{}, err
+	}
+	s := snapshotv1.Snapshot{
+		SchemaVersion:      snapshotv1.SchemaVersion,
+		MediaType:          snapshotv1.MediaType,
+		CollectorVersion:   options.CollectorVersion,
+		Agent:              local.Agent,
+		SourceSessionID:    local.ID,
+		SessionStartedAtMs: local.StartedAt,
+		Repository: snapshotv1.Repository{
+			Canonical: b.text("/repository/canonical", *local.Repository, snapshotv1.MaxRepositoryBytes),
+			LocalOnly: local.RepositoryLocalOnly,
+		},
+		Truncation: []snapshotv1.Truncation{},
+		Redactions: []snapshotv1.Redaction{},
+		Session: snapshotv1.Session{
+			Name:             b.optionalText("/session/name", local.Name, maxNameBytes),
+			Summary:          b.optionalText("/session/summary", local.Summary, maxSummaryBytes),
+			Status:           b.optionalText("/session/status", local.Status, maxStatusBytes),
+			WorkingDirectory: b.relativePath("/session/cwd", "/session", local.WorkingDirectory),
+			Branch:           b.optionalText("/session/branch", local.Branch, maxBranchBytes),
+			Entrypoint:       b.optionalText("/session/entrypoint", local.Entrypoint, maxEntrypointBytes),
+			DurationMs:       copyIntPointer(local.DurationMs),
+			LastActivityAtMs: max(local.LastActivityTime, local.StartedAt),
+			LastEditAtMs:     copyInt64Pointer(local.LastEditAt),
+			Model:            b.optionalRequiredText("/session/model", local.Model, maxModelBytes),
+			ContextTokens:    copyIntPointer(local.ContextTokens),
+			ContextWindow:    copyIntPointer(local.ContextWindow),
+			DeclaredGoal:     b.optionalText("/session/declaredGoal", local.DeclaredGoal, maxGoalBytes),
+			FirstPrompt:      b.optionalText("/session/firstPrompt", local.FirstPrompt, maxPromptBytes),
+			Counts: snapshotv1.Counts{
+				EditedFiles:  local.EditedFileCount,
+				Turns:        local.Turns,
+				ToolUses:     local.ToolUses,
+				Errors:       local.Errors,
+				Compactions:  local.Compactions,
+				Commands:     len(local.Commands),
+				PullRequests: local.PullRequests,
+			},
+			Usage:     usage,
+			Digest:    b.digest(local.Digest),
+			Todos:     b.todos(local.Todos),
+			FileEdits: b.fileEdits(local.FileEdits),
+			Commits:   b.strings("/session/commits", local.Commits, maxCommitItems, maxCommitTextBytes),
+			Git:       b.git(local.Git),
+			Subagents: []snapshotv1.Subagent{},
+		},
+	}
+	s.Session.Subagents, err = b.subagents(local.Subagents)
+	if err != nil {
+		return snapshotv1.Snapshot{}, err
+	}
+	s.Truncation = b.truncation
+	s.Redactions = b.redactions
+	if err := snapshotv1.Validate(s, false); err != nil {
+		return snapshotv1.Snapshot{}, fmt.Errorf("local session cannot produce a valid snapshot: %w", err)
+	}
+	return s, nil
+}
+
+type builder struct {
+	root       string
+	cwd        string
+	truncation []snapshotv1.Truncation
+	redactions []snapshotv1.Redaction
+	redacted   map[string]struct{}
+}
+
+var credentialPatterns = []struct {
+	pattern     *regexp.Regexp
+	replacement string
+}{
+	{regexp.MustCompile(`(?i)("authorization"\s*:\s*"bearer\s+)(?:\\.|[^"\\])*(")`), `${1}[REDACTED]${2}`},
+	{regexp.MustCompile(`(?i)("(?:password|passwd|token|secret|api[_-]?key)"\s*:\s*")(?:\\.|[^"\\])*(")`), `${1}[REDACTED]${2}`},
+	{regexp.MustCompile(`(?i)(\bauthorization\b\s*[:=]\s*"bearer\s+)(?:\\.|[^"\\])*(")`), `${1}[REDACTED]${2}`},
+	{regexp.MustCompile(`(?i)(\bauthorization\b\s*[:=]\s*'bearer\s+)[^']*(')`), `${1}[REDACTED]${2}`},
+	{regexp.MustCompile(`(?i)(\b(?:password|passwd|token|secret|api[_-]?key)\b\s*[:=]\s*")(?:\\.|[^"\\])*(")`), `${1}[REDACTED]${2}`},
+	{regexp.MustCompile(`(?i)(\b(?:password|passwd|token|secret|api[_-]?key)\b\s*[:=]\s*')[^']*(')`), `${1}[REDACTED]${2}`},
+	{regexp.MustCompile(`(?i)(authorization\s*[:=]\s*bearer\s+)[^\s"']+`), `${1}[REDACTED]`},
+	{regexp.MustCompile(`(?i)(\b(?:password|passwd|token|secret|api[_-]?key)\b\s*[:=]\s*)[^\s,;]+`), `${1}[REDACTED]`},
+	{regexp.MustCompile(`\b(?:gh[pousr]_[A-Za-z0-9_]{12,}|sk-[A-Za-z0-9_-]{12,}|AIza[0-9A-Za-z_-]{20,}|AKIA[0-9A-Z]{16})\b`), `[REDACTED]`},
+	{regexp.MustCompile(`(?i)([a-z][a-z0-9+.-]*://)[^/@\s]+@`), `${1}[REDACTED]@`},
+	{regexp.MustCompile(`(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----`), `[REDACTED PRIVATE KEY]`},
+}
+
+type boundedText struct {
+	value         string
+	redacted      bool
+	originalBytes int
+	truncated     bool
+}
+
+func boundText(value string, limit int) boundedText {
+	result := boundedText{}
+	if redacted, changed := redactCredentials(value); changed {
+		value = redacted
+		result.redacted = true
+	}
+	value = strings.ReplaceAll(value, "\r\n", "\n")
+	value = strings.ReplaceAll(value, "\r", "\n")
+	result.originalBytes = len(value)
+	if len(value) > limit {
+		for limit > 0 && !utf8.RuneStart(value[limit]) {
+			limit--
+		}
+		value = value[:limit]
+		result.truncated = true
+	}
+	result.value = value
+	return result
+}
+
+func (b *builder) recordText(path string, value boundedText) {
+	if value.redacted {
+		b.redact(path, "credential_pattern")
+	}
+	if value.truncated {
+		b.truncation = append(b.truncation, snapshotv1.Truncation{
+			Path: path, Reason: snapshotv1.TruncationReasonTextBudget,
+			OriginalBytes: intPointer(value.originalBytes), ExportedBytes: intPointer(len(value.value)),
+		})
+	}
+}
+
+func (b *builder) recordTexts(path string, values []boundedText) {
+	redacted := false
+	truncated := false
+	originalBytes := 0
+	exportedBytes := 0
+	for _, value := range values {
+		redacted = redacted || value.redacted
+		if value.truncated && (!truncated || value.originalBytes > originalBytes) {
+			truncated = true
+			originalBytes = value.originalBytes
+			exportedBytes = len(value.value)
+		}
+	}
+	if redacted {
+		b.redact(path, "credential_pattern")
+	}
+	if truncated {
+		b.truncation = append(b.truncation, snapshotv1.Truncation{
+			Path: path, Reason: snapshotv1.TruncationReasonTextBudget,
+			OriginalBytes: intPointer(originalBytes), ExportedBytes: intPointer(exportedBytes),
+		})
+	}
+}
+
+func (b *builder) text(path, value string, limit int) string {
+	bounded := boundText(value, limit)
+	b.recordText(path, bounded)
+	return bounded.value
+}
+
+func redactCredentials(value string) (string, bool) {
+	original := value
+	for _, rule := range credentialPatterns {
+		value = rule.pattern.ReplaceAllString(value, rule.replacement)
+	}
+	return value, value != original
+}
+
+func (b *builder) optionalText(path string, value *string, limit int) *string {
+	if value == nil {
+		return nil
+	}
+	text := b.text(path, *value, limit)
+	return &text
+}
+
+func (b *builder) optionalRequiredText(path string, value *string, limit int) *string {
+	if value == nil || *value == "" {
+		return nil
+	}
+	return b.optionalText(path, value, limit)
+}
+
+func (b *builder) items(path string, original, limit int) int {
+	if original <= limit {
+		return original
+	}
+	b.truncation = append(b.truncation, snapshotv1.Truncation{
+		Path: path, Reason: snapshotv1.TruncationReasonItemBudget, OriginalItems: intPointer(original), ExportedItems: intPointer(limit),
+	})
+	return limit
+}
+
+func (b *builder) relativePath(path, omittedPath, value string) *string {
+	relative := b.repositoryRelativePath(omittedPath, value)
+	if relative == nil {
+		return nil
+	}
+	bounded := b.pathText(path, *relative)
+	return &bounded
+}
+
+func (b *builder) repositoryRelativePath(omittedPath, value string) *string {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	clean := filepath.Clean(value)
+	if filepath.IsAbs(clean) {
+		if b.root == "" {
+			b.redact(omittedPath, "repository_root_unavailable")
+			return nil
+		}
+		rel, err := filepath.Rel(b.root, clean)
+		if err != nil || outsideRoot(rel) {
+			b.redact(omittedPath, "outside_repository")
+			return nil
+		}
+		clean = rel
+	}
+	if outsideRoot(clean) {
+		b.redact(omittedPath, "outside_repository")
+		return nil
+	}
+	clean = filepath.ToSlash(clean)
+	return &clean
+}
+
+func (b *builder) normalizeFileEditPath(value string) *string {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	clean := filepath.Clean(value)
+	if !filepath.IsAbs(clean) {
+		cwd := strings.TrimSpace(b.cwd)
+		if cwd == "" {
+			cwd = b.root
+		}
+		if cwd == "" {
+			b.redact("/session/fileEdits", "repository_root_unavailable")
+			return nil
+		}
+		cwd = filepath.Clean(cwd)
+		if !filepath.IsAbs(cwd) {
+			if b.root == "" {
+				b.redact("/session/fileEdits", "repository_root_unavailable")
+				return nil
+			}
+			cwd = filepath.Join(b.root, cwd)
+		}
+		clean = filepath.Join(cwd, clean)
+	}
+	relative := b.repositoryRelativePath("/session/fileEdits", clean)
+	if relative != nil && *relative == "." {
+		b.redact("/session/fileEdits", "invalid_path")
+		return nil
+	}
+	return relative
+}
+
+func (b *builder) pathText(path, value string) string {
+	firstTruncation := len(b.truncation)
+	value = b.text(path, value, maxPathBytes)
+	for {
+		separator := strings.LastIndex(value, "/")
+		final := value
+		if separator >= 0 {
+			final = value[separator+1:]
+		}
+		if final != "" && final != "." && final != ".." {
+			break
+		}
+		if separator < 0 {
+			value = strings.TrimRight(value, "/")
+			break
+		}
+		value = strings.TrimRight(value[:separator], "/")
+	}
+	for i := firstTruncation; i < len(b.truncation); i++ {
+		if b.truncation[i].Path == path && b.truncation[i].ExportedBytes != nil {
+			*b.truncation[i].ExportedBytes = len(value)
+		}
+	}
+	return value
+}
+
+func (b *builder) redact(path, reason string) {
+	key := path + "\x00" + reason
+	if _, exists := b.redacted[key]; exists {
+		return
+	}
+	if b.redacted == nil {
+		b.redacted = make(map[string]struct{})
+	}
+	b.redacted[key] = struct{}{}
+	b.redactions = append(b.redactions, snapshotv1.Redaction{Path: path, Reason: reason})
+}
+
+func (b *builder) digest(values []session.DigestEntry) []snapshotv1.Digest {
+	retained := b.items("/session/digest", len(values), maxDigestItems)
+	values = values[len(values)-retained:]
+	result := make([]snapshotv1.Digest, 0, len(values))
+	for i, value := range values {
+		base := fmt.Sprintf("/session/digest/%d", i)
+		item := snapshotv1.Digest{
+			Turn: value.Turn, Category: b.text(base+"/category", value.Category, maxCategoryBytes),
+			Description: b.text(base+"/description", value.Description, maxDigestTextBytes),
+		}
+		if value.Answer != "" {
+			item.Answer = stringPointer(b.text(base+"/answer", value.Answer, maxDigestTextBytes))
+		}
+		if value.SubagentID != "" {
+			item.SubagentID = stringPointer(b.text(base+"/subagentId", value.SubagentID, maxIdentifierBytes))
+		}
+		result = append(result, item)
+	}
+	return result
+}
+
+func (b *builder) todos(values []session.Todo) []snapshotv1.Todo {
+	values = values[:b.items("/session/todos", len(values), maxTodoItems)]
+	result := make([]snapshotv1.Todo, 0, len(values))
+	for i, value := range values {
+		result = append(result, snapshotv1.Todo{Text: b.text(fmt.Sprintf("/session/todos/%d/text", i), value.Text, maxTodoTextBytes), Done: value.Done})
+	}
+	return result
+}
+
+func (b *builder) fileEdits(values []session.FileEdit) []snapshotv1.FileEdit {
+	type candidate struct {
+		edit session.FileEdit
+		path string
+	}
+	candidates := make([]candidate, 0, min(len(values), maxFileEditItems))
+	validItems := 0
+	for _, value := range values {
+		relative := b.normalizeFileEditPath(value.Path)
+		if relative == nil {
+			continue
+		}
+		validItems++
+		if len(candidates) < maxFileEditItems {
+			candidates = append(candidates, candidate{edit: value, path: *relative})
+		}
+	}
+	b.items("/session/fileEdits", validItems, maxFileEditItems)
+	result := make([]snapshotv1.FileEdit, 0, len(candidates))
+	for _, value := range candidates {
+		path := fmt.Sprintf("/session/fileEdits/%d/path", len(result))
+		result = append(result, snapshotv1.FileEdit{
+			Path: b.pathText(path, value.path), Additions: value.edit.Additions, Deletions: value.edit.Deletions, Edits: value.edit.Edits, IsNew: value.edit.IsNew,
+		})
+	}
+	return result
+}
+
+func (b *builder) strings(path string, values []string, maxItems, maxBytes int) []string {
+	values = values[:b.items(path, len(values), maxItems)]
+	result := make([]string, 0, len(values))
+	for i, value := range values {
+		result = append(result, b.text(fmt.Sprintf("%s/%d", path, i), value, maxBytes))
+	}
+	return result
+}
+
+func (b *builder) git(value *session.GitDrift) *snapshotv1.GitDrift {
+	if value == nil {
+		return nil
+	}
+	return &snapshotv1.GitDrift{BaseBranch: b.text("/session/git/baseBranch", value.BaseBranch, maxBranchBytes), Ahead: value.Ahead, Behind: value.Behind}
+}
+
+func (b *builder) usage(tokens map[string]session.ModelTokens, cost float64, unpriced []string, path string) (snapshotv1.Usage, error) {
+	estimated, err := snapshotv1.CostMicroUSD(cost)
+	if err != nil {
+		return snapshotv1.Usage{}, fmt.Errorf("%s: %w", path, err)
+	}
+	usage, err := b.modelUsage(tokens, path+"/models")
+	if err != nil {
+		return snapshotv1.Usage{}, err
+	}
+	type unpricedCandidate struct {
+		changes []boundedText
+	}
+	unpricedByName := make(map[string]*unpricedCandidate, len(unpriced))
+	seenRaw := make(map[string]struct{}, len(unpriced))
+	for _, model := range unpriced {
+		if _, exists := seenRaw[model]; exists {
+			continue
+		}
+		seenRaw[model] = struct{}{}
+		if strings.TrimSpace(model) == "" {
+			b.redact(path+"/unpricedModels", "invalid_model")
+			continue
+		}
+		bounded := boundText(model, maxModelBytes)
+		candidate := unpricedByName[bounded.value]
+		if candidate == nil {
+			candidate = &unpricedCandidate{}
+			unpricedByName[bounded.value] = candidate
+		}
+		candidate.changes = append(candidate.changes, bounded)
+	}
+	names := make([]string, 0, len(unpricedByName))
+	for name := range unpricedByName {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	names = names[:b.items(path+"/unpricedModels", len(names), maxUnpricedModels)]
+	boundedUnpriced := make([]string, 0, len(names))
+	for i, name := range names {
+		modelPath := fmt.Sprintf("%s/unpricedModels/%d", path, i)
+		b.recordTexts(modelPath, unpricedByName[name].changes)
+		boundedUnpriced = append(boundedUnpriced, name)
+	}
+	return snapshotv1.Usage{Models: usage, EstimatedCostMicroUSD: estimated, UnpricedModels: boundedUnpriced}, nil
+}
+
+func (b *builder) modelUsage(tokens map[string]session.ModelTokens, path string) ([]snapshotv1.ModelUsage, error) {
+	type usageCandidate struct {
+		usage   snapshotv1.ModelUsage
+		changes []boundedText
+	}
+	usageByName := make(map[string]*usageCandidate, len(tokens))
+	for model, value := range tokens {
+		if strings.TrimSpace(model) == "" {
+			b.redact(path, "invalid_model")
+			continue
+		}
+		bounded := boundText(model, maxModelBytes)
+		modelCost, err := snapshotv1.CostMicroUSD(value.Cost)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", path, err)
+		}
+		boundedUsage := snapshotv1.ModelUsage{
+			Model:       bounded.value,
+			InputTokens: value.InputTokens, OutputTokens: value.OutputTokens,
+			CacheCreationInputTokens:   value.CacheCreationInputTokens,
+			CacheCreation1hInputTokens: value.CacheCreation1hInputTokens,
+			CacheReadInputTokens:       value.CacheReadInputTokens, EstimatedCostMicroUSD: modelCost,
+		}
+		candidate := usageByName[bounded.value]
+		if candidate == nil {
+			candidate = &usageCandidate{usage: boundedUsage}
+			usageByName[bounded.value] = candidate
+		} else {
+			mergeModelUsage(&candidate.usage, boundedUsage)
+		}
+		candidate.changes = append(candidate.changes, bounded)
+	}
+	names := make([]string, 0, len(usageByName))
+	for name := range usageByName {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	names = names[:b.items(path, len(names), snapshotv1.MaxUsageModels)]
+	usage := make([]snapshotv1.ModelUsage, 0, len(names))
+	for i, name := range names {
+		modelPath := fmt.Sprintf("%s/%d/model", path, i)
+		candidate := usageByName[name]
+		b.recordTexts(modelPath, candidate.changes)
+		usage = append(usage, candidate.usage)
+	}
+	return usage, nil
+}
+
+func mergeModelUsage(target *snapshotv1.ModelUsage, value snapshotv1.ModelUsage) {
+	target.InputTokens += value.InputTokens
+	target.OutputTokens += value.OutputTokens
+	target.CacheCreationInputTokens += value.CacheCreationInputTokens
+	target.CacheCreation1hInputTokens += value.CacheCreation1hInputTokens
+	target.CacheReadInputTokens += value.CacheReadInputTokens
+	target.EstimatedCostMicroUSD += value.EstimatedCostMicroUSD
+}
+
+func (b *builder) subagents(values []session.Subagent) ([]snapshotv1.Subagent, error) {
+	values = values[:b.items("/session/subagents", len(values), maxSubagentItems)]
+	result := make([]snapshotv1.Subagent, 0, len(values))
+	commandLabels := 0
+	for i, value := range values {
+		base := fmt.Sprintf("/session/subagents/%d", i)
+		usage, err := b.modelUsage(value.Tokens, base+"/usage")
+		if err != nil {
+			return nil, err
+		}
+		labels := make([]string, 0, len(value.Commands))
+		candidates := 0
+		rawOmitted := false
+		for _, command := range value.Commands {
+			if strings.TrimSpace(command.Label) == "" || command.Label == command.Command {
+				rawOmitted = true
+				continue
+			}
+			candidates++
+			if commandLabels >= maxCommandLabelItems {
+				continue
+			}
+			labels = append(labels, b.text(fmt.Sprintf("%s/commandLabels/%d", base, len(labels)), command.Label, maxCommandLabelBytes))
+			commandLabels++
+		}
+		if rawOmitted {
+			b.redact(base+"/commandLabels", "raw_command")
+		}
+		if candidates > len(labels) {
+			b.truncation = append(b.truncation, snapshotv1.Truncation{
+				Path: base + "/commandLabels", Reason: snapshotv1.TruncationReasonItemBudget,
+				OriginalItems: intPointer(candidates), ExportedItems: intPointer(len(labels)),
+			})
+		}
+		cost, err := snapshotv1.CostMicroUSD(value.Cost)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, snapshotv1.Subagent{
+			ID: b.text(base+"/id", value.ID, maxIdentifierBytes), Name: b.text(base+"/name", value.Name, maxNameBytes),
+			Model: b.optionalRequiredText(base+"/model", value.Model, maxModelBytes), Status: b.text(base+"/status", value.Status, maxStatusBytes),
+			Task: b.text(base+"/task", value.Task, maxSubagentTextBytes), Result: b.text(base+"/result", value.Result, maxSubagentTextBytes),
+			DurationMs: copyIntPointer(value.DurationMs), SpawnedAtTurn: copyIntPointer(value.SpawnedAtTurn), ToolUses: value.ToolUses,
+			CommandLabels: labels, Usage: usage, EstimatedCostMicroUSD: cost,
+		})
+	}
+	return result, nil
+}
+
+func cleanRoot(root string) string {
+	if root == "" {
+		return ""
+	}
+	root, err := filepath.Abs(root)
+	if err != nil {
+		return ""
+	}
+	return filepath.Clean(root)
+}
+
+func outsideRoot(path string) bool {
+	return path == ".." || strings.HasPrefix(path, ".."+string(filepath.Separator)) || filepath.IsAbs(path)
+}
+
+func copyIntPointer(value *int) *int {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func copyInt64Pointer(value *int64) *int64 {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func intPointer(value int) *int          { return &value }
+func stringPointer(value string) *string { return &value }

--- a/collector/internal/sessionexport/snapshot_test.go
+++ b/collector/internal/sessionexport/snapshot_test.go
@@ -114,6 +114,44 @@ func TestCredentialPatternsAreRedactedWithoutLeakingMetadata(t *testing.T) {
 	}
 }
 
+func TestUnterminatedCredentialPatternsRedactThroughEndOfText(t *testing.T) {
+	repository := "github.com/centauri-ai/coslash"
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"JSON bearer", `{"Authorization":"Bearer json-first-secret json-second-secret`},
+		{"JSON password", `{"password":"json-first-secret json-second-secret`},
+		{"double-quoted bearer", `Authorization="Bearer auth-first-secret auth-second-secret`},
+		{"single-quoted bearer", `Authorization='Bearer auth-first-secret auth-second-secret`},
+		{"double-quoted password", `password="first-secret second-secret`},
+		{"double-quoted password with dangling escape", `password="first-secret second-secret\`},
+		{"single-quoted token", `token='first-secret second-secret`},
+		{"private key", "-----BEGIN PRIVATE KEY-----\nprivate-first-secret\nprivate-second-secret"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			local := session.Session{
+				Agent: "codex", ID: "source", Repository: &repository, StartedAt: 1,
+				Summary: &test.value, Tokens: map[string]session.ModelTokens{},
+			}
+			data, err := Marshal(local, BuildOptions{CollectorVersion: "0.1.0"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, secret := range []string{"first-secret", "second-secret"} {
+				if bytes.Contains(data, []byte(secret)) {
+					t.Fatalf("snapshot leaked %q", secret)
+				}
+			}
+			if !bytes.Contains(data, []byte("credential_pattern")) {
+				t.Fatal("credential redaction was not recorded")
+			}
+		})
+	}
+}
+
 func TestBuildResolvesRelativeFileEditsAgainstWorkingDirectory(t *testing.T) {
 	root := filepath.Join(string(filepath.Separator), "repo")
 	repository := "github.com/centauri-ai/coslash"

--- a/collector/internal/sessionexport/snapshot_test.go
+++ b/collector/internal/sessionexport/snapshot_test.go
@@ -1,0 +1,480 @@
+package sessionexport
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/centauri-ai/coslash/collector/internal/session"
+	snapshotv1 "github.com/centauri-ai/coslash/collector/snapshot/v1"
+)
+
+func TestBuildUsesExplicitAllowListAndStructuralRedaction(t *testing.T) {
+	root := filepath.Join(string(filepath.Separator), "work", "coslash")
+	repository := "github.com/centauri-ai/coslash"
+	name := "Implement export"
+	summary := "Never retain Authorization: Bearer prose-secret"
+	firstPrompt := "Use TOKEN=prompt-secret only for this local test"
+	model := "gpt-5"
+	local := session.Session{
+		Agent: "codex", ID: "source-1", Name: &name, Summary: &summary,
+		WorkingDirectory: filepath.Join(root, "collector"),
+		Repository:       &repository, StartedAt: 7_000, LastActivityTime: 10_000, DurationMs: intPointerForTest(2_000),
+		Tokens: map[string]session.ModelTokens{"gpt-5": {InputTokens: 12, OutputTokens: 3, Cost: 0.25}},
+		Cost:   0.25,
+		Subagents: []session.Subagent{{
+			ID: "child", Name: "reviewer", Status: session.SubagentReturned,
+			Commands: []session.SubagentCommand{
+				{Label: "Run unit tests", Command: "go test ./..."},
+				{Label: "cat $TOKEN", Command: "cat $TOKEN"},
+			},
+			Tokens: map[string]session.ModelTokens{},
+		}},
+		SessionDetails: session.SessionDetails{
+			Model: &model, FirstPrompt: &firstPrompt,
+			Commands: []string{"curl -H 'Authorization: Bearer fake-secret'"},
+			FileEdits: []session.FileEdit{
+				{Path: filepath.Join(root, "collector", "main.go"), Additions: 3, Edits: 1},
+				{Path: filepath.Join(string(filepath.Separator), "Users", "person", ".ssh", "config"), Edits: 1},
+			},
+			Synthesis:        &session.SessionSynthesis{Outcome: "must stay local"},
+			SynthesisPending: true,
+			CompactionSeed:   "must stay local",
+		},
+	}
+
+	snapshot, err := Build(local, BuildOptions{CollectorVersion: "0.1.0", RepositoryRoot: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.Session.WorkingDirectory == nil || *snapshot.Session.WorkingDirectory != "collector" {
+		t.Fatalf("cwd = %v", snapshot.Session.WorkingDirectory)
+	}
+	if snapshot.SessionStartedAtMs != 7_000 {
+		t.Fatalf("session start = %d", snapshot.SessionStartedAtMs)
+	}
+	if len(snapshot.Session.FileEdits) != 1 || snapshot.Session.FileEdits[0].Path != "collector/main.go" {
+		t.Fatalf("file edits = %#v", snapshot.Session.FileEdits)
+	}
+	if got := snapshot.Session.Subagents[0].CommandLabels; len(got) != 1 || got[0] != "Run unit tests" {
+		t.Fatalf("command labels = %#v", got)
+	}
+	if snapshot.Session.Counts.Commands != 1 {
+		t.Fatalf("command count = %d", snapshot.Session.Counts.Commands)
+	}
+	data, err := snapshotv1.Marshal(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, excluded := range []string{"fake-secret", "prose-secret", "prompt-secret", "cat $TOKEN", ".ssh", "must stay local", root} {
+		if bytes.Contains(data, []byte(excluded)) {
+			t.Errorf("serialized snapshot leaked %q", excluded)
+		}
+	}
+	if _, err := snapshotv1.Decode(data); err != nil {
+		t.Fatal(err)
+	}
+	assertMetadataPointersResolve(t, data, snapshot)
+}
+
+func TestCredentialPatternsAreRedactedWithoutLeakingMetadata(t *testing.T) {
+	repository := "github.com/centauri-ai/coslash"
+	patterns := `{"Authorization":"Bearer json-bearer-secret","password":"json password secret"} ` +
+		`password="quoted-prefix quoted-shell-tail-9382" token='single-prefix single-shell-tail-4721' ` +
+		`secret="escaped-prefix \"inside\" escaped-shell-tail-2846" ` +
+		`Authorization="Bearer auth-prefix auth-shell-tail-6153" ` +
+		"ghp_1234567890abcdef sk-1234567890abcdef https://person:password@example.com " +
+		"-----BEGIN PRIVATE KEY-----\nprivate-material\n-----END PRIVATE KEY-----"
+	local := session.Session{
+		Agent: "codex", ID: "source", Repository: &repository, StartedAt: 1,
+		Summary: &patterns, Tokens: map[string]session.ModelTokens{},
+	}
+	data, err := Marshal(local, BuildOptions{CollectorVersion: "0.1.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, secret := range []string{
+		"json-bearer-secret", "json password secret",
+		"quoted-prefix", "quoted-shell-tail-9382",
+		"single-prefix", "single-shell-tail-4721",
+		"escaped-prefix", "inside", "escaped-shell-tail-2846",
+		"auth-prefix", "auth-shell-tail-6153",
+		"ghp_1234567890abcdef", "sk-1234567890abcdef", "person:password", "private-material",
+	} {
+		if bytes.Contains(data, []byte(secret)) {
+			t.Fatalf("snapshot leaked %q", secret)
+		}
+	}
+	if !bytes.Contains(data, []byte("credential_pattern")) {
+		t.Fatal("credential redaction was not recorded")
+	}
+}
+
+func TestBuildResolvesRelativeFileEditsAgainstWorkingDirectory(t *testing.T) {
+	root := filepath.Join(string(filepath.Separator), "repo")
+	repository := "github.com/centauri-ai/coslash"
+	local := session.Session{
+		Agent: "opencode", ID: "source", Repository: &repository, StartedAt: 1,
+		WorkingDirectory: filepath.Join(root, "pkg"), Tokens: map[string]session.ModelTokens{},
+		SessionDetails: session.SessionDetails{FileEdits: []session.FileEdit{{Path: "main.go"}}},
+	}
+
+	snapshot, err := Build(local, BuildOptions{CollectorVersion: "0.1.0", RepositoryRoot: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := snapshot.Session.FileEdits; len(got) != 1 || got[0].Path != "pkg/main.go" {
+		t.Fatalf("file edits = %#v", got)
+	}
+
+	local.WorkingDirectory = filepath.Join(string(filepath.Separator), "outside")
+	snapshot, err = Build(local, BuildOptions{CollectorVersion: "0.1.0", RepositoryRoot: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.Session.FileEdits) != 0 {
+		t.Fatalf("outside-cwd file edits = %#v", snapshot.Session.FileEdits)
+	}
+}
+
+func TestBuildKeepsTruncatedPathsValid(t *testing.T) {
+	root := filepath.Join(string(filepath.Separator), "repo")
+	repository := "github.com/centauri-ai/coslash"
+	paths := []string{
+		strings.Repeat("a/", maxPathBytes/2) + "x",
+		strings.Repeat("a", maxPathBytes-3) + "/...x",
+		strings.Repeat("a", maxPathBytes-2) + "/.x",
+	}
+	for _, path := range paths {
+		local := session.Session{
+			Agent: "codex", ID: "source", Repository: &repository, StartedAt: 1,
+			WorkingDirectory: root, Tokens: map[string]session.ModelTokens{},
+			SessionDetails: session.SessionDetails{FileEdits: []session.FileEdit{{Path: path}}},
+		}
+
+		snapshot, err := Build(local, BuildOptions{CollectorVersion: "0.1.0", RepositoryRoot: root})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := snapshot.Session.FileEdits; len(got) != 1 || strings.HasSuffix(got[0].Path, "/") || strings.HasSuffix(got[0].Path, "/.") || strings.HasSuffix(got[0].Path, "/..") || len(got[0].Path) > maxPathBytes {
+			t.Fatalf("truncated file edits = %#v", got)
+		}
+		if _, err := snapshotv1.Marshal(snapshot); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestBuildOmitsUnprovenRelativeFileEdits(t *testing.T) {
+	repository := "github.com/centauri-ai/coslash"
+	local := session.Session{
+		Agent: "codex", ID: "source", Repository: &repository, StartedAt: 1,
+		Tokens:         map[string]session.ModelTokens{},
+		SessionDetails: session.SessionDetails{FileEdits: []session.FileEdit{{Path: "unproven.go"}}},
+	}
+
+	snapshot, err := Build(local, BuildOptions{CollectorVersion: "0.1.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.Session.FileEdits) != 0 || len(snapshot.Redactions) != 1 || snapshot.Redactions[0].Path != "/session/fileEdits" {
+		t.Fatalf("unproven edits were not structurally redacted: edits=%#v redactions=%#v", snapshot.Session.FileEdits, snapshot.Redactions)
+	}
+}
+
+func TestBuildAppliesFileEditBudgetAfterPathRedaction(t *testing.T) {
+	root := filepath.Join(string(filepath.Separator), "repo")
+	repository := "github.com/centauri-ai/coslash"
+	edits := make([]session.FileEdit, 0, maxFileEditItems*2+1)
+	for range maxFileEditItems {
+		edits = append(edits, session.FileEdit{Path: filepath.Join(string(filepath.Separator), "outside", "secret.go")})
+	}
+	for i := 0; i < maxFileEditItems+1; i++ {
+		edits = append(edits, session.FileEdit{Path: fmt.Sprintf("safe/%04d.go", i), Edits: 1})
+	}
+	local := session.Session{
+		Agent: "opencode", ID: "source", Repository: &repository, StartedAt: 1,
+		WorkingDirectory: root, Tokens: map[string]session.ModelTokens{},
+		SessionDetails: session.SessionDetails{FileEdits: edits},
+	}
+
+	snapshot, err := Build(local, BuildOptions{CollectorVersion: "0.1.0", RepositoryRoot: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := snapshot.Session.FileEdits; len(got) != maxFileEditItems || got[0].Path != "safe/0000.go" || got[len(got)-1].Path != "safe/1999.go" {
+		t.Fatalf("file edits = first/last/count %#v %#v %d", got[0], got[len(got)-1], len(got))
+	}
+	if len(snapshot.Redactions) != 1 || snapshot.Redactions[0].Path != "/session/fileEdits" || snapshot.Redactions[0].Reason != "outside_repository" {
+		t.Fatalf("file-edit redactions = %#v", snapshot.Redactions)
+	}
+	for _, item := range snapshot.Truncation {
+		if item.Path == "/session/fileEdits" && item.Reason == snapshotv1.TruncationReasonItemBudget {
+			if item.OriginalItems == nil || *item.OriginalItems != maxFileEditItems+1 || item.ExportedItems == nil || *item.ExportedItems != maxFileEditItems {
+				t.Fatalf("file-edit item metadata = %#v", item)
+			}
+			return
+		}
+	}
+	t.Fatal("file-edit item truncation was not recorded")
+}
+
+func TestBuildMergesModelNamesThatCollideAfterTruncation(t *testing.T) {
+	repository := "github.com/centauri-ai/coslash"
+	prefix := strings.Repeat("m", maxModelBytes)
+	first, second := prefix+"-a", prefix+"-b"
+	local := session.Session{
+		Agent: "codex", ID: "source", Repository: &repository, StartedAt: 1,
+		Tokens: map[string]session.ModelTokens{
+			first:  {InputTokens: 2, Cost: 0.25},
+			second: {OutputTokens: 3, Cost: 0.50},
+		},
+		Cost: 0.75, UnpricedModels: []string{first, second},
+	}
+
+	snapshot, err := Build(local, BuildOptions{CollectorVersion: "0.1.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := snapshot.Session.Usage.Models; len(got) != 1 || got[0].Model != prefix || got[0].InputTokens != 2 || got[0].OutputTokens != 3 || got[0].EstimatedCostMicroUSD != 750_000 {
+		t.Fatalf("merged usage = %#v", got)
+	}
+	if got := snapshot.Session.Usage.UnpricedModels; len(got) != 1 || got[0] != prefix {
+		t.Fatalf("merged unpriced models = %#v", got)
+	}
+	if _, err := snapshotv1.Marshal(snapshot); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBuildSortsAndMergesModelsAfterTransformation(t *testing.T) {
+	repository := "github.com/centauri-ai/coslash"
+	secretModel := "ghp_1234567890abcdef"
+	secondSecret := "sk-1234567890abcdef"
+	local := session.Session{
+		Agent: "codex", ID: "source", Repository: &repository, StartedAt: 1,
+		Tokens: map[string]session.ModelTokens{
+			"":           {InputTokens: 100},
+			"a-model":    {InputTokens: 1},
+			secretModel:  {InputTokens: 2},
+			secondSecret: {OutputTokens: 3},
+		},
+		UnpricedModels: []string{"", "a-model", secretModel, secondSecret},
+	}
+
+	snapshot, err := Build(local, BuildOptions{CollectorVersion: "0.1.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	models := snapshot.Session.Usage.Models
+	if len(models) != 2 || models[0].Model != "[REDACTED]" || models[0].InputTokens != 2 || models[0].OutputTokens != 3 || models[1].Model != "a-model" {
+		t.Fatalf("transformed models = %#v", models)
+	}
+	if got := snapshot.Session.Usage.UnpricedModels; len(got) != 2 || got[0] != "[REDACTED]" || got[1] != "a-model" {
+		t.Fatalf("transformed unpriced models = %#v", got)
+	}
+	data, err := snapshotv1.Marshal(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, secret := range []string{secretModel, secondSecret} {
+		if bytes.Contains(data, []byte(secret)) {
+			t.Fatalf("snapshot leaked model credential %q", secret)
+		}
+	}
+}
+
+func TestBuildUsesWirePathsForSubagentUsageAndOmitsEmptyModels(t *testing.T) {
+	repository := "github.com/centauri-ai/coslash"
+	emptyModel := ""
+	longModel := strings.Repeat("m", maxModelBytes+1)
+	local := session.Session{
+		Agent: "codex", ID: "source", Repository: &repository, StartedAt: 1,
+		Tokens:         map[string]session.ModelTokens{},
+		SessionDetails: session.SessionDetails{Model: &emptyModel},
+		Subagents: []session.Subagent{{
+			ID: "child", Name: "worker", Model: &emptyModel, Status: session.SubagentReturned,
+			Tokens: map[string]session.ModelTokens{longModel: {InputTokens: 1}},
+		}},
+	}
+
+	snapshot, err := Build(local, BuildOptions{CollectorVersion: "0.1.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.Session.Model != nil || snapshot.Session.Subagents[0].Model != nil {
+		t.Fatalf("empty models were exported: session=%v subagent=%v", snapshot.Session.Model, snapshot.Session.Subagents[0].Model)
+	}
+	if got := snapshot.Truncation; len(got) != 1 || got[0].Path != "/session/subagents/0/usage/0/model" {
+		t.Fatalf("subagent usage truncation = %#v", got)
+	}
+	if _, err := snapshotv1.Marshal(snapshot); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBuildRetainsNewestDigestEntriesAtItemBudget(t *testing.T) {
+	repository := "github.com/centauri-ai/coslash"
+	digest := make([]session.DigestEntry, maxDigestItems+5)
+	for i := range digest {
+		digest[i] = session.DigestEntry{Turn: i, Category: session.DigestUser, Description: "entry"}
+	}
+	local := session.Session{
+		Agent: "codex", ID: "source", Repository: &repository, StartedAt: 1,
+		Tokens:         map[string]session.ModelTokens{},
+		SessionDetails: session.SessionDetails{Digest: digest},
+	}
+
+	snapshot, err := Build(local, BuildOptions{CollectorVersion: "0.1.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := snapshot.Session.Digest; len(got) != maxDigestItems || got[0].Turn != 5 || got[len(got)-1].Turn != maxDigestItems+4 {
+		t.Fatalf("retained digest range = first %d, last %d, count %d", got[0].Turn, got[len(got)-1].Turn, len(got))
+	}
+}
+
+func TestBuildAppliesUTF8AndItemBudgetsWithoutSilentTruncation(t *testing.T) {
+	repository := "local-repository"
+	long := strings.Repeat("界", maxNameBytes)
+	commits := make([]string, maxCommitItems+1)
+	for i := range commits {
+		commits[i] = "commit"
+	}
+	local := session.Session{
+		Agent: "claude", ID: "source-2", Name: &long, Repository: &repository,
+		RepositoryLocalOnly: true, StartedAt: 1, LastActivityTime: 1, Tokens: map[string]session.ModelTokens{},
+		SessionDetails: session.SessionDetails{Commits: commits},
+	}
+	snapshot, err := Build(local, BuildOptions{CollectorVersion: "0.1.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(*snapshot.Session.Name); got > maxNameBytes || !strings.HasPrefix(long, *snapshot.Session.Name) {
+		t.Fatalf("name exported bytes = %d", got)
+	}
+	if len(snapshot.Session.Commits) != maxCommitItems {
+		t.Fatalf("commits = %d", len(snapshot.Session.Commits))
+	}
+	if len(snapshot.Truncation) != 2 {
+		t.Fatalf("truncation = %#v", snapshot.Truncation)
+	}
+	data, err := snapshotv1.Marshal(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertMetadataPointersResolve(t, data, snapshot)
+}
+
+func TestMarshalIsStableAcrossTokenMapOrder(t *testing.T) {
+	repository := "github.com/centauri-ai/coslash"
+	base := session.Session{Agent: "codex", ID: "source", Repository: &repository, StartedAt: 1, Tokens: map[string]session.ModelTokens{}, UnpricedModels: []string{"b", "a"}}
+	base.Tokens["z"] = session.ModelTokens{InputTokens: 1}
+	base.Tokens["a"] = session.ModelTokens{OutputTokens: 1}
+	first, err := Marshal(base, BuildOptions{CollectorVersion: "0.1.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	base.Tokens = map[string]session.ModelTokens{"a": {OutputTokens: 1}, "z": {InputTokens: 1}}
+	second, err := Marshal(base, BuildOptions{CollectorVersion: "0.1.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatal("map insertion order changed canonical bytes")
+	}
+}
+
+func TestMetadataPointersUseExportedStructure(t *testing.T) {
+	root := filepath.Join(string(filepath.Separator), "work", "coslash")
+	repository := "github.com/centauri-ai/coslash"
+	model := strings.Repeat("model/segment", 30)
+	commands := func(count int) []session.SubagentCommand {
+		result := make([]session.SubagentCommand, count)
+		for i := range result {
+			result[i] = session.SubagentCommand{Label: "safe label", Command: "raw"}
+		}
+		return result
+	}
+	secondCommands := commands(100)
+	secondCommands[0].Label = secondCommands[0].Command
+	local := session.Session{
+		Agent: "future-agent", ID: "source", Repository: &repository, StartedAt: 1,
+		WorkingDirectory: filepath.Join(string(filepath.Separator), "outside"),
+		Tokens:           map[string]session.ModelTokens{model: {}},
+		Subagents: []session.Subagent{
+			{ID: "one", Name: "one", Status: session.SubagentReturned, Commands: commands(150), Tokens: map[string]session.ModelTokens{}},
+			{ID: "two", Name: "two", Status: session.SubagentReturned, Commands: secondCommands, Tokens: map[string]session.ModelTokens{}},
+		},
+		SessionDetails: session.SessionDetails{FileEdits: []session.FileEdit{
+			{Path: filepath.Join(string(filepath.Separator), "outside", "secret")},
+			{Path: filepath.Join(root, strings.Repeat("p", maxPathBytes+10))},
+		}},
+	}
+	snapshot, err := Build(local, BuildOptions{CollectorVersion: "0.1.0", RepositoryRoot: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := snapshotv1.Marshal(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertMetadataPointersResolve(t, data, snapshot)
+	for _, item := range snapshot.Truncation {
+		if strings.Contains(item.Path, "*") || strings.Contains(item.Path, "model/segment") {
+			t.Fatalf("unstable truncation pointer: %s", item.Path)
+		}
+	}
+	for _, item := range snapshot.Redactions {
+		if strings.Contains(item.Path, "*") {
+			t.Fatalf("wildcard redaction pointer: %s", item.Path)
+		}
+	}
+}
+
+func intPointerForTest(value int) *int { return &value }
+
+func assertMetadataPointersResolve(t *testing.T, data []byte, snapshot snapshotv1.Snapshot) {
+	t.Helper()
+	var document any
+	if err := json.Unmarshal(data, &document); err != nil {
+		t.Fatal(err)
+	}
+	for _, item := range snapshot.Truncation {
+		if !pointerResolves(document, item.Path) {
+			t.Errorf("truncation pointer does not resolve: %s", item.Path)
+		}
+	}
+	for _, item := range snapshot.Redactions {
+		if !pointerResolves(document, item.Path) {
+			t.Errorf("redaction pointer does not resolve: %s", item.Path)
+		}
+	}
+}
+
+func pointerResolves(value any, pointer string) bool {
+	for _, encoded := range strings.Split(strings.TrimPrefix(pointer, "/"), "/") {
+		segment := strings.ReplaceAll(strings.ReplaceAll(encoded, "~1", "/"), "~0", "~")
+		switch current := value.(type) {
+		case map[string]any:
+			var ok bool
+			value, ok = current[segment]
+			if !ok {
+				return false
+			}
+		case []any:
+			index, err := strconv.Atoi(segment)
+			if err != nil || index < 0 || index >= len(current) {
+				return false
+			}
+			value = current[index]
+		default:
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

Add the explicit private-to-wire allow-list for session snapshots, including path proof, credential redaction, text/item budgets, and frozen usage/cost mapping.

## Why this is separate

This is the privacy boundary. Keeping it apart from the public schema and aggregate fitting lets reviewers focus on exactly which local fields may leave the machine and how each one is sanitized.

## Changes

- map approved session, usage, digest, todo, edit, commit, Git, and subagent facts;
- exclude raw commands, transcripts, tool output, diffs, reasoning, log paths, and parser state;
- redact quoted and unquoted credential patterns without leaking quoted suffixes;
- export file paths only after proving they are repository-relative;
- normalize and safely truncate UTF-8 text and paths;
- transform, drop, merge, sort, and deduplicate model names before validation;
- add a nested allow-list census so new local fields remain excluded by default.

## Review guide

Review `Build` field by field, then the credential/path helpers, followed by `allowlist_test.go`. `Marshal` still delegates directly to the public contract in this slice; aggregate degradation arrives next.

## Verification

- `go test ./...`
- `go vet ./...`

## Stack

This is PR 3 of 5 for ENG-1340. Its base is PR 2.

| Order | PR | Scope |
| ---: | --- | --- |
| 1 | [#83](https://github.com/centauri-ai/coslash/pull/83) | Canonical session start |
| 2 | [#84](https://github.com/centauri-ai/coslash/pull/84) | Public v1 contract |
| 3 | [#85](https://github.com/centauri-ai/coslash/pull/85) | Private-to-wire export boundary |
| 4 | [#86](https://github.com/centauri-ai/coslash/pull/86) | Aggregate payload fitting |
| 5 | [#87](https://github.com/centauri-ai/coslash/pull/87) | Fixtures, measurement, and docs |

## Rollout

The mapper is internal and has no preview/upload caller in this stack, so it remains inert until integration is added.
