### PR TITLE
Expand model pricing and context coverage

### DIFF
--- a/collector/Makefile
+++ b/collector/Makefile
@@ -9,6 +9,7 @@ ARGS :=
 LDFLAGS := -X main.version=$(VERSION)
 MODELS := internal/session/models.json
 LITELLM_URL := https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json
+OPENCODE_MODELS_URL := https://models.opencode.ai/api.json
 
 .PHONY: build run test check tidy clean release stage unstage smoke smoke-dev dist models
 
@@ -82,13 +83,20 @@ tidy:
 # Rewrites the embedded model table from LiteLLM. The Models workflow runs this
 # daily and opens a pull request; run it by hand for a model LiteLLM just added.
 models:
-	curl -sfL $(LITELLM_URL) | jq -S -f scripts/models.jq > $(MODELS).new
-	@test -s $(MODELS).new || { echo "error: the download produced no model table"; rm -f $(MODELS).new; exit 1; }
-	@jq -e 'length > 50' $(MODELS).new > /dev/null || { \
-		echo "error: $$(jq length $(MODELS).new) models is too few; the upstream format changed"; \
-		rm -f $(MODELS).new; exit 1; }
-	mv $(MODELS).new $(MODELS)
-	@echo "wrote $(MODELS) ($$(jq length $(MODELS)) models)"
+	@set -eu; \
+		trap 'rm -f $(MODELS).new $(MODELS).opencode' EXIT; \
+		curl -sfL $(OPENCODE_MODELS_URL) -o $(MODELS).opencode; \
+		curl -sfL $(LITELLM_URL) | jq -S --slurpfile opencode $(MODELS).opencode -f scripts/models.jq > $(MODELS).new; \
+		test -s $(MODELS).new || { echo "error: the downloads produced no model table"; exit 1; }; \
+		jq -e 'length > 50' $(MODELS).new > /dev/null || { \
+			echo "error: $$(jq length $(MODELS).new) models is too few; an upstream format changed"; exit 1; }; \
+		jq -e --slurpfile opencode $(MODELS).opencode \
+			'. as $$table | all($$opencode[0].opencode.models | keys[]; . as $$id | (($$table | has($$id)) or ($$table | has("opencode/" + $$id))))' \
+			$(MODELS).new > /dev/null || { echo "error: the OpenCode model merge is incomplete"; exit 1; }; \
+		mv $(MODELS).new $(MODELS); \
+		rm -f $(MODELS).opencode; \
+		trap - EXIT; \
+		echo "wrote $(MODELS) ($$(jq length $(MODELS)) models)"
 
 clean: unstage
 	rm -rf bin $(DIST)

--- a/collector/scripts/models.jq
+++ b/collector/scripts/models.jq
@@ -1,7 +1,9 @@
 # Prunes LiteLLM's model_prices_and_context_window.json to priced chat models,
-# keeping only the fields coslash reads. Field names stay exactly as LiteLLM
-# publishes them so a refresh diff is auditable against upstream. Run through
+# then adds OpenCode models missing from that table. OpenCode costs are dollars
+# per million tokens; LiteLLM costs are already dollars per token. Run through
 # `make models`.
+def per_token: if . == null then null else . / 1000000 end;
+
 with_entries(
   select(
     (.value.mode == "chat" or .value.mode == "responses")
@@ -19,3 +21,22 @@ with_entries(
       | with_entries(select(.value != null))
     )
 )
+| . as $litellm
+| reduce ($opencode[0].opencode.models | to_entries[]) as $model (
+    .;
+    if ($litellm | has($model.key)) then
+      .
+    else
+      .["opencode/\($model.key)"] = (
+        $model.value
+        | {
+            input_cost_per_token: (.cost.input | per_token),
+            output_cost_per_token: (.cost.output | per_token),
+            cache_creation_input_token_cost: (.cost.cache_write | per_token),
+            cache_read_input_token_cost: (.cost.cache_read | per_token),
+            max_input_tokens: .limit.context,
+          }
+        | with_entries(select(.value != null))
+      )
+    end
+  )

--- a/collector/scripts/models.jq
+++ b/collector/scripts/models.jq
@@ -1,11 +1,10 @@
-# Prunes LiteLLM's model_prices_and_context_window.json to the Anthropic and
-# OpenAI chat models coslash can see, keeping only the fields it reads. Field
-# names stay exactly as LiteLLM publishes them so a refresh diff is auditable
-# against upstream. Run through `make models`.
+# Prunes LiteLLM's model_prices_and_context_window.json to priced chat models,
+# keeping only the fields coslash reads. Field names stay exactly as LiteLLM
+# publishes them so a refresh diff is auditable against upstream. Run through
+# `make models`.
 with_entries(
   select(
-    (.value.litellm_provider == "anthropic" or .value.litellm_provider == "openai")
-    and (.value.mode == "chat" or .value.mode == "responses")
+    (.value.mode == "chat" or .value.mode == "responses")
     and .value.input_cost_per_token != null
   )
   | .value |= (


### PR DESCRIPTION
## Context

Coslash uses an embedded model table for context windows and estimated prices. The table excluded most LiteLLM providers and OpenCode-only models.

## Changes

- Include priced chat models from every LiteLLM provider.
- Add namespaced OpenCode models when LiteLLM has no matching unqualified model ID.
- Preserve LiteLLM precedence and exclude embedding, image, and audio models.
- Convert OpenCode prices to the per-token format used by the embedded table.

## Test

- `make -C collector models` — passed with 2,325 models
- `cd collector && go build ./...` — passed
- `cd collector && go test ./cmd/coslash ./internal/httpsec ./internal/web` — passed with 31 tests
- Manual: `deepseek-v4-pro` uses LiteLLM metadata.
- Manual: `opencode/deepseek-v4-flash-free` uses OpenCode metadata.