### PR TITLE
feat(collector): fit snapshots to aggregate budget

### DIFF
--- a/collector/internal/session/file_edits.go
+++ b/collector/internal/session/file_edits.go
@@ -34,6 +34,15 @@ func (s *FileEditSet) Add(path string, additions, deletions int, isNew bool) {
 			edit.IsNew = true
 		}
 		edit.changes = append(edit.changes, change)
+		if i != len(s.Edits)-1 {
+			updated := *edit
+			copy(s.Edits[i:], s.Edits[i+1:])
+			s.Edits[len(s.Edits)-1] = updated
+			for shifted := i; shifted < len(s.Edits)-1; shifted++ {
+				s.index[s.Edits[shifted].Path] = shifted
+			}
+			s.index[path] = len(s.Edits) - 1
+		}
 		return
 	}
 	s.index[path] = len(s.Edits)

--- a/collector/internal/session/file_edits_test.go
+++ b/collector/internal/session/file_edits_test.go
@@ -1,0 +1,22 @@
+package session
+
+import "testing"
+
+func TestFileEditSetOrdersFilesByMostRecentEdit(t *testing.T) {
+	edits := NewFileEditSet()
+	edits.Add("hot.go", 1, 0, false)
+	edits.Add("cold.go", 2, 0, false)
+	edits.Add("hot.go", 3, 1, false)
+
+	if edits.Edits[0].Path != "cold.go" || edits.Edits[1].Path != "hot.go" {
+		t.Fatalf("edit order = %#v", edits.Edits)
+	}
+	if hot := edits.Edits[1]; hot.Additions != 4 || hot.Deletions != 1 || hot.Edits != 2 {
+		t.Fatalf("updated edit = %#v", hot)
+	}
+
+	edits.Add("cold.go", 1, 1, false)
+	if edits.Edits[0].Path != "hot.go" || edits.Edits[1].Path != "cold.go" {
+		t.Fatalf("second edit order = %#v", edits.Edits)
+	}
+}

