### PR TITLE
Hide undetected vendors from filters and synthesis settings

### DIFF
--- a/frontend/src/pages/coslash/CoslashPage.tsx
+++ b/frontend/src/pages/coslash/CoslashPage.tsx
@@ -37,7 +37,7 @@ import type { Diagnostics } from '@/pages/coslash/lib/diagnostics';
 import { formatEstimatedCost } from '@/pages/coslash/lib/format';
 import { sessionsEmptyStateCopy } from '@/pages/coslash/lib/page-copy';
 import { sessionMatchesSearchTerm } from '@/pages/coslash/lib/search';
-import { getStatus, type Session } from '@/pages/coslash/lib/session';
+import { getSessionVendors, getStatus, type Session } from '@/pages/coslash/lib/session';
 import { shouldPromptForSynthesisConsent } from '@/pages/coslash/lib/settings';
 import { timeWindowStart, type TimeWindow } from '@/pages/coslash/lib/time-window';
 
@@ -298,10 +298,14 @@ export function CoslashPage() {
       })),
     [sessions],
   );
+  const sessionVendors = getSessionVendors(sessions);
 
   useEffect(() => {
     if (settingsState.response) setTheme(settingsState.response.settings.appearance.theme);
   }, [settingsState.response]);
+  useEffect(() => {
+    if (vendor !== 'all' && !sessions.some((session) => session.agent === vendor)) setVendor('all');
+  }, [sessions, vendor]);
   // Held by id, not by value: the inspector must render the freshest record
   // each refresh, and a stored object would freeze at click time. Looked up
   // from the unfiltered list so filters never close an open inspector.
