### PR TITLE
Add session sorting by status

### DIFF
--- a/frontend/src/pages/coslash/components/SessionBoard.tsx
+++ b/frontend/src/pages/coslash/components/SessionBoard.tsx
@@ -3,7 +3,14 @@ import { cn } from '@/lib/utils';
 import { SessionCard } from '@/pages/coslash/components/SessionCard';
 import { UnpricedModelWarning } from '@/pages/coslash/components/UnpricedModelWarning';
 import { formatEstimatedCost, formatTokens } from '@/pages/coslash/lib/format';
-import { getStatus, getTotalTokens, STATUSES, type Session, type Status } from '@/pages/coslash/lib/session';
+import {
+  getStatus,
+  getTotalTokens,
+  STATUS_ORDER,
+  STATUSES,
+  type Session,
+  type Status,
+} from '@/pages/coslash/lib/session';
 
 // Preserves insertion order, so sorted input yields groups ordered by their top session.
 function groupBy(sessions: Session[], keyOf: (session: Session) => string): [string, Session[]][] {
@@ -111,9 +118,9 @@ export function SessionBoard({
   sessions: Session[];
   onSelectSession: (session: Session) => void;
 }) {
-  const visibleStatuses = Object.entries(STATUSES).filter(([status]) =>
+  const visibleStatuses = STATUS_ORDER.filter((status) =>
     sessions.some((session) => getStatus(session.status) === status),
-  );
+  ).map((status): [string, Status] => [status, STATUSES[status]]);
 
   return (
     <div

--- a/frontend/src/pages/coslash/components/SessionSortDropdownMenu.test.ts
+++ b/frontend/src/pages/coslash/components/SessionSortDropdownMenu.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { SortKey, sortSessions } from '@/pages/coslash/components/SessionSortDropdownMenu';
+import type { Session } from '@/pages/coslash/lib/session';
+
+function session(id: string, status: string | null): Session {
+  return { id, status } as Session;
+}
+
+describe('sortSessions', () => {
+  it('sorts descending status by current activity', () => {
+    const sessions = [
+      session('inactive', null),
+      session('waiting', 'waiting'),
+      session('active', 'busy'),
+      session('idle', 'idle'),
+    ];
+
+    expect(sortSessions(sessions, SortKey.Status, 'desc').map(({ id }) => id)).toEqual([
+      'active',
+      'idle',
+      'waiting',
+      'inactive',
+    ]);
+  });
+});

--- a/frontend/src/pages/coslash/components/SessionSortDropdownMenu.test.ts
+++ b/frontend/src/pages/coslash/components/SessionSortDropdownMenu.test.ts
@@ -17,8 +17,8 @@ describe('sortSessions', () => {
 
     expect(sortSessions(sessions, SortKey.Status, 'desc').map(({ id }) => id)).toEqual([
       'active',
-      'idle',
       'waiting',
+      'idle',
       'inactive',
     ]);
   });

--- a/frontend/src/pages/coslash/components/SessionSortDropdownMenu.tsx
+++ b/frontend/src/pages/coslash/components/SessionSortDropdownMenu.tsx
@@ -9,10 +9,11 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { assertOneOf } from '@/pages/coslash/lib/narrow';
-import { getTotalTokens, type Session } from '@/pages/coslash/lib/session';
+import { getStatus, getTotalTokens, type Session, type StatusKey } from '@/pages/coslash/lib/session';
 
 export const SortKey = {
   Recency: 'recency',
+  Status: 'status',
   Value: 'value',
   Tokens: 'tokens',
   Duration: 'duration',
@@ -23,15 +24,25 @@ export type SortDir = 'asc' | 'desc';
 
 const SORT_LABELS: Record<SortKey, string> = {
   [SortKey.Recency]: 'Recency',
+  [SortKey.Status]: 'Status',
   [SortKey.Value]: 'Est. cost',
   [SortKey.Tokens]: 'Tokens',
   [SortKey.Duration]: 'Duration',
+};
+
+const STATUS_PRIORITY: Record<StatusKey, number> = {
+  busy: 3,
+  idle: 2,
+  waiting: 1,
+  inactive: 0,
 };
 
 function sortValue(session: Session, key: SortKey): number {
   switch (key) {
     case SortKey.Recency:
       return session.mtime;
+    case SortKey.Status:
+      return STATUS_PRIORITY[getStatus(session.status)];
     case SortKey.Value:
       return session.cost;
     case SortKey.Tokens:

--- a/frontend/src/pages/coslash/components/SessionSortDropdownMenu.tsx
+++ b/frontend/src/pages/coslash/components/SessionSortDropdownMenu.tsx
@@ -9,7 +9,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { assertOneOf } from '@/pages/coslash/lib/narrow';
-import { getStatus, getTotalTokens, type Session, type StatusKey } from '@/pages/coslash/lib/session';
+import { getStatus, getTotalTokens, STATUS_ORDER, type Session } from '@/pages/coslash/lib/session';
 
 export const SortKey = {
   Recency: 'recency',
@@ -30,19 +30,12 @@ const SORT_LABELS: Record<SortKey, string> = {
   [SortKey.Duration]: 'Duration',
 };
 
-const STATUS_PRIORITY: Record<StatusKey, number> = {
-  busy: 3,
-  idle: 2,
-  waiting: 1,
-  inactive: 0,
-};
-
 function sortValue(session: Session, key: SortKey): number {
   switch (key) {
     case SortKey.Recency:
       return session.mtime;
     case SortKey.Status:
-      return STATUS_PRIORITY[getStatus(session.status)];
+      return STATUS_ORDER.length - STATUS_ORDER.indexOf(getStatus(session.status));
     case SortKey.Value:
       return session.cost;
     case SortKey.Tokens:

--- a/frontend/src/pages/coslash/lib/session.ts
+++ b/frontend/src/pages/coslash/lib/session.ts
@@ -182,6 +182,8 @@ export const STATUSES = {
 
 export type StatusKey = keyof typeof STATUSES;
 
+export const STATUS_ORDER: readonly StatusKey[] = ['busy', 'waiting', 'idle', 'inactive'];
+
 export type SubagentStatus = { label: string; fg: string; bg: string };
 
 export const SUBAGENT_STATUSES = {


### PR DESCRIPTION
## Context

Session lists can be sorted by recency, estimated cost, token usage, and duration, but not by current activity. A shared status priority makes active and attention-needed work easier to find while keeping list sorting and board columns consistent.

## Changes

- Add Status to the session sort menu, ordered Active → Waiting → Idle → Inactive when descending
- Apply the same status order to board columns
- Preserve the direction control so ascending reverses the list order
- Treat sessions without a live status as inactive

## Test

- `npm test` — passed (11 tests)
- `npm run build` — passed
- Manual: Not run

### Screenshots

- [ ] Session sort menu — Status selected with mixed session states ordered descending
- [ ] Board view — status columns ordered Active, Waiting, Idle, Inactive