### PR TITLE
Display timestamps alongside turn numbers in the session timeline

### DIFF
--- a/collector/internal/session/accumulators.go
+++ b/collector/internal/session/accumulators.go
@@ -16,8 +16,9 @@ type DigestLog struct {
 }
 
 // Push appends an entry attributed to turn (at least 1). A recap keeps its
-// full text; everything else is truncated for display.
-func (log *DigestLog) Push(turn int, category, description string) {
+// full text; everything else is truncated for display. time is the epoch
+// milliseconds when the event occurred (0 if unknown).
+func (log *DigestLog) Push(turn int, category, description string, time int64) {
 	text := Truncate(description, TruncateTextLimit)
 	if category == DigestRecap {
 		text = strings.TrimSpace(description)
@@ -26,19 +27,21 @@ func (log *DigestLog) Push(turn int, category, description string) {
 		Turn:        max(turn, 1),
 		Category:    category,
 		Description: text,
+		Time:        time,
 	})
 }
 
-func (log *DigestLog) PushQuestion(turn int, description, answer string) {
-	log.Push(turn, DigestQuestion, description)
+func (log *DigestLog) PushQuestion(turn int, description, answer string, time int64) {
+	log.Push(turn, DigestQuestion, description, time)
 	log.entries[len(log.entries)-1].Answer = Truncate(answer, TruncateTextLimit)
 }
 
-func (log *DigestLog) PushSubagent(turn int, spawnKey string) {
+func (log *DigestLog) PushSubagent(turn int, spawnKey string, time int64) {
 	log.entries = append(log.entries, DigestEntry{
 		Turn:     max(turn, 1),
 		Category: DigestSubagent,
 		SpawnKey: spawnKey,
+		Time:     time,
 	})
 }
 

--- a/collector/internal/session/session.go
+++ b/collector/internal/session/session.go
@@ -75,6 +75,7 @@ type DigestEntry struct {
 	Description string `json:"description"`
 	Answer      string `json:"answer,omitempty"`
 	SubagentID  string `json:"subagentId,omitempty"`
+	Time        int64  `json:"time,omitempty"`
 	SpawnKey    string `json:"-"`
 }
 

--- a/collector/internal/vendors/claude/parse.go
+++ b/collector/internal/vendors/claude/parse.go
@@ -121,7 +121,7 @@ func analyzeClaudeSession(file string) (*claudeSessionAnalysis, error) {
 	}
 	pendingAssistantText := ""
 	pendingCommand := ""
-	emitPrompt := func(text string) {
+	emitPrompt := func(text string, timestamp int64) {
 		analysis.inTurn = true
 		pendingAssistantText = ""
 		analysis.userPromptCount++
@@ -132,7 +132,7 @@ func analyzeClaudeSession(file string) (*claudeSessionAnalysis, error) {
 		if analysis.userPromptCount == 1 {
 			category = session.DigestFirstPrompt
 		}
-		analysis.digest.Push(analysis.userPromptCount, category, text)
+		analysis.digest.Push(analysis.userPromptCount, category, text, timestamp)
 	}
 	for _, row := range rows {
 		if row.SessionID != "" {
@@ -153,12 +153,14 @@ func analyzeClaudeSession(file string) (*claudeSessionAnalysis, error) {
 			analysis.inTurn = false
 			pendingAssistantText = ""
 		}
+		var rowTimestamp int64
 		if row.Timestamp != "" {
-			timestamp, err := session.RFC3339ToUnixEpoch(row.Timestamp)
+			ts, err := session.RFC3339ToUnixEpoch(row.Timestamp)
 			if err != nil {
 				log.Printf("%s: skipping unparseable timestamp %q: %v", file, row.Timestamp, err)
 			} else {
-				analysis.timestamps.Note(timestamp)
+				rowTimestamp = ts
+				analysis.timestamps.Note(ts)
 			}
 		}
 		if row.Type == "custom-title" && row.CustomTitle != "" {
@@ -181,6 +183,7 @@ func analyzeClaudeSession(file string) (*claudeSessionAnalysis, error) {
 			analysis.digest.Push(analysis.userPromptCount,
 				session.DigestCompaction,
 				fmt.Sprintf("context compacted (%d)", analysis.compactBoundaries),
+				rowTimestamp,
 			)
 		}
 		if row.IsCompactSummary && row.Message != nil {
@@ -200,7 +203,7 @@ func analyzeClaudeSession(file string) (*claudeSessionAnalysis, error) {
 				pendingCommand = row.commandInvocation()
 			case row.IsMeta:
 				if pendingCommand != "" {
-					emitPrompt(pendingCommand)
+					emitPrompt(pendingCommand, rowTimestamp)
 					pendingCommand = ""
 				}
 			default:
@@ -211,7 +214,7 @@ func analyzeClaudeSession(file string) (*claudeSessionAnalysis, error) {
 					analysis.inTurn = false
 					pendingAssistantText = ""
 				case text != "":
-					emitPrompt(text)
+					emitPrompt(text, rowTimestamp)
 				}
 			}
 		}
@@ -236,7 +239,7 @@ func analyzeClaudeSession(file string) (*claudeSessionAnalysis, error) {
 							Turn: &turn,
 						}
 						if isSubagentTool(block.Name) {
-							analysis.digest.PushSubagent(analysis.userPromptCount, block.ID)
+							analysis.digest.PushSubagent(analysis.userPromptCount, block.ID, rowTimestamp)
 						}
 					}
 				}
@@ -255,6 +258,7 @@ func analyzeClaudeSession(file string) (*claudeSessionAnalysis, error) {
 						analysis.userPromptCount,
 						session.DigestRecap,
 						pendingAssistantText,
+						rowTimestamp,
 					)
 					pendingAssistantText = ""
 				}
@@ -268,7 +272,7 @@ func analyzeClaudeSession(file string) (*claudeSessionAnalysis, error) {
 						} else if block.Input.Status != "" {
 							task.status = block.Input.Status
 							if block.Input.Status == "completed" {
-								analysis.digest.Push(analysis.userPromptCount, session.DigestTodos, "completed — "+task.subject)
+								analysis.digest.Push(analysis.userPromptCount, session.DigestTodos, "completed — "+task.subject, rowTimestamp)
 							}
 						}
 					}
@@ -296,7 +300,7 @@ func analyzeClaudeSession(file string) (*claudeSessionAnalysis, error) {
 					analysis.inTurn = false
 					reply := strings.TrimSpace(row.Message.textContent())
 					if analysis.userPromptCount > 0 && reply != "" {
-						analysis.digest.Push(analysis.userPromptCount, session.DigestRecap, reply)
+						analysis.digest.Push(analysis.userPromptCount, session.DigestRecap, reply, rowTimestamp)
 					}
 					pendingAssistantText = ""
 				}
@@ -351,7 +355,7 @@ func analyzeClaudeSession(file string) (*claudeSessionAnalysis, error) {
 				if spawn, ok := analysis.spawns[resultToolUseID]; ok {
 					analysis.spawns[result.RunID] = vendors.SpawnState{Turn: spawn.Turn}
 				}
-				analysis.digest.PushSubagent(analysis.userPromptCount, result.RunID)
+				analysis.digest.PushSubagent(analysis.userPromptCount, result.RunID, rowTimestamp)
 			}
 			if result != nil && result.Answers != nil {
 				for _, question := range result.Questions {
@@ -359,6 +363,7 @@ func analyzeClaudeSession(file string) (*claudeSessionAnalysis, error) {
 						analysis.userPromptCount,
 						question.Question,
 						result.Answers[question.Question].String(),
+						rowTimestamp,
 					)
 				}
 			}

--- a/collector/internal/vendors/codex/parse.go
+++ b/collector/internal/vendors/codex/parse.go
@@ -47,7 +47,7 @@ type codexSessionAnalysis struct {
 }
 
 // Review mode's own generated instruction is not a user turn
-func (analysis *codexSessionAnalysis) notePrompt(prompt string) {
+func (analysis *codexSessionAnalysis) notePrompt(prompt string, timestamp *int64) {
 	analysis.prompts++
 	if analysis.firstUserPrompt == "" {
 		analysis.firstUserPrompt = prompt
@@ -56,7 +56,11 @@ func (analysis *codexSessionAnalysis) notePrompt(prompt string) {
 	if analysis.prompts == 1 {
 		category = session.DigestFirstPrompt
 	}
-	analysis.digest.Push(analysis.prompts, category, prompt)
+	ts := int64(0)
+	if timestamp != nil {
+		ts = *timestamp
+	}
+	analysis.digest.Push(analysis.prompts, category, prompt, ts)
 }
 
 func (analysis *codexSessionAnalysis) noteFileChanges(changes codexPatchChanges) {
@@ -76,7 +80,7 @@ func (analysis *codexSessionAnalysis) noteFileChanges(changes codexPatchChanges)
 	}
 }
 
-func (analysis *codexSessionAnalysis) noteSubagentStarted(id string) {
+func (analysis *codexSessionAnalysis) noteSubagentStarted(id string, timestamp *int64) {
 	if id == "" {
 		return
 	}
@@ -85,7 +89,11 @@ func (analysis *codexSessionAnalysis) noteSubagentStarted(id string) {
 	}
 	turn := max(analysis.prompts, 1)
 	analysis.spawns[id] = vendors.SpawnState{Turn: &turn}
-	analysis.digest.PushSubagent(analysis.prompts, id)
+	ts := int64(0)
+	if timestamp != nil {
+		ts = *timestamp
+	}
+	analysis.digest.PushSubagent(analysis.prompts, id, ts)
 }
 
 func completedItemText(item codexItem) string {
@@ -209,7 +217,7 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 				case "UserMessage":
 					message := completedItemText(item)
 					if !analysis.inReview && message != "" && !session.IsHarnessWrapped(message) {
-						analysis.notePrompt(message)
+						analysis.notePrompt(message, timestamp)
 					}
 				case "AgentMessage":
 					if item.Phase == "final_answer" || item.Phase == "" {
@@ -219,7 +227,7 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 					analysis.noteFileChanges(item.Changes)
 				case "SubAgentActivity":
 					if item.Kind == "started" {
-						analysis.noteSubagentStarted(item.AgentThreadID)
+						analysis.noteSubagentStarted(item.AgentThreadID, timestamp)
 					}
 				}
 			case "user_message":
@@ -231,7 +239,7 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 					if prompt == "" {
 						prompt = row.Payload.Message
 					}
-					analysis.notePrompt(prompt)
+					analysis.notePrompt(prompt, timestamp)
 				}
 			case "entered_review_mode":
 				analysis.inReview = true
@@ -239,12 +247,12 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 				if row.Payload.UserFacingHint != "" {
 					review += " · " + row.Payload.UserFacingHint
 				}
-				analysis.notePrompt(review)
+				analysis.notePrompt(review, timestamp)
 			case "exited_review_mode":
 				analysis.inReview = false
 			case "sub_agent_activity":
 				if row.Payload.Kind == "started" {
-					analysis.noteSubagentStarted(row.Payload.AgentThreadID)
+					analysis.noteSubagentStarted(row.Payload.AgentThreadID, timestamp)
 				}
 			case "agent_message":
 				if row.Payload.Phase == "final_answer" || row.Payload.Phase == "" {
@@ -260,9 +268,14 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 				}
 			case "context_compacted":
 				analysis.compactions++
+				ts := int64(0)
+				if timestamp != nil {
+					ts = *timestamp
+				}
 				analysis.digest.Push(analysis.prompts,
 					session.DigestCompaction,
 					fmt.Sprintf("context compacted (%d)", analysis.compactions),
+					ts,
 				)
 			case "task_started":
 				if analysis.turnDepth == 0 {
@@ -274,10 +287,15 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 			case "task_complete", "turn_aborted":
 				if row.Payload.Type == "task_complete" && analysis.turnDepth <= 1 &&
 					analysis.prompts > 0 && analysis.turnFinalReply != "" {
+					ts := int64(0)
+					if timestamp != nil {
+						ts = *timestamp
+					}
 					analysis.digest.Push(
 						analysis.prompts,
 						session.DigestRecap,
 						analysis.turnFinalReply,
+						ts,
 					)
 				}
 				analysis.turnFinalReply = ""
@@ -312,17 +330,25 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 				if questions := questionsFrom(row.Payload); len(questions) > 0 {
 					for _, question := range questions {
 						answer := strings.Join(questionAnswers[row.Payload.CallID][question.id].values(), ", ")
-						analysis.digest.PushQuestion(analysis.prompts, question.text, answer)
+						ts := int64(0)
+						if timestamp != nil {
+							ts = *timestamp
+						}
+						analysis.digest.PushQuestion(analysis.prompts, question.text, answer, ts)
 					}
 				}
-				analysis.notePlan(row.Payload)
+				analysis.notePlan(row.Payload, timestamp)
 			case "function_call_output":
 				if id := spawnedAgentID(row.Payload.Output); id != "" {
 					turn := max(analysis.prompts, 1)
 					analysis.spawns[id] = vendors.SpawnState{Turn: &turn}
-					analysis.digest.PushSubagent(analysis.prompts, id)
+					ts := int64(0)
+					if timestamp != nil {
+						ts = *timestamp
+					}
+					analysis.digest.PushSubagent(analysis.prompts, id, ts)
 				}
-				analysis.notePlan(row.Payload)
+				analysis.notePlan(row.Payload, timestamp)
 			}
 		}
 	}
@@ -547,7 +573,7 @@ var planStepPattern = regexp.MustCompile(
 	`"?step"?\s*:\s*("(?:[^"\\]|\\.)*")\s*,\s*"?status"?\s*:\s*"(\w+)"`,
 )
 
-func (analysis *codexSessionAnalysis) notePlan(payload codexPayload) {
+func (analysis *codexSessionAnalysis) notePlan(payload codexPayload, timestamp *int64) {
 	text := payloadText(payload)
 	if payload.Name != "update_plan" && !strings.Contains(text, "update_plan") {
 		return
@@ -569,7 +595,11 @@ func (analysis *codexSessionAnalysis) notePlan(payload codexPayload) {
 		status := m[2]
 		steps = append(steps, planStep{step: text, status: status})
 		if status == "completed" && before[text] != "completed" {
-			analysis.digest.Push(analysis.prompts, session.DigestTodos, "completed — "+text)
+			ts := int64(0)
+			if timestamp != nil {
+				ts = *timestamp
+			}
+			analysis.digest.Push(analysis.prompts, session.DigestTodos, "completed — "+text, ts)
 		}
 	}
 	analysis.plan = steps

--- a/collector/internal/vendors/opencode/parse.go
+++ b/collector/internal/vendors/opencode/parse.go
@@ -75,7 +75,7 @@ func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 			for _, part := range message.parts {
 				if part.Type == "compaction" {
 					compactions++
-					digest.Push(turns, session.DigestCompaction, "Context compacted")
+					digest.Push(turns, session.DigestCompaction, "Context compacted", message.Time.Created)
 				}
 			}
 			prompt := userText(message.parts)
@@ -90,7 +90,7 @@ func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 			if turns == 1 {
 				category = session.DigestFirstPrompt
 			}
-			digest.Push(turns, category, prompt)
+			digest.Push(turns, category, prompt, message.Time.Created)
 			continue
 		}
 		if message.Role != "assistant" {
@@ -172,7 +172,7 @@ func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 						if !exists {
 							turn := max(turns, 1)
 							spawns[childID] = vendors.SpawnState{Turn: &turn}
-							digest.PushSubagent(turns, childID)
+							digest.PushSubagent(turns, childID, message.Time.Created)
 						}
 						if part.State.Input.Description != "" {
 							link.name = part.State.Input.Description
@@ -213,7 +213,7 @@ func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 						for _, todo := range part.State.Input.Todos {
 							if todo.Status == "completed" &&
 								todoStatus[todo.Content] != "completed" {
-								digest.Push(turns, session.DigestTodos, "completed: "+todo.Content)
+								digest.Push(turns, session.DigestTodos, "completed: "+todo.Content, message.Time.Created)
 							}
 							todoStatus[todo.Content] = todo.Status
 						}
@@ -224,7 +224,7 @@ func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 							if index < len(part.State.Metadata.Answers) {
 								answer = strings.Join(part.State.Metadata.Answers[index], ", ")
 							}
-							digest.PushQuestion(turns, question.Question, answer)
+							digest.PushQuestion(turns, question.Question, answer, message.Time.Created)
 						}
 					}
 				}
@@ -237,7 +237,7 @@ func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 		if text := strings.Join(texts, "\n"); message.Finish == "stop" && !internalSummary &&
 			text != "" {
 			summary = text
-			digest.Push(turns, session.DigestRecap, text)
+			digest.Push(turns, session.DigestRecap, text, message.Time.Created)
 		}
 	}
 	for _, task := range tasks {

--- a/frontend/src/pages/coslash/components/SessionInspector.tsx
+++ b/frontend/src/pages/coslash/components/SessionInspector.tsx
@@ -30,7 +30,7 @@ import { UnpricedModelWarning } from '@/pages/coslash/components/UnpricedModelWa
 import { useLaunchTerminal } from '@/pages/coslash/hooks/use-launch-terminal';
 import { useFileDiff, type FileSelection } from '@/pages/coslash/hooks/use-sessions';
 import { ApiAuthenticationError, apiFetch } from '@/pages/coslash/lib/api';
-import { formatDuration, formatEstimatedCost, formatTimeAgo, formatTokens } from '@/pages/coslash/lib/format';
+import { digestDateKey, formatDigestDateDivider, formatDigestDateRange, formatDigestTime, formatDuration, formatEstimatedCost, formatTimeAgo, formatTokens } from '@/pages/coslash/lib/format';
 import { handoffBrief } from '@/pages/coslash/lib/handoff';
 import {
   getModality,
@@ -497,13 +497,13 @@ function CategoryChip({
   );
 }
 
-function DigestRow({ entry }: { entry: DigestEntry }) {
+function DigestRow({ entry, endsDay }: { entry: DigestEntry; endsDay?: boolean }) {
   const [expanded, setExpanded] = useState(false);
   const meta = DIGEST_CATEGORIES[entry.category];
   const collapsible = entry.category === 'recap' && entry.description.length > 120;
 
   return (
-    <div className="border-border flex items-baseline gap-2 border-b py-1">
+    <div className={cn('border-border flex items-baseline gap-2 py-1', { 'border-b': !endsDay })}>
       <span className={cn('w-24 shrink-0 text-xs font-bold tracking-wide', meta.fg)}>{meta.label}</span>
       <div className="min-w-0 flex-1">
         <div className={cn('text-xs', { 'line-clamp-1': collapsible && !expanded })}>{entry.description}</div>
@@ -520,8 +520,11 @@ function DigestRow({ entry }: { entry: DigestEntry }) {
           </div>
         )}
       </div>
-      <span className="text-muted-foreground shrink-0 font-mono text-xs whitespace-nowrap">
-        turn {entry.turn}
+      <span className="text-muted-foreground shrink-0 font-mono text-xs whitespace-nowrap flex flex-col items-end">
+        <span>turn {entry.turn}</span>
+        {entry.time != null && entry.time > 0 && (
+          <span className="text-muted-foreground">{formatDigestTime(entry.time)}</span>
+        )}
       </span>
     </div>
   );
@@ -559,6 +562,16 @@ function SubagentDigestRow({ subagentId, detail }: { subagentId: string; detail:
   );
 }
 
+function DateDivider({ label }: { label: string }) {
+  return (
+    <div className="text-muted-foreground grid grid-cols-[1fr_auto_1fr] items-center gap-2 pt-2 text-xs font-bold tracking-wide">
+      <span className="bg-border h-px" />
+      <span>{label}</span>
+      <span className="bg-border h-px" />
+    </div>
+  );
+}
+
 function DigestSection({ detail }: { detail: SessionDetail }) {
   const [hiddenCategories, setHiddenCategories] = useState<Set<DigestCategory>>(
     () => new Set(DEFAULT_HIDDEN_CATEGORIES),
@@ -579,6 +592,39 @@ function DigestSection({ detail }: { detail: SessionDetail }) {
   };
 
   const visible = digest.filter((entry) => !hiddenCategories.has(entry.category));
+  const times = digest.map((e) => e.time ?? 0).filter((t) => t > 0);
+  const dateRange = formatDigestDateRange(times);
+
+  const endsDayIndices = new Set<number>();
+  let lastDate = '';
+  for (let i = 0; i < visible.length; i++) {
+    const entryDate = visible[i].time != null && visible[i].time! > 0 ? digestDateKey(visible[i].time!) : '';
+    if (i > 0 && entryDate !== '' && lastDate !== '' && entryDate !== lastDate) {
+      endsDayIndices.add(i - 1);
+    }
+    if (entryDate !== '') {
+      lastDate = entryDate;
+    }
+  }
+
+  let previousDate = '';
+  const rows = visible.map((entry, index) => {
+    const entryDate = entry.time != null && entry.time > 0 ? digestDateKey(entry.time) : '';
+    const showDivider = entryDate !== '' && entryDate !== previousDate;
+    if (entryDate !== '') {
+      previousDate = entryDate;
+    }
+    return (
+      <div key={index}>
+        {showDivider && <DateDivider label={formatDigestDateDivider(entry.time!)} />}
+        {entry.category === 'subagent' ? (
+          <SubagentDigestRow subagentId={entry.subagentId!} detail={detail} />
+        ) : (
+          <DigestRow entry={entry} endsDay={endsDayIndices.has(index) || index === visible.length - 1} />
+        )}
+      </div>
+    );
+  });
 
   return (
     <div>
@@ -587,7 +633,7 @@ function DigestSection({ detail }: { detail: SessionDetail }) {
           <span className="text-muted-foreground text-xs font-semibold tracking-wide">TIMELINE</span>
           <span className="text-muted-foreground text-xs">key events from this session</span>
         </div>
-        <span className="text-muted-foreground text-xs">Click a category to show or hide it.</span>
+        <span className="text-muted-foreground text-xs">{dateRange}</span>
       </div>
       <div className="flex flex-wrap gap-1 pb-2">
         {(Object.keys(DIGEST_CATEGORIES) as DigestCategory[])
@@ -602,15 +648,7 @@ function DigestSection({ detail }: { detail: SessionDetail }) {
             />
           ))}
       </div>
-      <div className="flex flex-col gap-1">
-        {visible.map((entry, index) =>
-          entry.category === 'subagent' ? (
-            <SubagentDigestRow key={index} subagentId={entry.subagentId!} detail={detail} />
-          ) : (
-            <DigestRow key={index} entry={entry} />
-          ),
-        )}
-      </div>
+      <div className="flex flex-col gap-1">{rows}</div>
     </div>
   );
 }

--- a/frontend/src/pages/coslash/components/SessionInspector.tsx
+++ b/frontend/src/pages/coslash/components/SessionInspector.tsx
@@ -30,7 +30,16 @@ import { UnpricedModelWarning } from '@/pages/coslash/components/UnpricedModelWa
 import { useLaunchTerminal } from '@/pages/coslash/hooks/use-launch-terminal';
 import { useFileDiff, type FileSelection } from '@/pages/coslash/hooks/use-sessions';
 import { ApiAuthenticationError, apiFetch } from '@/pages/coslash/lib/api';
-import { digestDateKey, formatDigestDateDivider, formatDigestDateRange, formatDigestTime, formatDuration, formatEstimatedCost, formatTimeAgo, formatTokens } from '@/pages/coslash/lib/format';
+import {
+  digestDateKey,
+  formatDigestDateDivider,
+  formatDigestDateRange,
+  formatDigestTime,
+  formatDuration,
+  formatEstimatedCost,
+  formatTimeAgo,
+  formatTokens,
+} from '@/pages/coslash/lib/format';
 import { handoffBrief } from '@/pages/coslash/lib/handoff';
 import {
   getModality,
@@ -520,7 +529,7 @@ function DigestRow({ entry, endsDay }: { entry: DigestEntry; endsDay?: boolean }
           </div>
         )}
       </div>
-      <span className="text-muted-foreground shrink-0 font-mono text-xs whitespace-nowrap flex flex-col items-end">
+      <span className="text-muted-foreground flex shrink-0 flex-col items-end font-mono text-xs whitespace-nowrap">
         <span>turn {entry.turn}</span>
         {entry.time != null && entry.time > 0 && (
           <span className="text-muted-foreground">{formatDigestTime(entry.time)}</span>

--- a/frontend/src/pages/coslash/lib/format.ts
+++ b/frontend/src/pages/coslash/lib/format.ts
@@ -32,3 +32,47 @@ export function formatTimeAgo(mtime: number): string {
     day: 'numeric',
   });
 }
+
+export function formatDigestTime(time: number): string {
+  return new Date(time).toLocaleTimeString(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+export function digestDateKey(time: number): string {
+  const d = new Date(time);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+export function formatDigestDateDivider(time: number): string {
+  return new Date(time)
+    .toLocaleDateString(undefined, {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+    })
+    .toUpperCase();
+}
+
+export function formatDigestDateRange(times: number[]): string | null {
+  const filtered = times.filter((t) => t > 0);
+  if (filtered.length === 0) return null;
+
+  const earliest = new Date(Math.min(...filtered));
+  const latest = new Date(Math.max(...filtered));
+
+  const fmt = (d: Date) =>
+    d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+
+  if (earliest.toDateString() === latest.toDateString()) {
+    return `${fmt(earliest)}, ${earliest.getFullYear()} · local time`;
+  }
+
+  const year = earliest.getFullYear();
+  if (earliest.getMonth() === latest.getMonth()) {
+    return `${fmt(earliest)}–${latest.getDate()}, ${year} · local time`;
+  }
+
+  return `${fmt(earliest)} – ${fmt(latest)}, ${year} · local time`;
+}

--- a/frontend/src/pages/coslash/lib/format.ts
+++ b/frontend/src/pages/coslash/lib/format.ts
@@ -61,18 +61,17 @@ export function formatDigestDateRange(times: number[]): string | null {
 
   const earliest = new Date(Math.min(...filtered));
   const latest = new Date(Math.max(...filtered));
-
-  const fmt = (d: Date) =>
-    d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  const fmt = (d: Date, withYear: boolean) =>
+    d.toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      ...(withYear ? { year: 'numeric' } : {}),
+    });
 
   if (earliest.toDateString() === latest.toDateString()) {
-    return `${fmt(earliest)}, ${earliest.getFullYear()} · local time`;
+    return `${fmt(earliest, true)} · local time`;
   }
 
-  const year = earliest.getFullYear();
-  if (earliest.getMonth() === latest.getMonth()) {
-    return `${fmt(earliest)}–${latest.getDate()}, ${year} · local time`;
-  }
-
-  return `${fmt(earliest)} – ${fmt(latest)}, ${year} · local time`;
+  const sameYear = earliest.getFullYear() === latest.getFullYear();
+  return `${fmt(earliest, !sameYear)} – ${fmt(latest, true)} · local time`;
 }

--- a/frontend/src/pages/coslash/lib/session.ts
+++ b/frontend/src/pages/coslash/lib/session.ts
@@ -87,6 +87,7 @@ export type DigestEntry = {
   description: string;
   answer?: string;
   subagentId?: string;
+  time?: number;
 };
 
 export type SessionDetail = Session;


### PR DESCRIPTION
## Context

The session inspector's timeline shows key events (first prompt, questions, recaps, subagents, todos) with just the turn number. Users want to know when each event happened — especially for sessions that cross midnight.

## Changes

- Each digest row stacks the turn number above the timestamp (e.g., "turn 1" / "11:32 PM")
- Full-width date dividers separate entries by day when a session spans multiple dates
- The row preceding a date divider drops its bottom border so the divider takes its place
- The timeline heading shows the session's date range (e.g., "Aug 17 – Aug 18, 2026 · local time")

## Test

- `go build ./...` — passed
- `npx tsc --noEmit` — passed

### Screenshot
<img width="718" height="555" alt="Screenshot 2026-08-17 at 2 49 06 PM" src="https://github.com/user-attachments/assets/026caa19-01af-4dc8-ac52-c559431fb9b9" />
<img width="721" height="653" alt="Screenshot 2026-08-17 at 2 48 43 PM" src="https://github.com/user-attachments/assets/8bcfdafa-2652-4784-8ad2-2a039211eadc" />
