### PR TITLE
Clear stale OpenCode waiting status on newer turns

### DIFF
--- a/collector/internal/vendors/opencode/parse.go
+++ b/collector/internal/vendors/opencode/parse.go
@@ -82,6 +82,7 @@ func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 			if prompt == "" {
 				continue
 			}
+			waiting = false
 			turns++
 			if firstPrompt == "" {
 				firstPrompt = prompt


### PR DESCRIPTION
## Context

OpenCode can retain an abandoned question tool as running after a session continues. Scanning that historical state caused completed resumed sessions to remain shown as waiting.

## Changes

- Clear question-derived waiting state when a newer non-synthetic user prompt begins.
- Keep unanswered questions in the current turn waiting and leave busy status handling unchanged.

## Test

- `go test $(git ls-files 'internal/vendors/opencode/*.go')` — passed

### Screenshots
- [ ] Session board — resumed session with a historical question no longer shown as Waiting