--- a/collector/internal/sessionexport/aggregate.go
+++ b/collector/internal/sessionexport/aggregate.go
@@ -27,6 +27,7 @@ func fitAggregate(snapshot snapshotv1.Snapshot) (snapshotv1.Snapshot, error) {
 		reduceTodos,
 		reduceCommits,
 		reduceFileEdits,
+		reduceSessionMetadata,
 	}
 	for _, reduce := range reducers {
 		if fits, err := reduce(&snapshot); err != nil {
@@ -136,6 +137,60 @@ func reduceCommits(snapshot *snapshotv1.Snapshot) (bool, error) {
 
 func reduceFileEdits(snapshot *snapshotv1.Snapshot) (bool, error) {
 	return reduceNewest(snapshot, "/session/fileEdits", &snapshot.Session.FileEdits)
+}
+
+// reduceSessionMetadata removes optional envelope fields only after all
+// collection evidence has been exhausted. The aggregate record targets the
+// session object because removed optional properties no longer resolve as JSON
+// Pointer targets.
+func reduceSessionMetadata(snapshot *snapshotv1.Snapshot) (bool, error) {
+	session := &snapshot.Session
+	fields := []struct {
+		path    string
+		present bool
+		clear   func()
+	}{
+		{"/session/firstPrompt", session.FirstPrompt != nil, func() { session.FirstPrompt = nil }},
+		{"/session/declaredGoal", session.DeclaredGoal != nil, func() { session.DeclaredGoal = nil }},
+		{"/session/summary", session.Summary != nil, func() { session.Summary = nil }},
+		{"/session/name", session.Name != nil, func() { session.Name = nil }},
+		{"/session/entrypoint", session.Entrypoint != nil, func() { session.Entrypoint = nil }},
+		{"/session/branch", session.Branch != nil, func() { session.Branch = nil }},
+		{"/session/cwd", session.WorkingDirectory != nil, func() { session.WorkingDirectory = nil }},
+		{"/session/status", session.Status != nil, func() { session.Status = nil }},
+		{"/session/git", session.Git != nil, func() { session.Git = nil }},
+		{"/session/lastEditAtMs", session.LastEditAtMs != nil, func() { session.LastEditAtMs = nil }},
+		{"/session/durationMs", session.DurationMs != nil, func() { session.DurationMs = nil }},
+		{"/session/contextWindow", session.ContextWindow != nil, func() { session.ContextWindow = nil }},
+		{"/session/contextTokens", session.ContextTokens != nil, func() { session.ContextTokens = nil }},
+		{"/session/model", session.Model != nil, func() { session.Model = nil }},
+	}
+
+	original := 0
+	for _, field := range fields {
+		if field.present {
+			original++
+		}
+	}
+	if original == 0 {
+		return false, nil
+	}
+
+	remaining := original
+	upsertAggregateItems(snapshot, "/session", original, remaining)
+	for _, field := range fields {
+		if !field.present {
+			continue
+		}
+		field.clear()
+		removeMetadata(snapshot, field.path)
+		remaining--
+		setAggregateItems(snapshot, "/session", remaining)
+		if fits, err := snapshotFits(snapshot); err != nil || fits {
+			return fits, err
+		}
+	}
+	return false, nil
 }
 
 func reduceTail[T any](snapshot *snapshotv1.Snapshot, path string, values *[]T) (bool, error) {

--- a/collector/internal/sessionexport/aggregate.go
+++ b/collector/internal/sessionexport/aggregate.go
@@ -1,0 +1,426 @@
+package sessionexport
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	snapshotv1 "github.com/centauri-ai/coslash/collector/snapshot/v1"
+)
+
+// fitAggregate preserves mandatory identity, repository, time, count, usage,
+// cost, and redaction facts. When a bounded snapshot is still too large, it
+// reduces optional evidence in the documented order and records every change.
+func fitAggregate(snapshot snapshotv1.Snapshot) (snapshotv1.Snapshot, error) {
+	fits, err := snapshotFits(&snapshot)
+	if err != nil || fits {
+		return snapshot, err
+	}
+
+	reducers := []func(*snapshotv1.Snapshot) (bool, error){
+		reduceCommandLabels,
+		reduceSubagentProse,
+		reduceDigestAnswers,
+		reduceOlderDigest,
+		reduceTodos,
+		reduceCommits,
+		reduceFileEdits,
+	}
+	for _, reduce := range reducers {
+		if fits, err := reduce(&snapshot); err != nil {
+			return snapshotv1.Snapshot{}, err
+		} else if fits {
+			return snapshot, nil
+		}
+	}
+
+	size, err := encodedSnapshotSize(snapshot)
+	if err != nil {
+		return snapshotv1.Snapshot{}, err
+	}
+	return snapshotv1.Snapshot{}, fmt.Errorf(
+		"mandatory snapshot facts are %d bytes after optional evidence reduction; maximum is %d: %w",
+		size, snapshotv1.MaxPayloadBytes, snapshotv1.ErrOversized,
+	)
+}
+
+func snapshotFits(snapshot *snapshotv1.Snapshot) (bool, error) {
+	size, err := encodedSnapshotSize(*snapshot)
+	if err != nil {
+		return false, err
+	}
+	return size <= snapshotv1.MaxPayloadBytes, nil
+}
+
+// encodedSnapshotSize avoids repeating validation, hashing, and a second
+// marshal during every aggregate-fitting probe. The placeholder has the same
+// encoded length as the final SHA-256 content hash; snapshotv1.Marshal still
+// performs the authoritative validation and hashing once after fitting.
+func encodedSnapshotSize(snapshot snapshotv1.Snapshot) (int, error) {
+	snapshot.ContentHash = "sha256:" + strings.Repeat("0", 64)
+	data, err := json.Marshal(snapshot)
+	if err != nil {
+		return 0, fmt.Errorf("measure snapshot: %w", err)
+	}
+	return len(data), nil
+}
+
+func reduceCommandLabels(snapshot *snapshotv1.Snapshot) (bool, error) {
+	for i := len(snapshot.Session.Subagents) - 1; i >= 0; i-- {
+		labels := &snapshot.Session.Subagents[i].CommandLabels
+		if len(*labels) == 0 {
+			continue
+		}
+		if fits, err := reduceTail(snapshot, fmt.Sprintf("/session/subagents/%d/commandLabels", i), labels); err != nil || fits {
+			return fits, err
+		}
+	}
+	return false, nil
+}
+
+func reduceSubagentProse(snapshot *snapshotv1.Snapshot) (bool, error) {
+	for i := len(snapshot.Session.Subagents) - 1; i >= 0; i-- {
+		subagent := &snapshot.Session.Subagents[i]
+		if fits, err := reduceRequiredText(snapshot, fmt.Sprintf("/session/subagents/%d/result", i), &subagent.Result); err != nil || fits {
+			return fits, err
+		}
+		if fits, err := reduceRequiredText(snapshot, fmt.Sprintf("/session/subagents/%d/task", i), &subagent.Task); err != nil || fits {
+			return fits, err
+		}
+	}
+	return false, nil
+}
+
+func reduceDigestAnswers(snapshot *snapshotv1.Snapshot) (bool, error) {
+	originalBytes := 0
+	remainingBytes := 0
+	for _, digest := range snapshot.Session.Digest {
+		if digest.Answer != nil {
+			originalBytes += len(*digest.Answer)
+			remainingBytes += len(*digest.Answer)
+		}
+	}
+	if originalBytes == 0 {
+		return false, nil
+	}
+	upsertAggregateBytes(snapshot, "/session/digest", originalBytes, remainingBytes)
+	for i := range snapshot.Session.Digest {
+		answer := snapshot.Session.Digest[i].Answer
+		if answer == nil {
+			continue
+		}
+		remainingBytes -= len(*answer)
+		snapshot.Session.Digest[i].Answer = nil
+		removeMetadata(snapshot, fmt.Sprintf("/session/digest/%d/answer", i))
+		setAggregateBytes(snapshot, "/session/digest", remainingBytes)
+		if fits, err := snapshotFits(snapshot); err != nil || fits {
+			return fits, err
+		}
+	}
+	return false, nil
+}
+
+func reduceOlderDigest(snapshot *snapshotv1.Snapshot) (bool, error) {
+	return reduceNewest(snapshot, "/session/digest", &snapshot.Session.Digest)
+}
+
+func reduceTodos(snapshot *snapshotv1.Snapshot) (bool, error) {
+	return reduceTail(snapshot, "/session/todos", &snapshot.Session.Todos)
+}
+
+func reduceCommits(snapshot *snapshotv1.Snapshot) (bool, error) {
+	return reduceNewest(snapshot, "/session/commits", &snapshot.Session.Commits)
+}
+
+func reduceFileEdits(snapshot *snapshotv1.Snapshot) (bool, error) {
+	return reduceNewest(snapshot, "/session/fileEdits", &snapshot.Session.FileEdits)
+}
+
+func reduceTail[T any](snapshot *snapshotv1.Snapshot, path string, values *[]T) (bool, error) {
+	if len(*values) == 0 {
+		return false, nil
+	}
+	originalValues := *values
+	original := len(originalValues)
+	upsertAggregateItems(snapshot, path, original, original)
+	metadata := captureMetadata(snapshot)
+	*values = originalValues[:0]
+	metadata.restore(snapshot)
+	retainPrefixMetadata(snapshot, path, 0)
+	setAggregateItems(snapshot, path, 0)
+	zeroFits, err := snapshotFits(snapshot)
+	if err != nil || !zeroFits {
+		return false, err
+	}
+	best := 0
+	low, high := 1, original
+	for low <= high {
+		middle := low + (high-low)/2
+		*values = originalValues[:middle]
+		metadata.restore(snapshot)
+		retainPrefixMetadata(snapshot, path, middle)
+		setAggregateItems(snapshot, path, middle)
+		fits, err := snapshotFits(snapshot)
+		if err != nil {
+			return false, err
+		}
+		if fits {
+			best = middle
+			low = middle + 1
+		} else {
+			high = middle - 1
+		}
+	}
+	*values = originalValues[:best]
+	metadata.restore(snapshot)
+	retainPrefixMetadata(snapshot, path, best)
+	setAggregateItems(snapshot, path, best)
+	return true, nil
+}
+
+func reduceNewest[T any](snapshot *snapshotv1.Snapshot, path string, values *[]T) (bool, error) {
+	if len(*values) == 0 {
+		return false, nil
+	}
+	originalValues := *values
+	original := len(originalValues)
+	upsertAggregateItems(snapshot, path, original, original)
+	metadata := captureMetadata(snapshot)
+	*values = originalValues[original:]
+	metadata.restore(snapshot)
+	retainSuffixMetadata(snapshot, path, original)
+	setAggregateItems(snapshot, path, 0)
+	zeroFits, err := snapshotFits(snapshot)
+	if err != nil || !zeroFits {
+		return false, err
+	}
+	best := 0
+	low, high := 1, original
+	for low <= high {
+		middle := low + (high-low)/2
+		removed := original - middle
+		*values = originalValues[removed:]
+		metadata.restore(snapshot)
+		retainSuffixMetadata(snapshot, path, removed)
+		setAggregateItems(snapshot, path, middle)
+		fits, err := snapshotFits(snapshot)
+		if err != nil {
+			return false, err
+		}
+		if fits {
+			best = middle
+			low = middle + 1
+		} else {
+			high = middle - 1
+		}
+	}
+	removed := original - best
+	*values = originalValues[removed:]
+	metadata.restore(snapshot)
+	retainSuffixMetadata(snapshot, path, removed)
+	setAggregateItems(snapshot, path, best)
+	return true, nil
+}
+
+func reduceRequiredText(snapshot *snapshotv1.Snapshot, path string, value *string) (bool, error) {
+	if value == nil || *value == "" {
+		return false, nil
+	}
+	original := *value
+	upsertAggregateBytes(snapshot, path, len(original), len(original))
+
+	*value = ""
+	setAggregateBytes(snapshot, path, 0)
+	zeroFits, err := snapshotFits(snapshot)
+	if err != nil || !zeroFits {
+		return false, err
+	}
+
+	best := 0
+	low, high := 1, utf8.RuneCountInString(original)
+	for low <= high {
+		middle := low + (high-low)/2
+		length := byteIndexForRuneCount(original, middle)
+		*value = original[:length]
+		setAggregateBytes(snapshot, path, length)
+		fits, err := snapshotFits(snapshot)
+		if err != nil {
+			return false, err
+		}
+		if fits {
+			best = length
+			low = middle + 1
+		} else {
+			high = middle - 1
+		}
+	}
+	*value = original[:best]
+	setAggregateBytes(snapshot, path, best)
+	return true, nil
+}
+
+func byteIndexForRuneCount(value string, count int) int {
+	seen := 0
+	for index := range value {
+		if seen == count {
+			return index
+		}
+		seen++
+	}
+	return len(value)
+}
+
+func upsertAggregateBytes(snapshot *snapshotv1.Snapshot, path string, original, exported int) {
+	for i := range snapshot.Truncation {
+		item := &snapshot.Truncation[i]
+		if item.Path == path && item.OriginalBytes != nil {
+			item.Reason = snapshotv1.TruncationReasonAggregateBudget
+			item.ExportedBytes = intPointer(exported)
+			return
+		}
+	}
+	snapshot.Truncation = append(snapshot.Truncation, snapshotv1.Truncation{
+		Path: path, Reason: snapshotv1.TruncationReasonAggregateBudget,
+		OriginalBytes: intPointer(original), ExportedBytes: intPointer(exported),
+	})
+}
+
+func upsertAggregateItems(snapshot *snapshotv1.Snapshot, path string, original, exported int) {
+	for i := range snapshot.Truncation {
+		item := &snapshot.Truncation[i]
+		if item.Path == path && item.OriginalItems != nil {
+			item.Reason = snapshotv1.TruncationReasonAggregateBudget
+			item.ExportedItems = intPointer(exported)
+			return
+		}
+	}
+	snapshot.Truncation = append(snapshot.Truncation, snapshotv1.Truncation{
+		Path: path, Reason: snapshotv1.TruncationReasonAggregateBudget,
+		OriginalItems: intPointer(original), ExportedItems: intPointer(exported),
+	})
+}
+
+func setAggregateBytes(snapshot *snapshotv1.Snapshot, path string, exported int) {
+	for i := range snapshot.Truncation {
+		item := &snapshot.Truncation[i]
+		if item.Path == path && item.Reason == snapshotv1.TruncationReasonAggregateBudget && item.ExportedBytes != nil {
+			item.ExportedBytes = intPointer(exported)
+			return
+		}
+	}
+}
+
+func setAggregateItems(snapshot *snapshotv1.Snapshot, path string, exported int) {
+	for i := range snapshot.Truncation {
+		item := &snapshot.Truncation[i]
+		if item.Path == path && item.Reason == snapshotv1.TruncationReasonAggregateBudget && item.ExportedItems != nil {
+			item.ExportedItems = intPointer(exported)
+			return
+		}
+	}
+}
+
+type aggregateMetadata struct {
+	truncation []snapshotv1.Truncation
+	redactions []snapshotv1.Redaction
+}
+
+func captureMetadata(snapshot *snapshotv1.Snapshot) aggregateMetadata {
+	return aggregateMetadata{
+		truncation: cloneTruncation(snapshot.Truncation),
+		redactions: cloneRedactions(snapshot.Redactions),
+	}
+}
+
+func (metadata aggregateMetadata) restore(snapshot *snapshotv1.Snapshot) {
+	snapshot.Truncation = cloneTruncation(metadata.truncation)
+	snapshot.Redactions = cloneRedactions(metadata.redactions)
+}
+
+func cloneTruncation(values []snapshotv1.Truncation) []snapshotv1.Truncation {
+	result := make([]snapshotv1.Truncation, len(values))
+	for i, item := range values {
+		result[i] = item
+		result[i].OriginalBytes = copyIntPointer(item.OriginalBytes)
+		result[i].ExportedBytes = copyIntPointer(item.ExportedBytes)
+		result[i].OriginalItems = copyIntPointer(item.OriginalItems)
+		result[i].ExportedItems = copyIntPointer(item.ExportedItems)
+	}
+	return result
+}
+
+func cloneRedactions(values []snapshotv1.Redaction) []snapshotv1.Redaction {
+	result := make([]snapshotv1.Redaction, len(values))
+	copy(result, values)
+	return result
+}
+
+func removeMetadata(snapshot *snapshotv1.Snapshot, removedPath string) {
+	filterMetadata(snapshot, func(path string) (string, bool) {
+		return path, path != removedPath && !strings.HasPrefix(path, removedPath+"/")
+	})
+}
+
+func retainPrefixMetadata(snapshot *snapshotv1.Snapshot, collection string, retained int) {
+	filterMetadata(snapshot, func(path string) (string, bool) {
+		index, _, ok := indexedMetadataPath(path, collection)
+		if ok && index >= retained {
+			return "", false
+		}
+		return path, true
+	})
+}
+
+func retainSuffixMetadata(snapshot *snapshotv1.Snapshot, collection string, removed int) {
+	filterMetadata(snapshot, func(path string) (string, bool) {
+		index, remainder, ok := indexedMetadataPath(path, collection)
+		if !ok {
+			return path, true
+		}
+		if index < removed {
+			return "", false
+		}
+		return collection + "/" + strconv.Itoa(index-removed) + remainder, true
+	})
+}
+
+func indexedMetadataPath(path, collection string) (int, string, bool) {
+	prefix := collection + "/"
+	if !strings.HasPrefix(path, prefix) {
+		return 0, "", false
+	}
+	rest := strings.TrimPrefix(path, prefix)
+	segment, remainder, _ := strings.Cut(rest, "/")
+	index, err := strconv.Atoi(segment)
+	if err != nil || index < 0 {
+		return 0, "", false
+	}
+	if remainder != "" {
+		remainder = "/" + remainder
+	}
+	return index, remainder, true
+}
+
+func filterMetadata(snapshot *snapshotv1.Snapshot, transform func(string) (string, bool)) {
+	truncation := make([]snapshotv1.Truncation, 0, len(snapshot.Truncation))
+	for _, item := range snapshot.Truncation {
+		path, keep := transform(item.Path)
+		if keep {
+			item.Path = path
+			truncation = append(truncation, item)
+		}
+	}
+	snapshot.Truncation = truncation
+
+	redactions := make([]snapshotv1.Redaction, 0, len(snapshot.Redactions))
+	for _, item := range snapshot.Redactions {
+		path, keep := transform(item.Path)
+		if keep {
+			item.Path = path
+			redactions = append(redactions, item)
+		}
+	}
+	snapshot.Redactions = redactions
+}

--- a/collector/internal/sessionexport/aggregate_test.go
+++ b/collector/internal/sessionexport/aggregate_test.go
@@ -109,6 +109,95 @@ func TestMarshalFailsWhenMandatoryCoreCannotFit(t *testing.T) {
 	}
 }
 
+func TestMarshalReducesOptionalSessionMetadataBeforeMandatoryOverflow(t *testing.T) {
+	repository := "github.com/centauri-ai/coslash"
+	models := make(map[string]session.ModelTokens, 40)
+	for i := range 40 {
+		prefix := fmt.Sprintf("model-%02d-", i)
+		models[prefix+strings.Repeat("m", maxModelBytes-len(prefix))] = session.ModelTokens{InputTokens: 1}
+	}
+
+	local := aggregateLocal(repository)
+	for i := 0; i < maxSubagentItems; i++ {
+		local.Subagents = append(local.Subagents, session.Subagent{
+			ID: fmt.Sprintf("child-%03d", i), Name: "worker", Status: session.SubagentReturned,
+			Commands: []session.SubagentCommand{}, Tokens: models,
+		})
+		built, err := Build(local, BuildOptions{CollectorVersion: "0.1.0"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		size, err := snapshotv1.Size(built)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if size > snapshotv1.MaxPayloadBytes {
+			local.Subagents = local.Subagents[:len(local.Subagents)-1]
+			break
+		}
+	}
+	if len(local.Subagents) == 0 {
+		t.Fatal("could not construct a fitting mandatory core")
+	}
+
+	summary := strings.Repeat("s", maxSummaryBytes)
+	goal := strings.Repeat("g", maxGoalBytes)
+	prompt := strings.Repeat("p", maxPromptBytes)
+	local.Summary = &summary
+	local.DeclaredGoal = &goal
+	local.FirstPrompt = &prompt
+	built, err := Build(local, BuildOptions{CollectorVersion: "0.1.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := snapshotv1.Size(built)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before <= snapshotv1.MaxPayloadBytes {
+		t.Fatalf("optional metadata profile is only %d bytes; want over %d", before, snapshotv1.MaxPayloadBytes)
+	}
+
+	decoded := marshalAggregate(t, local)
+	if len(decoded.Session.Subagents) != len(local.Subagents) {
+		t.Fatal("mandatory subagent usage was reduced")
+	}
+	for _, item := range decoded.Truncation {
+		if item.Path == "/session" && item.Reason == snapshotv1.TruncationReasonAggregateBudget && item.OriginalItems != nil && *item.OriginalItems == 3 && item.ExportedItems != nil && *item.ExportedItems < 3 {
+			return
+		}
+	}
+	t.Fatalf("optional session metadata reduction was not recorded: %#v", decoded.Truncation)
+}
+
+func TestMarshalRetainsMostRecentlyTouchedFileDuringAggregateFitting(t *testing.T) {
+	repository := "github.com/centauri-ai/coslash"
+	edits := session.NewFileEditSet()
+	edits.Add("hot.go", 1, 0, false)
+	for i := 0; i < 300; i++ {
+		prefix := fmt.Sprintf("cold-%03d-", i)
+		edits.Add(prefix+strings.Repeat("p", maxPathBytes-len(prefix)), 1, 0, false)
+	}
+	edits.Add("hot.go", 1, 1, false)
+
+	local := aggregateLocal(repository)
+	local.WorkingDirectory = "/repo"
+	local.FileEdits = edits.Edits
+	decoded := marshalAggregateWithOptions(t, local, BuildOptions{CollectorVersion: "0.1.0", RepositoryRoot: "/repo"})
+	if len(decoded.Session.FileEdits) >= len(local.FileEdits) {
+		t.Fatal("test profile did not require file-edit fitting")
+	}
+	for _, edit := range decoded.Session.FileEdits {
+		if edit.Path == "hot.go" {
+			if edit.Edits != 2 || edit.Additions != 2 || edit.Deletions != 1 {
+				t.Fatalf("retained hot edit = %#v", edit)
+			}
+			return
+		}
+	}
+	t.Fatal("most recently touched file was removed as old evidence")
+}
+
 func TestMarshalAppliesAggregateReductionStages(t *testing.T) {
 	repository := "github.com/centauri-ai/coslash"
 

--- a/collector/internal/sessionexport/aggregate_test.go
+++ b/collector/internal/sessionexport/aggregate_test.go
@@ -1,0 +1,356 @@
+package sessionexport
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/centauri-ai/coslash/collector/internal/session"
+	snapshotv1 "github.com/centauri-ai/coslash/collector/snapshot/v1"
+)
+
+func TestMarshalDeterministicallyFitsHeavySession(t *testing.T) {
+	repository := "github.com/centauri-ai/coslash"
+	todoText := strings.Repeat("t", maxTodoTextBytes)
+	label := strings.Repeat("l", maxCommandLabelBytes+1)
+	task := strings.Repeat("q", maxSubagentTextBytes)
+	result := strings.Repeat("r", maxSubagentTextBytes)
+	commands := make([]session.SubagentCommand, maxCommandLabelItems)
+	for i := range commands {
+		commands[i] = session.SubagentCommand{Label: label, Command: fmt.Sprintf("raw-%d", i)}
+	}
+	todos := make([]session.Todo, 80)
+	for i := range todos {
+		todos[i] = session.Todo{Text: todoText}
+	}
+	local := session.Session{
+		Agent: "codex", ID: "heavy", Repository: &repository, StartedAt: 1,
+		Tokens: map[string]session.ModelTokens{},
+		Subagents: []session.Subagent{{
+			ID: "child", Name: "reviewer", Status: session.SubagentReturned,
+			Task: task, Result: result, Commands: commands, Tokens: map[string]session.ModelTokens{},
+		}},
+		SessionDetails: session.SessionDetails{Todos: todos},
+	}
+
+	built, err := Build(local, BuildOptions{CollectorVersion: "0.1.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := snapshotv1.Size(built)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fastSize, err := encodedSnapshotSize(built)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fastSize != before {
+		t.Fatalf("fast encoded size = %d; canonical size = %d", fastSize, before)
+	}
+	if before <= snapshotv1.MaxPayloadBytes {
+		t.Fatalf("test profile is only %d bytes; want over %d", before, snapshotv1.MaxPayloadBytes)
+	}
+
+	first, err := Marshal(local, BuildOptions{CollectorVersion: "0.1.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := Marshal(local, BuildOptions{CollectorVersion: "0.1.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatal("aggregate fitting is not deterministic")
+	}
+	if len(first) > snapshotv1.MaxPayloadBytes {
+		t.Fatalf("fitted snapshot is %d bytes", len(first))
+	}
+	decoded, err := snapshotv1.Decode(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(decoded.Session.Subagents[0].CommandLabels); got >= len(commands) {
+		t.Fatalf("command labels were not reduced: %d", got)
+	}
+	if decoded.Session.Subagents[0].Result != result || decoded.Session.Subagents[0].Task != task {
+		t.Fatal("later degradation stage ran before command labels were sufficient")
+	}
+	if len(decoded.Session.Todos) != len(todos) {
+		t.Fatal("todos changed before higher-priority degradation was exhausted")
+	}
+	if !hasAggregateTruncation(decoded.Truncation, "/session/subagents/0/commandLabels") {
+		t.Fatalf("aggregate reduction was not recorded: %#v", decoded.Truncation)
+	}
+}
+
+func TestMarshalFailsWhenMandatoryCoreCannotFit(t *testing.T) {
+	repository := "github.com/centauri-ai/coslash"
+	models := make(map[string]session.ModelTokens, snapshotv1.MaxUsageModels)
+	for i := 0; i < snapshotv1.MaxUsageModels; i++ {
+		models[fmt.Sprintf("model-%03d", i)] = session.ModelTokens{InputTokens: 1}
+	}
+	subagents := make([]session.Subagent, maxSubagentItems)
+	for i := range subagents {
+		subagents[i] = session.Subagent{
+			ID: fmt.Sprintf("child-%03d", i), Name: "worker", Status: session.SubagentReturned,
+			Commands: []session.SubagentCommand{}, Tokens: models,
+		}
+	}
+	local := session.Session{
+		Agent: "codex", ID: "irreducible", Repository: &repository, StartedAt: 1,
+		Tokens: map[string]session.ModelTokens{}, Subagents: subagents,
+	}
+	_, err := Marshal(local, BuildOptions{CollectorVersion: "0.1.0"})
+	if !errors.Is(err, snapshotv1.ErrOversized) {
+		t.Fatalf("mandatory overflow error = %v", err)
+	}
+}
+
+func TestMarshalAppliesAggregateReductionStages(t *testing.T) {
+	repository := "github.com/centauri-ai/coslash"
+
+	t.Run("subagent prose", func(t *testing.T) {
+		local := aggregateLocal(repository)
+		local.Todos = aggregateTodos(124)
+		local.Subagents = []session.Subagent{{
+			ID: "child", Name: "worker", Status: session.SubagentReturned,
+			Task: strings.Repeat("t", maxSubagentTextBytes), Result: strings.Repeat("r", maxSubagentTextBytes),
+			Tokens: map[string]session.ModelTokens{},
+		}}
+		decoded := marshalAggregate(t, local)
+		if decoded.Session.Subagents[0].Result != "" || decoded.Session.Subagents[0].Task == local.Subagents[0].Task || len(decoded.Session.Todos) != len(local.Todos) {
+			t.Fatal("subagent result and task were not reduced before todos")
+		}
+		assertFirstAggregatePath(t, decoded, "/session/subagents/0/result")
+	})
+
+	t.Run("digest answers", func(t *testing.T) {
+		local := aggregateLocal(repository)
+		local.Todos = aggregateTodos(115)
+		local.Digest = make([]session.DigestEntry, 10)
+		for i := range local.Digest {
+			local.Digest[i] = session.DigestEntry{Turn: i, Category: session.DigestUser, Description: "d", Answer: strings.Repeat("a", maxDigestTextBytes)}
+		}
+		decoded := marshalAggregate(t, local)
+		if decoded.Session.Digest[0].Answer != nil || len(decoded.Session.Digest) != len(local.Digest) || len(decoded.Session.Todos) != len(local.Todos) {
+			t.Fatal("digest answers were not reduced before digest entries or todos")
+		}
+		assertFirstAggregatePath(t, decoded, "/session/digest")
+	})
+
+	t.Run("older digest", func(t *testing.T) {
+		local := aggregateLocal(repository)
+		local.Digest = make([]session.DigestEntry, 80)
+		for i := range local.Digest {
+			local.Digest[i] = session.DigestEntry{Turn: i, Category: session.DigestUser, Description: strings.Repeat("d", maxDigestTextBytes)}
+		}
+		decoded := marshalAggregate(t, local)
+		if len(decoded.Session.Digest) >= len(local.Digest) || decoded.Session.Digest[0].Turn == 0 || decoded.Session.Digest[len(decoded.Session.Digest)-1].Turn != len(local.Digest)-1 {
+			t.Fatal("older digest entries were not removed while retaining the newest")
+		}
+		assertFirstAggregatePath(t, decoded, "/session/digest")
+	})
+
+	t.Run("todos", func(t *testing.T) {
+		local := aggregateLocal(repository)
+		local.Todos = aggregateTodos(maxTodoItems)
+		for i := range local.Todos {
+			local.Todos[i].Text += "x"
+		}
+		decoded := marshalAggregate(t, local)
+		if len(decoded.Session.Todos) >= len(local.Todos) {
+			t.Fatal("todos were not reduced")
+		}
+		assertFirstAggregatePath(t, decoded, "/session/todos")
+	})
+
+	t.Run("commits", func(t *testing.T) {
+		local := aggregateLocal(repository)
+		local.Commits = make([]string, maxCommitItems)
+		for i := range local.Commits {
+			prefix := fmt.Sprintf("%03d-", i)
+			local.Commits[i] = prefix + strings.Repeat("c", maxCommitTextBytes-len(prefix))
+		}
+		decoded := marshalAggregate(t, local)
+		if len(decoded.Session.Commits) >= len(local.Commits) || decoded.Session.Commits[0] == local.Commits[0] || decoded.Session.Commits[len(decoded.Session.Commits)-1] != local.Commits[len(local.Commits)-1] {
+			t.Fatal("commits were not reduced while retaining the newest")
+		}
+		assertFirstAggregatePath(t, decoded, "/session/commits")
+	})
+
+	t.Run("file edits", func(t *testing.T) {
+		local := aggregateLocal(repository)
+		local.FileEdits = make([]session.FileEdit, 300)
+		for i := range local.FileEdits {
+			prefix := fmt.Sprintf("%03d-", i)
+			local.FileEdits[i] = session.FileEdit{Path: prefix + strings.Repeat("p", maxPathBytes-len(prefix))}
+		}
+		local.WorkingDirectory = "/repo"
+		decoded := marshalAggregateWithOptions(t, local, BuildOptions{CollectorVersion: "0.1.0", RepositoryRoot: "/repo"})
+		if len(decoded.Session.FileEdits) >= len(local.FileEdits) || decoded.Session.FileEdits[0].Path == local.FileEdits[0].Path || decoded.Session.FileEdits[len(decoded.Session.FileEdits)-1].Path != local.FileEdits[len(local.FileEdits)-1].Path {
+			t.Fatal("file edits were not reduced while retaining the newest")
+		}
+		assertFirstAggregatePath(t, decoded, "/session/fileEdits")
+	})
+}
+
+func TestMarshalRemovesMetadataForRemovedAggregateEvidence(t *testing.T) {
+	repository := "github.com/centauri-ai/coslash"
+	local := aggregateLocal(repository)
+	local.Todos = aggregateTodos(115)
+	local.Digest = make([]session.DigestEntry, 10)
+	for i := range local.Digest {
+		local.Digest[i] = session.DigestEntry{
+			Turn: i, Category: session.DigestUser, Description: "d",
+			Answer: strings.Repeat("a", maxDigestTextBytes+1) + ` {"password":"digest-secret"}`,
+		}
+	}
+
+	decoded := marshalAggregate(t, local)
+	if decoded.Session.Digest[0].Answer != nil {
+		t.Fatal("digest answers were not removed")
+	}
+	for i, digest := range decoded.Session.Digest {
+		if digest.Answer != nil {
+			continue
+		}
+		removedAnswer := fmt.Sprintf("/session/digest/%d/answer", i)
+		for _, item := range decoded.Truncation {
+			if item.Path == removedAnswer || strings.HasPrefix(item.Path, removedAnswer+"/") {
+				t.Fatalf("removed answer retained truncation pointer %q", item.Path)
+			}
+		}
+		for _, item := range decoded.Redactions {
+			if item.Path == removedAnswer || strings.HasPrefix(item.Path, removedAnswer+"/") {
+				t.Fatalf("removed answer retained redaction pointer %q", item.Path)
+			}
+		}
+	}
+}
+
+func TestMarshalMergesCollectionBudgetsAndDropsRemovedItemMetadata(t *testing.T) {
+	repository := "github.com/centauri-ai/coslash"
+	local := aggregateLocal(repository)
+	local.Todos = aggregateTodos(maxTodoItems + 5)
+	for i := range local.Todos {
+		local.Todos[i].Text += "x"
+	}
+
+	decoded := marshalAggregate(t, local)
+	collectionRecords := 0
+	retainedItemRecords := 0
+	for _, item := range decoded.Truncation {
+		switch {
+		case item.Path == "/session/todos":
+			collectionRecords++
+			if item.Reason != snapshotv1.TruncationReasonAggregateBudget || item.OriginalItems == nil || *item.OriginalItems != len(local.Todos) || item.ExportedItems == nil || *item.ExportedItems != len(decoded.Session.Todos) {
+				t.Fatalf("merged todo budget = %#v", item)
+			}
+		case strings.HasPrefix(item.Path, "/session/todos/"):
+			retainedItemRecords++
+		}
+	}
+	if collectionRecords != 1 {
+		t.Fatalf("todo collection budget records = %d; want 1", collectionRecords)
+	}
+	if retainedItemRecords != len(decoded.Session.Todos) {
+		t.Fatalf("retained todo metadata = %d; want %d", retainedItemRecords, len(decoded.Session.Todos))
+	}
+}
+
+func TestByteIndexForRuneCount(t *testing.T) {
+	value := "a界🙂z"
+	for count, want := range []string{"", "a", "a界", "a界🙂", value} {
+		if got := value[:byteIndexForRuneCount(value, count)]; got != want {
+			t.Fatalf("first %d runes = %q; want %q", count, got, want)
+		}
+	}
+}
+
+func TestMarshalReindexesMetadataWhenOlderDigestIsRemoved(t *testing.T) {
+	repository := "github.com/centauri-ai/coslash"
+	local := aggregateLocal(repository)
+	local.Digest = make([]session.DigestEntry, 80)
+	for i := range local.Digest {
+		local.Digest[i] = session.DigestEntry{
+			Turn: i, Category: session.DigestUser,
+			Description: strings.Repeat("d", maxDigestTextBytes+1),
+		}
+	}
+
+	decoded := marshalAggregate(t, local)
+	if len(decoded.Session.Digest) == 0 || decoded.Session.Digest[0].Turn == 0 {
+		t.Fatal("older digest evidence was not removed")
+	}
+	if !hasMetadataPathPrefix(decoded.Truncation, "/session/digest/0/") {
+		t.Fatalf("retained digest metadata was not reindexed: %#v", decoded.Truncation)
+	}
+}
+
+func hasMetadataPathPrefix(values []snapshotv1.Truncation, prefix string) bool {
+	for _, value := range values {
+		if strings.HasPrefix(value.Path, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func aggregateLocal(repository string) session.Session {
+	return session.Session{
+		Agent: "codex", ID: "aggregate", Repository: &repository, StartedAt: 1,
+		Tokens: map[string]session.ModelTokens{},
+	}
+}
+
+func aggregateTodos(count int) []session.Todo {
+	values := make([]session.Todo, count)
+	for i := range values {
+		values[i].Text = strings.Repeat("t", maxTodoTextBytes)
+	}
+	return values
+}
+
+func marshalAggregate(t *testing.T, local session.Session) snapshotv1.Snapshot {
+	t.Helper()
+	return marshalAggregateWithOptions(t, local, BuildOptions{CollectorVersion: "0.1.0"})
+}
+
+func marshalAggregateWithOptions(t *testing.T, local session.Session, options BuildOptions) snapshotv1.Snapshot {
+	t.Helper()
+	data, err := Marshal(local, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := snapshotv1.Decode(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertMetadataPointersResolve(t, data, decoded)
+	return decoded
+}
+
+func assertFirstAggregatePath(t *testing.T, snapshot snapshotv1.Snapshot, path string) {
+	t.Helper()
+	for _, item := range snapshot.Truncation {
+		if item.Reason == snapshotv1.TruncationReasonAggregateBudget {
+			if item.Path != path {
+				t.Fatalf("first aggregate path = %q; want %q", item.Path, path)
+			}
+			return
+		}
+	}
+	t.Fatalf("aggregate truncation %q not recorded", path)
+}
+
+func hasAggregateTruncation(values []snapshotv1.Truncation, path string) bool {
+	for _, value := range values {
+		if value.Path == path && value.Reason == snapshotv1.TruncationReasonAggregateBudget {
+			return true
+		}
+	}
+	return false
+}

--- a/collector/internal/sessionexport/snapshot.go
+++ b/collector/internal/sessionexport/snapshot.go
@@ -406,19 +406,16 @@ func (b *builder) fileEdits(values []session.FileEdit) []snapshotv1.FileEdit {
 		edit session.FileEdit
 		path string
 	}
-	candidates := make([]candidate, 0, min(len(values), maxFileEditItems))
-	validItems := 0
+	candidates := make([]candidate, 0, len(values))
 	for _, value := range values {
 		relative := b.normalizeFileEditPath(value.Path)
 		if relative == nil {
 			continue
 		}
-		validItems++
-		if len(candidates) < maxFileEditItems {
-			candidates = append(candidates, candidate{edit: value, path: *relative})
-		}
+		candidates = append(candidates, candidate{edit: value, path: *relative})
 	}
-	b.items("/session/fileEdits", validItems, maxFileEditItems)
+	retained := b.items("/session/fileEdits", len(candidates), maxFileEditItems)
+	candidates = candidates[len(candidates)-retained:]
 	result := make([]snapshotv1.FileEdit, 0, len(candidates))
 	for _, value := range candidates {
 		path := fmt.Sprintf("/session/fileEdits/%d/path", len(result))

--- a/collector/internal/sessionexport/snapshot.go
+++ b/collector/internal/sessionexport/snapshot.go
@@ -54,6 +54,10 @@ func Marshal(local session.Session, options BuildOptions) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	snapshot, err = fitAggregate(snapshot)
+	if err != nil {
+		return nil, err
+	}
 	return snapshotv1.Marshal(snapshot)
 }
 

--- a/collector/internal/sessionexport/snapshot_test.go
+++ b/collector/internal/sessionexport/snapshot_test.go
@@ -244,7 +244,7 @@ func TestBuildAppliesFileEditBudgetAfterPathRedaction(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := snapshot.Session.FileEdits; len(got) != maxFileEditItems || got[0].Path != "safe/0000.go" || got[len(got)-1].Path != "safe/1999.go" {
+	if got := snapshot.Session.FileEdits; len(got) != maxFileEditItems || got[0].Path != "safe/0001.go" || got[len(got)-1].Path != "safe/2000.go" {
 		t.Fatalf("file edits = first/last/count %#v %#v %d", got[0], got[len(got)-1], len(got))
 	}
 	if len(snapshot.Redactions) != 1 || snapshot.Redactions[0].Path != "/session/fileEdits" || snapshot.Redactions[0].Reason != "outside_repository" {


### PR DESCRIPTION
## Summary

Fit oversized snapshots to the 256 KiB contract ceiling by deterministically reducing optional evidence while preserving the mandatory core.

## Why this is separate

Aggregate fitting is an algorithmic layer with its own ordering and metadata invariants. Reviewers can validate those rules without re-reading the schema or privacy mapper.

## Changes

- reduce command labels, subagent prose, digest answers, older digest entries, todos, older commits, and older edits in a fixed order;
- retain newest digest, commit, and edit evidence;
- merge per-field and aggregate budget records instead of emitting contradictory duplicates;
- delete or reindex metadata pointers whenever evidence is removed;
- use exact-length single-marshal probes during binary search, with authoritative validation and hashing once at the end;
- preserve UTF-8 boundaries without allocating a rune-index table;
- fail clearly only when the mandatory snapshot core cannot fit.

## Review guide

Start with the reducer order in `fitAggregate`, then inspect the shared prefix/newest reducers and metadata filtering. The tests exercise every degradation stage and pointer invariant.

## Verification

- `go test ./...`
- `go vet ./...`

## Stack

This is PR 4 of 5 for ENG-1340. Its base is PR 3.

| Order | PR | Scope |
| ---: | --- | --- |
| 1 | [#83](https://github.com/centauri-ai/coslash/pull/83) | Canonical session start |
| 2 | [#84](https://github.com/centauri-ai/coslash/pull/84) | Public v1 contract |
| 3 | [#85](https://github.com/centauri-ai/coslash/pull/85) | Private-to-wire export boundary |
| 4 | [#86](https://github.com/centauri-ai/coslash/pull/86) | Aggregate payload fitting |
| 5 | [#87](https://github.com/centauri-ai/coslash/pull/87) | Fixtures, measurement, and docs |

## Rollout

Fitting is deterministic and only runs when a built snapshot exceeds the public limit. The original monolithic branch remains available as a rollback reference.