@@ -355,7 +359,7 @@ export function CoslashPage() {
         <div className="-m-1 flex items-center gap-2 overflow-x-auto p-1">
           <SessionSearch searchTerm={searchTerm} onSearchTermChange={setSearchTerm} />
           <div className="flex shrink-0 items-center gap-2">
-            <AgentVendorFilterTabMenu value={vendor} onValueChange={setVendor} />
+            <AgentVendorFilterTabMenu value={vendor} vendors={sessionVendors} onValueChange={setVendor} />
             <span className="bg-border h-5 w-px" />
             <TimeWindowFilterTabMenu value={timeWindow} onValueChange={setTimeWindow} />
             <span className="bg-border h-5 w-px" />

--- a/frontend/src/pages/coslash/CoslashTabMenus.tsx
+++ b/frontend/src/pages/coslash/CoslashTabMenus.tsx
@@ -1,19 +1,21 @@
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { assertOneOf } from '@/pages/coslash/lib/narrow';
-import { type VendorKey } from '@/pages/coslash/lib/session';
+import { getVendor, VENDOR_KEYS, type VendorKey } from '@/pages/coslash/lib/session';
 import { TIME_WINDOW_VALUES, TIME_WINDOWS, type TimeWindow } from '@/pages/coslash/lib/time-window';
 
 export type AgentVendor = 'all' | VendorKey;
 export type ViewMode = 'list' | 'board';
 
-const AGENT_VENDORS = ['all', 'claude', 'codex', 'opencode'] as const satisfies readonly AgentVendor[];
+const AGENT_VENDORS = ['all', ...VENDOR_KEYS] as const satisfies readonly AgentVendor[];
 const VIEW_MODES = ['list', 'board'] as const satisfies readonly ViewMode[];
 
 export function AgentVendorFilterTabMenu({
   value,
+  vendors,
   onValueChange,
 }: {
   value: AgentVendor;
+  vendors: readonly VendorKey[];
   onValueChange: (value: AgentVendor) => void;
 }) {
   return (
@@ -22,15 +24,11 @@ export function AgentVendorFilterTabMenu({
         <TabsTrigger value="all" className="text-xs font-semibold">
           <span>All vendors</span>
         </TabsTrigger>
-        <TabsTrigger value="claude" className="text-xs font-semibold">
-          <span>Claude Code</span>
-        </TabsTrigger>
-        <TabsTrigger value="codex" className="text-xs font-semibold">
-          <span>Codex</span>
-        </TabsTrigger>
-        <TabsTrigger value="opencode" className="text-xs font-semibold">
-          <span>OpenCode</span>
-        </TabsTrigger>
+        {vendors.map((vendor) => (
+          <TabsTrigger key={vendor} value={vendor} className="text-xs font-semibold">
+            <span>{getVendor(vendor).label}</span>
+          </TabsTrigger>
+        ))}
       </TabsList>
     </Tabs>
   );

--- a/frontend/src/pages/coslash/components/SettingsDialog.tsx
+++ b/frontend/src/pages/coslash/components/SettingsDialog.tsx
@@ -5,6 +5,7 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } f
 import { setTheme } from '@/lib/theme';
 import { cn } from '@/lib/utils';
 import {
+  availableSynthesisBackends,
   initialSettingsDraft,
   modelForBackend,
   requiresFirstRunConsent,
@@ -204,9 +205,8 @@ export function SettingsDialog({
   const initialDraft = response ? initialSettingsDraft(response) : null;
   // Both sides are spreads of the same response.settings, so key order matches.
   const isDirty = JSON.stringify(draft) !== JSON.stringify(initialDraft);
-  const selectedBackend = response?.options.synthesisBackends.find(
-    (option) => option.id === draft?.synthesis.backend,
-  );
+  const synthesisBackends = availableSynthesisBackends(response?.options.synthesisBackends ?? []);
+  const selectedBackend = synthesisBackends.find((option) => option.id === draft?.synthesis.backend);
   const selectedModel = selectedBackend?.models.find((option) => option.id === draft?.synthesis.model);
   const selectedTerminal = response?.options.terminals.find((option) => option.id === draft?.launch.terminal);
   const synthesisBackendAvailable = draft?.synthesis.enabled !== true || selectedBackend?.available === true;
@@ -297,7 +297,7 @@ export function SettingsDialog({
                           </div>
                         </div>
                         <div className="grid gap-2.5 sm:grid-cols-2">
-                          {response.options.synthesisBackends.map((option) => (
+                          {synthesisBackends.map((option) => (
                             <BackendChoice
                               key={option.id}
                               option={option}

--- a/frontend/src/pages/coslash/components/SettingsDialog.tsx
+++ b/frontend/src/pages/coslash/components/SettingsDialog.tsx
@@ -206,6 +206,7 @@ export function SettingsDialog({
   // Both sides are spreads of the same response.settings, so key order matches.
   const isDirty = JSON.stringify(draft) !== JSON.stringify(initialDraft);
   const synthesisBackends = availableSynthesisBackends(response?.options.synthesisBackends ?? []);
+  const hasSynthesisBackends = synthesisBackends.length > 0;
   const selectedBackend = synthesisBackends.find((option) => option.id === draft?.synthesis.backend);
   const selectedModel = selectedBackend?.models.find((option) => option.id === draft?.synthesis.model);
   const selectedTerminal = response?.options.terminals.find((option) => option.id === draft?.launch.terminal);
@@ -314,10 +315,20 @@ export function SettingsDialog({
                               }
                             />
                           ))}
+                          {!hasSynthesisBackends && (
+                            <div className="text-muted-foreground py-2 text-xs sm:col-span-2">
+                              No supported CLI detected
+                            </div>
+                          )}
                         </div>
                       </div>
 
-                      <div className="border-border flex flex-col gap-3 border-t pt-3 sm:flex-row sm:items-center sm:justify-between">
+                      <div
+                        className={cn(
+                          'border-border flex flex-col gap-3 border-t pt-3 sm:flex-row sm:items-center sm:justify-between',
+                          { hidden: !hasSynthesisBackends },
+                        )}
+                      >
                         <div className="flex min-w-0 flex-col gap-1">
                           <div className="text-[13px] font-semibold">Model</div>
                           <div className="text-muted-foreground text-[11px]">

--- a/frontend/src/pages/coslash/lib/session.test.ts
+++ b/frontend/src/pages/coslash/lib/session.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { getSessionVendors, type Session } from '@/pages/coslash/lib/session';
+
+describe('getSessionVendors', () => {
+  it('returns only vendors represented by loaded sessions in display order', () => {
+    const sessions = [
+      { agent: 'opencode' },
+      { agent: 'claude' },
+      { agent: 'claude' },
+      { agent: 'unknown' },
+    ] satisfies Pick<Session, 'agent'>[];
+
+    expect(getSessionVendors(sessions)).toEqual(['claude', 'opencode']);
+  });
+});

--- a/frontend/src/pages/coslash/lib/session.ts
+++ b/frontend/src/pages/coslash/lib/session.ts
@@ -154,6 +154,12 @@ const VENDORS = {
 
 export type VendorKey = keyof typeof VENDORS;
 
+export const VENDOR_KEYS = ['claude', 'codex', 'opencode'] as const satisfies readonly VendorKey[];
+
+export function getSessionVendors(sessions: readonly Pick<Session, 'agent'>[]): VendorKey[] {
+  return VENDOR_KEYS.filter((vendor) => sessions.some((session) => session.agent === vendor));
+}
+
 export const STATUSES = {
   busy: {
     label: 'Active',

--- a/frontend/src/pages/coslash/lib/settings.test.ts
+++ b/frontend/src/pages/coslash/lib/settings.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { availableSynthesisBackends, type BackendOption } from '@/pages/coslash/lib/settings';
+
+function backend(id: string, available: boolean): BackendOption {
+  return { id, label: id, models: [], available };
+}
+
+describe('availableSynthesisBackends', () => {
+  it('excludes undetected backends', () => {
+    const options = [backend('claude-cli', true), backend('codex_exec', false)];
+
+    expect(availableSynthesisBackends(options).map(({ id }) => id)).toEqual(['claude-cli']);
+  });
+});

--- a/frontend/src/pages/coslash/lib/settings.ts
+++ b/frontend/src/pages/coslash/lib/settings.ts
@@ -44,6 +44,10 @@ export type SettingsResponse = {
   };
 };
 
+export function availableSynthesisBackends(options: readonly BackendOption[]): BackendOption[] {
+  return options.filter((option) => option.available);
+}
+
 export function modelForBackend(response: SettingsResponse, backend: string): string {
   const option = response.options.synthesisBackends.find((candidate) => candidate.id === backend);
   return option?.models.find((model) => model.default)?.id ?? option?.models[0]?.id ?? '';
@@ -53,7 +57,7 @@ export function initialSettingsDraft(response: SettingsResponse): CoslashSetting
   const synthesis = { ...response.settings.synthesis };
 
   if (!response.persisted) {
-    const availableBackend = response.options.synthesisBackends.find((option) => option.available);
+    const availableBackend = availableSynthesisBackends(response.options.synthesisBackends)[0];
     synthesis.enabled = availableBackend != null;
     if (availableBackend) {
       synthesis.backend = availableBackend.id;


### PR DESCRIPTION
## Context

The filter bar currently lists every supported vendor even when the loaded session set has no matching sessions. Synthesis settings similarly show backends whose CLI is unavailable. Limit both controls to relevant, usable choices.

## Changes

- Show vendor filter tabs only for vendors represented in loaded sessions, resetting a stale selection to All vendors
- Hide unavailable synthesis backends and their model choices

## Test

- `cd frontend && npm test` — passed
- `cd frontend && npm run build` — passed
- `cd frontend && npm run lint` — passed with two existing Fast Refresh warnings
- Manual UI verification not run; a clean-machine state was not available locally

### Screenshots

- [ ] Vendor filter — only vendors with loaded sessions are shown
- [ ] Synthesis settings — unavailable CLI backends are omitted