### PR TITLE
feat: add exact snapshot preview

### DIFF
--- a/collector/cmd/coslash/api.go
+++ b/collector/cmd/coslash/api.go
@@ -14,6 +14,8 @@ import (
 	"github.com/centauri-ai/coslash/collector/internal/collector"
 	"github.com/centauri-ai/coslash/collector/internal/launch"
 	"github.com/centauri-ai/coslash/collector/internal/session"
+	"github.com/centauri-ai/coslash/collector/internal/sessionexport"
+	"github.com/centauri-ai/coslash/collector/internal/sessionpreview"
 	"github.com/centauri-ai/coslash/collector/internal/settings"
 	"github.com/centauri-ai/coslash/collector/internal/synthesis"
 )
@@ -82,6 +84,42 @@ func handleDiff(
 	writeJSON(w, struct {
 		Changes []session.FileChange `json:"changes"`
 	}{Changes: selected.Changes()})
+}
+
+func handleSharePreview(
+	w http.ResponseWriter,
+	r *http.Request,
+	getSession func(string, int64) (*session.Session, error),
+	collectorVersion string,
+) {
+	revision, err := parseRevision(r.URL.Query().Get("revision"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	found, err := getSession(r.URL.Query().Get("id"), revision)
+	if err != nil {
+		log.Printf("share preview: %v", err)
+		http.Error(w, "could not load share preview", http.StatusInternalServerError)
+		return
+	}
+	if found == nil {
+		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+	preview := sessionpreview.Build(*found, sessionexport.BuildOptions{
+		CollectorVersion: collectorVersion,
+		RepositoryRoot:   session.RepositoryRoot(found.WorkingDirectory),
+	}, revision)
+	writeJSON(w, preview)
+}
+
+func parseRevision(value string) (int64, error) {
+	revision, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || revision <= 0 {
+		return 0, fmt.Errorf("invalid 'revision' parameter")
+	}
+	return revision, nil
 }
 
 // /api/synthesis?id=X → cached synthesis for one session, triggering a run

--- a/collector/cmd/coslash/main.go
+++ b/collector/cmd/coslash/main.go
@@ -153,6 +153,9 @@ func routes(mgr *synthesis.Manager, settingsStore *settings.Store) *http.ServeMu
 	api.HandleFunc("GET /api/diff", func(w http.ResponseWriter, r *http.Request) {
 		handleDiff(w, r, collector.GetSessionFacts)
 	})
+	api.HandleFunc("GET /api/share-preview", func(w http.ResponseWriter, r *http.Request) {
+		handleSharePreview(w, r, collector.GetSessionForPreview, version)
+	})
 	api.HandleFunc("GET /api/settings", func(w http.ResponseWriter, _ *http.Request) {
 		writeSettings(w, settingsStore.State())
 	})

--- a/collector/internal/collector/collector.go
+++ b/collector/internal/collector/collector.go
@@ -45,6 +45,11 @@ var vendorSources = []vendorSource{
 	},
 }
 
+var previewSessionCache = struct {
+	sync.RWMutex
+	byID map[string]session.Session
+}{byID: map[string]session.Session{}}
+
 type SourceHealth = vendors.SourceHealth
 
 func Sources() []SourceHealth {
@@ -83,7 +88,46 @@ func List(since int64) ([]*session.Session, error) {
 	for _, root := range roots {
 		sessions = append(sessions, root.Session)
 	}
+	cachePreviewSessions(sessions)
 	return sessions, nil
+}
+
+// GetSessionForPreview returns the selected fully composed revision.
+func GetSessionForPreview(id string, expectedRevision int64) (*session.Session, error) {
+	if id == "" {
+		return nil, nil
+	}
+	current, err := GetSessionFacts(id)
+	if err != nil || current == nil {
+		return current, err
+	}
+	if current.LastActivityTime != expectedRevision {
+		return current, nil
+	}
+	previewSessionCache.RLock()
+	cached, ok := previewSessionCache.byID[id]
+	previewSessionCache.RUnlock()
+	if ok && cached.LastActivityTime == current.LastActivityTime {
+		return &cached, nil
+	}
+	sessions, err := List(0)
+	if err != nil {
+		return nil, err
+	}
+	for _, candidate := range sessions {
+		if candidate.ID == id {
+			return candidate, nil
+		}
+	}
+	return nil, nil
+}
+
+func cachePreviewSessions(sessions []*session.Session) {
+	previewSessionCache.Lock()
+	defer previewSessionCache.Unlock()
+	for _, value := range sessions {
+		previewSessionCache.byID[value.ID] = *value
+	}
 }
 
 func applyActivityFallbacks(parsed []*vendors.ParsedSession) {

--- a/collector/internal/collector/collector.go
+++ b/collector/internal/collector/collector.go
@@ -45,11 +45,6 @@ var vendorSources = []vendorSource{
 	},
 }
 
-var previewSessionCache = struct {
-	sync.RWMutex
-	byID map[string]session.Session
-}{byID: map[string]session.Session{}}
-
 type SourceHealth = vendors.SourceHealth
 
 func Sources() []SourceHealth {
@@ -88,7 +83,6 @@ func List(since int64) ([]*session.Session, error) {
 	for _, root := range roots {
 		sessions = append(sessions, root.Session)
 	}
-	cachePreviewSessions(sessions)
 	return sessions, nil
 }
 
@@ -104,13 +98,7 @@ func GetSessionForPreview(id string, expectedRevision int64) (*session.Session, 
 	if current.LastActivityTime != expectedRevision {
 		return current, nil
 	}
-	previewSessionCache.RLock()
-	cached, ok := previewSessionCache.byID[id]
-	previewSessionCache.RUnlock()
-	if ok && cached.LastActivityTime == current.LastActivityTime {
-		return &cached, nil
-	}
-	sessions, err := List(0)
+	sessions, err := List(expectedRevision)
 	if err != nil {
 		return nil, err
 	}
@@ -120,14 +108,6 @@ func GetSessionForPreview(id string, expectedRevision int64) (*session.Session, 
 		}
 	}
 	return nil, nil
-}
-
-func cachePreviewSessions(sessions []*session.Session) {
-	previewSessionCache.Lock()
-	defer previewSessionCache.Unlock()
-	for _, value := range sessions {
-		previewSessionCache.byID[value.ID] = *value
-	}
 }
 
 func applyActivityFallbacks(parsed []*vendors.ParsedSession) {

--- a/collector/internal/sessionpreview/README.md
+++ b/collector/internal/sessionpreview/README.md
@@ -1,0 +1,24 @@
+# `snapshot-preview/v1` (T2-I2)
+
+This adapter is a view over the accepted `session-snapshot/v1` payload. It
+does not define or assemble snapshot fields. `sessionexport.Marshal` creates
+the canonical bytes once; `FromCanonical` decodes those exact bytes for the
+preview, and `UploadBytes` returns the unchanged bytes after asserting that
+they still match the previewed semantic object.
+
+The canonical fixture pin is `fixturegen/1` at public head `e7035bc`. All
+fixtures under `snapshot/v1/testdata/fixtures` are the provider-side consumer
+test kit. The response schema is [`schema.json`](schema.json).
+
+| State | Approval | Meaning | Action |
+| --- | --- | --- | --- |
+| `ready` | allowed | Canonical v1 bytes decoded and parity-checked | Review the exact payload and privacy notices |
+| `invalid` | blocked | Serialization, hash, canonical form, redaction, or field-budget validation failed | Update coSlash or repair the source |
+| `unsupported_version` | blocked | The payload names a schema other than v1 | Update coSlash |
+| `stale_source` | blocked | The selected source revision changed before preview | Refresh and review the new revision |
+| `oversized` | blocked | The mandatory canonical payload cannot fit the 256 KiB cap | Reduce evidence and retry |
+
+Successful snapshots can still contain `redactions` and `truncation` records.
+Those records describe the exact bounded content being reviewed; they are
+shown prominently but do not create an alternate payload. A canonical
+validation failure in either mechanism is blocked as `invalid`.

--- a/collector/internal/sessionpreview/preview.go
+++ b/collector/internal/sessionpreview/preview.go
@@ -1,0 +1,147 @@
+// Package sessionpreview exposes canonical session-snapshot/v1 bytes for preview and upload.
+package sessionpreview
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/centauri-ai/coslash/collector/internal/session"
+	"github.com/centauri-ai/coslash/collector/internal/sessionexport"
+	snapshotv1 "github.com/centauri-ai/coslash/collector/snapshot/v1"
+)
+
+const AdapterVersion = "snapshot-preview/v1"
+
+type State string
+
+const (
+	StateReady              State = "ready"
+	StateInvalid            State = "invalid"
+	StateUnsupportedVersion State = "unsupported_version"
+	StateStaleSource        State = "stale_source"
+	StateOversized          State = "oversized"
+)
+
+type Problem struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Action  string `json:"action"`
+}
+
+type Response struct {
+	AdapterVersion         string               `json:"adapterVersion"`
+	State                  State                `json:"state"`
+	ApprovalAllowed        bool                 `json:"approvalAllowed"`
+	SourceRevision         int64                `json:"sourceRevision"`
+	SchemaVersion          string               `json:"schemaVersion,omitempty"`
+	MediaType              string               `json:"mediaType,omitempty"`
+	PayloadBytes           int                  `json:"payloadBytes,omitempty"`
+	MaxPayloadBytes        int                  `json:"maxPayloadBytes"`
+	CanonicalPayloadBase64 string               `json:"canonicalPayloadBase64,omitempty"`
+	Snapshot               *snapshotv1.Snapshot `json:"snapshot,omitempty"`
+	Problem                *Problem             `json:"problem,omitempty"`
+}
+
+func Build(local session.Session, options sessionexport.BuildOptions, expectedRevision int64) Response {
+	if expectedRevision != local.LastActivityTime {
+		return blocked(StateStaleSource, local.LastActivityTime, Problem{
+			Code:    "source_changed",
+			Message: "This session changed after it was selected, so the previous preview is stale.",
+			Action:  "Refresh the session list and review the current snapshot before sharing.",
+		})
+	}
+	payload, err := sessionexport.Marshal(local, options)
+	if err != nil {
+		return fromError(err, local.LastActivityTime)
+	}
+	return FromCanonical(payload, local.LastActivityTime)
+}
+
+func FromCanonical(payload []byte, sourceRevision int64) Response {
+	if len(payload) > snapshotv1.MaxPayloadBytes {
+		return blocked(StateOversized, sourceRevision, Problem{
+			Code:    "aggregate_size_exceeded",
+			Message: fmt.Sprintf("The canonical snapshot is %d bytes; the limit is %d bytes.", len(payload), snapshotv1.MaxPayloadBytes),
+			Action:  "Reduce the session evidence before previewing it again.",
+		})
+	}
+	var envelope struct {
+		SchemaVersion string `json:"schemaVersion"`
+	}
+	if err := json.Unmarshal(payload, &envelope); err == nil &&
+		strings.TrimSpace(envelope.SchemaVersion) != "" &&
+		envelope.SchemaVersion != snapshotv1.SchemaVersion {
+		return blocked(StateUnsupportedVersion, sourceRevision, Problem{
+			Code:    "unsupported_schema_version",
+			Message: fmt.Sprintf("Snapshot version %q is not supported by this preview.", envelope.SchemaVersion),
+			Action:  "Update coSlash before reviewing or sharing this session.",
+		})
+	}
+	snapshot, err := snapshotv1.Decode(payload)
+	if err != nil {
+		return fromError(err, sourceRevision)
+	}
+	return Response{
+		AdapterVersion:         AdapterVersion,
+		State:                  StateReady,
+		ApprovalAllowed:        true,
+		SourceRevision:         sourceRevision,
+		SchemaVersion:          snapshot.SchemaVersion,
+		MediaType:              snapshot.MediaType,
+		PayloadBytes:           len(payload),
+		MaxPayloadBytes:        snapshotv1.MaxPayloadBytes,
+		CanonicalPayloadBase64: base64.StdEncoding.EncodeToString(payload),
+		Snapshot:               &snapshot,
+	}
+}
+
+func UploadBytes(response Response) ([]byte, error) {
+	if response.State != StateReady || !response.ApprovalAllowed || response.Snapshot == nil {
+		return nil, fmt.Errorf("preview state %q is not approvable", response.State)
+	}
+	payload, err := base64.StdEncoding.DecodeString(response.CanonicalPayloadBase64)
+	if err != nil {
+		return nil, fmt.Errorf("decode canonical preview payload: %w", err)
+	}
+	decoded, err := snapshotv1.Decode(payload)
+	if err != nil {
+		return nil, fmt.Errorf("validate canonical preview payload: %w", err)
+	}
+	if !reflect.DeepEqual(decoded, *response.Snapshot) {
+		return nil, fmt.Errorf("preview snapshot does not match canonical upload payload")
+	}
+	if len(payload) != response.PayloadBytes {
+		return nil, fmt.Errorf("preview payload length is %d; metadata says %d", len(payload), response.PayloadBytes)
+	}
+	return payload, nil
+}
+
+func fromError(err error, sourceRevision int64) Response {
+	if errors.Is(err, snapshotv1.ErrOversized) {
+		return blocked(StateOversized, sourceRevision, Problem{
+			Code:    "aggregate_size_exceeded",
+			Message: "The canonical snapshot cannot fit within the aggregate payload limit.",
+			Action:  "Reduce the session evidence before previewing it again.",
+		})
+	}
+	return blocked(StateInvalid, sourceRevision, Problem{
+		Code:    "invalid_snapshot",
+		Message: "This session cannot produce a valid canonical snapshot.",
+		Action:  "Update coSlash or repair the source session, then preview it again.",
+	})
+}
+
+func blocked(state State, sourceRevision int64, problem Problem) Response {
+	return Response{
+		AdapterVersion:  AdapterVersion,
+		State:           state,
+		ApprovalAllowed: false,
+		SourceRevision:  sourceRevision,
+		MaxPayloadBytes: snapshotv1.MaxPayloadBytes,
+		Problem:         &problem,
+	}
+}

--- a/collector/internal/sessionpreview/schema.json
+++ b/collector/internal/sessionpreview/schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coslash.dev/schemas/snapshot-preview-v1.json",
+  "title": "snapshot-preview/v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["adapterVersion", "state", "approvalAllowed", "sourceRevision", "maxPayloadBytes"],
+  "properties": {
+    "adapterVersion": { "const": "snapshot-preview/v1" },
+    "state": { "enum": ["ready", "invalid", "unsupported_version", "stale_source", "oversized"] },
+    "approvalAllowed": { "type": "boolean" },
+    "sourceRevision": { "type": "integer", "minimum": 0 },
+    "schemaVersion": { "const": "session-snapshot/v1" },
+    "mediaType": { "const": "application/vnd.coslash.session-snapshot.v1+json" },
+    "payloadBytes": { "type": "integer", "minimum": 1, "maximum": 262144 },
+    "maxPayloadBytes": { "const": 262144 },
+    "canonicalPayloadBase64": { "type": "string", "contentEncoding": "base64" },
+    "snapshot": { "$ref": "../../snapshot/v1/schema.json" },
+    "problem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "message", "action"],
+      "properties": {
+        "code": { "type": "string" },
+        "message": { "type": "string" },
+        "action": { "type": "string" }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "state": { "const": "ready" } } },
+      "then": {
+        "required": ["schemaVersion", "mediaType", "payloadBytes", "canonicalPayloadBase64", "snapshot"],
+        "properties": { "approvalAllowed": { "const": true } }
+      },
+      "else": {
+        "required": ["problem"],
+        "properties": { "approvalAllowed": { "const": false } }
+      }
+    }
+  ]
+}

--- a/docs/data-and-privacy.md
+++ b/docs/data-and-privacy.md
@@ -42,11 +42,12 @@ For opt-in user testing before the Team flow ships, append
 preview-only trigger in session details; it does not enable a Team workspace,
 approval, or upload.
 
-The preview can include a bounded `firstPrompt` (up to 16 KiB) after
-credential-pattern redaction; it does not claim that prompt data is always
-excluded. Redaction and truncation records identify affected canonical paths.
-Raw transcripts, assistant reasoning, tool output, file diffs, raw commands,
-credentials, environment variables, and unresolved local paths are excluded.
+The preview can include a bounded `firstPrompt` (up to 16 KiB). Known
+credential patterns are redacted, but other sensitive text can remain, so the
+exact bounded value must be reviewed. Redaction and truncation records identify
+affected canonical paths. Raw transcripts, assistant reasoning, tool output,
+file diffs, raw commands, environment variables, and unresolved local paths are
+excluded.
 
 ## Local server
 

--- a/docs/data-and-privacy.md
+++ b/docs/data-and-privacy.md
@@ -28,6 +28,26 @@ The collector does not upload data itself. If you enable synthesis, it passes a 
 
 Resume and Start fresh launch your installed agent CLI. Its later network and data behavior is governed by that tool.
 
+## Snapshot preview
+
+During an active Share to Hub flow, **See what gets shared** builds a local
+`session-snapshot/v1` preview through the same canonical serializer whose bytes
+a future opt-in upload will use. Local-only session details do not show this
+action. Previewing does not upload or approve anything. If the source revision
+changes, validation fails, or the mandatory snapshot exceeds 256 KiB, approval
+remains blocked.
+
+For opt-in user testing before the Team flow ships, append
+`?team-preview=1` to the local coSlash URL. This reveals a clearly labeled
+preview-only trigger in session details; it does not enable a Team workspace,
+approval, or upload.
+
+The preview can include a bounded `firstPrompt` (up to 16 KiB) after
+credential-pattern redaction; it does not claim that prompt data is always
+excluded. Redaction and truncation records identify affected canonical paths.
+Raw transcripts, assistant reasoning, tool output, file diffs, raw commands,
+credentials, environment variables, and unresolved local paths are excluded.
+
 ## Local server
 
 coSlash listens on IPv4 loopback and protects API requests with a new access token on every start. It rejects unexpected hosts, origins, and cross-site browser requests. The token is stored in `~/.coslash/token` with mode `0600`, so other processes running as your macOS user can still read it and access coSlash. Do not proxy or forward the port.

--- a/frontend/src/pages/coslash/components/SessionInspector.tsx
+++ b/frontend/src/pages/coslash/components/SessionInspector.tsx
@@ -4,6 +4,7 @@ import {
   ChevronDownIcon,
   ChevronRightIcon,
   ExternalLinkIcon,
+  EyeIcon,
   LoaderCircleIcon,
   PlayIcon,
   SquareCheckIcon,
@@ -26,6 +27,7 @@ import {
   SubagentModelBadge,
   TokenBreakdown,
 } from '@/pages/coslash/components/SessionCard';
+import { SnapshotPreviewDialog } from '@/pages/coslash/components/SnapshotPreviewDialog';
 import { UnpricedModelWarning } from '@/pages/coslash/components/UnpricedModelWarning';
 import { useLaunchTerminal } from '@/pages/coslash/hooks/use-launch-terminal';
 import { useFileDiff, type FileSelection } from '@/pages/coslash/hooks/use-sessions';
@@ -41,6 +43,7 @@ import {
   formatTokens,
 } from '@/pages/coslash/lib/format';
 import { handoffBrief } from '@/pages/coslash/lib/handoff';
+import { teamPreviewEnabled } from '@/pages/coslash/lib/preview';
 import {
   getModality,
   getSessionOutcome,
@@ -827,6 +830,9 @@ function InspectorBody({
 }
 
 function InspectorFooter({ detail }: { detail: SessionDetail }) {
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const showTeamPreview = teamPreviewEnabled(window.location.search);
+
   return (
     <SheetFooter className="bg-muted flex-row items-center justify-between gap-4 border-t">
       <div className="flex min-w-0 flex-col">
@@ -835,7 +841,22 @@ function InspectorFooter({ detail }: { detail: SessionDetail }) {
           Reopens this session in {getVendor(detail.agent).label} with its full context.
         </span>
       </div>
-      <ResumeSessionButton detail={detail} />
+      <div className="flex shrink-0 items-center gap-2">
+        {showTeamPreview && (
+          <>
+            <Button variant="outline" onClick={() => setPreviewOpen(true)}>
+              <EyeIcon /> Team sharing preview
+            </Button>
+            <SnapshotPreviewDialog
+              detail={detail}
+              open={previewOpen}
+              onOpenChange={setPreviewOpen}
+              previewOnly
+            />
+          </>
+        )}
+        <ResumeSessionButton detail={detail} />
+      </div>
     </SheetFooter>
   );
 }

--- a/frontend/src/pages/coslash/components/SnapshotPreviewDialog.tsx
+++ b/frontend/src/pages/coslash/components/SnapshotPreviewDialog.tsx
@@ -14,6 +14,7 @@ import {
   canonicalPayloadText,
   formatCanonicalJson,
   frozenCostDisclosure,
+  isSnapshotPreview,
   PREVIEW_PRIVACY_COPY,
   previewNotices,
   previewRequestPath,
@@ -146,9 +147,10 @@ export function SnapshotPreviewDialog({
     apiFetch(previewRequestPath(detail.id, detail.mtime), { signal: controller.signal })
       .then((response) => {
         if (!response.ok) throw new Error(`Preview request failed (${response.status})`);
-        return response.json() as Promise<SnapshotPreview>;
+        return response.json() as Promise<unknown>;
       })
       .then((preview) => {
+        if (!isSnapshotPreview(preview)) throw new Error('Invalid preview response');
         if (!controller.signal.aborted) setLoad({ status: 'loaded', preview });
       })
       .catch(() => {

--- a/frontend/src/pages/coslash/components/SnapshotPreviewDialog.tsx
+++ b/frontend/src/pages/coslash/components/SnapshotPreviewDialog.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useState } from 'react';
+import { AlertTriangleIcon, CheckIcon, LockKeyholeIcon } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { apiFetch } from '@/pages/coslash/lib/api';
+import {
+  canonicalPayloadText,
+  formatCanonicalJson,
+  frozenCostDisclosure,
+  PREVIEW_PRIVACY_COPY,
+  previewNotices,
+  previewRequestPath,
+  STRUCTURALLY_EXCLUDED,
+  type SnapshotPreview,
+} from '@/pages/coslash/lib/preview';
+import type { SessionDetail } from '@/pages/coslash/lib/session';
+
+type LoadState =
+  | { status: 'idle' | 'loading' }
+  | { status: 'error'; message: string }
+  | { status: 'loaded'; preview: SnapshotPreview };
+
+function PreviewReady({ preview }: { preview: SnapshotPreview }) {
+  let payload: string;
+  try {
+    payload = formatCanonicalJson(canonicalPayloadText(preview));
+  } catch {
+    return (
+      <div role="alert" className="bg-warning-bg text-warning-fg rounded-lg border p-3 text-sm">
+        The canonical bytes no longer match this preview. Close it and try again; sharing is blocked.
+      </div>
+    );
+  }
+  const notices = previewNotices(preview);
+  const hash = typeof preview.snapshot?.contentHash === 'string' ? preview.snapshot.contentHash : '—';
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto pr-1">
+      <div className="bg-success-bg text-success-fg flex items-start gap-2 rounded-lg border p-3">
+        <CheckIcon className="mt-0.5 size-4 shrink-0" />
+        <div>
+          <div className="text-sm font-semibold">Canonical snapshot ready</div>
+          <div className="pt-1 text-xs">
+            {preview.payloadBytes?.toLocaleString()} exact bytes · {frozenCostDisclosure(preview)}
+          </div>
+          <div className="max-w-full truncate pt-1 font-mono text-xs" title={hash}>
+            {hash}
+          </div>
+        </div>
+      </div>
+
+      {notices.length > 0 && (
+        <section aria-labelledby="preview-notices">
+          <h3 id="preview-notices" className="text-warning-fg text-xs font-bold tracking-wide">
+            BOUNDED OR REDACTED BEFORE SHARING
+          </h3>
+          <div className="mt-1 rounded-lg border">
+            {notices.map((notice, index) => (
+              <div
+                key={`${notice.kind}-${notice.path}-${index}`}
+                className="flex gap-2 border-b p-2 text-xs last:border-b-0"
+              >
+                <Badge variant="secondary">{notice.kind}</Badge>
+                <span className="min-w-0 font-mono break-all">{notice.path}</span>
+                <span className="text-muted-foreground ml-auto shrink-0">{notice.reason}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      <section className="rounded-lg border p-3" aria-labelledby="preview-privacy">
+        <h3 id="preview-privacy" className="flex items-center gap-1 text-xs font-bold tracking-wide">
+          <LockKeyholeIcon className="size-3" /> PRIVACY BOUNDARY
+        </h3>
+        <p className="text-muted-foreground pt-2 text-xs">{PREVIEW_PRIVACY_COPY}</p>
+        <ul className="text-muted-foreground grid list-disc gap-1 pt-2 pl-4 text-xs sm:grid-cols-2">
+          {STRUCTURALLY_EXCLUDED.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="min-h-48" aria-labelledby="preview-payload">
+        <div className="flex items-baseline justify-between gap-2">
+          <h3 id="preview-payload" className="text-xs font-bold tracking-wide">
+            EXACT DESTINATION-INDEPENDENT PAYLOAD
+          </h3>
+          <span className="text-muted-foreground text-xs">{preview.schemaVersion}</span>
+        </div>
+        <pre className="bg-muted mt-1 max-h-80 overflow-auto rounded-lg border p-3 font-mono text-[11px] leading-relaxed whitespace-pre">
+          {payload}
+        </pre>
+      </section>
+    </div>
+  );
+}
+
+function PreviewBlocked({ preview }: { preview: SnapshotPreview }) {
+  return (
+    <div role="alert" className="bg-warning-bg text-warning-fg flex items-start gap-2 rounded-lg border p-3">
+      <AlertTriangleIcon className="mt-0.5 size-4 shrink-0" />
+      <div>
+        <div className="text-sm font-semibold">This snapshot cannot be approved</div>
+        <p className="pt-1 text-xs">{preview.problem?.message ?? 'The canonical preview is unavailable.'}</p>
+        <p className="pt-2 text-xs font-semibold">
+          {preview.problem?.action ?? 'Close this preview and try again.'}
+        </p>
+        <Badge variant="secondary" className="mt-3 font-mono">
+          {preview.state}
+        </Badge>
+      </div>
+    </div>
+  );
+}
+
+export type SnapshotPreviewDialogProps = {
+  detail: SessionDetail;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  previewOnly?: boolean;
+};
+
+export function SnapshotPreviewDialog({
+  detail,
+  open,
+  onOpenChange,
+  previewOnly = false,
+}: SnapshotPreviewDialogProps) {
+  const [load, setLoad] = useState<LoadState>({ status: 'idle' });
+
+  useEffect(() => {
+    if (!open) {
+      setLoad({ status: 'idle' });
+      return;
+    }
+    const controller = new AbortController();
+    setLoad({ status: 'loading' });
+    apiFetch(previewRequestPath(detail.id, detail.mtime), { signal: controller.signal })
+      .then((response) => {
+        if (!response.ok) throw new Error(`Preview request failed (${response.status})`);
+        return response.json() as Promise<SnapshotPreview>;
+      })
+      .then((preview) => {
+        if (!controller.signal.aborted) setLoad({ status: 'loaded', preview });
+      })
+      .catch(() => {
+        if (!controller.signal.aborted) {
+          setLoad({ status: 'error', message: 'Could not build the canonical snapshot preview.' });
+        }
+      });
+    return () => controller.abort();
+  }, [detail.id, detail.mtime, open]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[calc(100vh-2rem)] w-[min(56rem,calc(100vw-2rem))] max-w-none! flex-col">
+        <DialogHeader>
+          <DialogTitle>{previewOnly ? 'Team sharing preview' : 'Exact snapshot preview'}</DialogTitle>
+          <DialogDescription>
+            {previewOnly
+              ? `Review the exact, destination-independent payload a future Team share could use for ${detail.name ?? detail.id}.`
+              : `This is the canonical, destination-independent revision for ${detail.name ?? detail.id}. Sharing stays off until you explicitly approve this exact revision in Share to Hub.`}
+          </DialogDescription>
+        </DialogHeader>
+
+        {previewOnly && (
+          <div role="note" className="bg-info-bg text-info-fg rounded-lg border p-3 text-sm">
+            <Badge variant="secondary">PREVIEW ONLY · TEAM FEATURE</Badge>
+            <p className="pt-2">
+              This local test screen cannot approve or upload anything. Sharing requires a Team workspace.
+            </p>
+          </div>
+        )}
+
+        {load.status === 'loading' && (
+          <div
+            role="status"
+            className="text-muted-foreground flex min-h-48 items-center justify-center text-sm"
+          >
+            Building the canonical preview…
+          </div>
+        )}
+        {load.status === 'error' && (
+          <div role="alert" className="text-destructive min-h-48 rounded-lg border p-3 text-sm">
+            {load.message} Close this dialog and try again; sharing is blocked.
+          </div>
+        )}
+        {load.status === 'loaded' &&
+          (load.preview.state === 'ready' && load.preview.approvalAllowed ? (
+            <PreviewReady preview={load.preview} />
+          ) : (
+            <PreviewBlocked preview={load.preview} />
+          ))}
+
+        <DialogFooter showCloseButton />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/pages/coslash/lib/preview.test.ts
+++ b/frontend/src/pages/coslash/lib/preview.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canonicalPayloadText,
+  canonicalUploadBytes,
+  formatCanonicalJson,
+  frozenCostDisclosure,
+  previewNotices,
+  previewRequestPath,
+  teamPreviewEnabled,
+  type SnapshotPreview,
+} from '@/pages/coslash/lib/preview';
+
+function ready(snapshot: Record<string, unknown>): SnapshotPreview {
+  const payload = JSON.stringify(snapshot);
+  const bytes = new TextEncoder().encode(payload);
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return {
+    adapterVersion: 'snapshot-preview/v1',
+    state: 'ready',
+    approvalAllowed: true,
+    sourceRevision: 42,
+    schemaVersion: 'session-snapshot/v1',
+    mediaType: 'application/vnd.coslash.session-snapshot.v1+json',
+    payloadBytes: bytes.byteLength,
+    maxPayloadBytes: 262_144,
+    canonicalPayloadBase64: btoa(binary),
+    snapshot: snapshot as SnapshotPreview['snapshot'],
+  };
+}
+
+describe('snapshot preview adapter', () => {
+  it('returns the exact canonical bytes intended for upload', () => {
+    const preview = ready({
+      schemaVersion: 'session-snapshot/v1',
+      contentHash: 'sha256:test',
+      repository: { canonical: 'github.com/centauri-ai/coslash' },
+    });
+    expect(new TextDecoder().decode(canonicalUploadBytes(preview))).toBe(canonicalPayloadText(preview));
+    expect(canonicalPayloadText(preview)).toContain('github.com/centauri-ai/coslash');
+  });
+
+  it('blocks bytes for every non-ready state', () => {
+    const preview: SnapshotPreview = {
+      adapterVersion: 'snapshot-preview/v1',
+      state: 'oversized',
+      approvalAllowed: false,
+      sourceRevision: 42,
+      maxPayloadBytes: 262_144,
+      problem: { code: 'aggregate_size_exceeded', message: 'Too large.', action: 'Reduce evidence.' },
+    };
+    expect(() => canonicalUploadBytes(preview)).toThrow('not approvable');
+  });
+
+  it('formats canonical JSON without changing string content', () => {
+    const canonical = '{"summary":"comma, brace } and escaped \\\"quote\\\"","count":9007199254740993}';
+    const formatted = formatCanonicalJson(canonical);
+    expect(formatted).toContain('"comma, brace } and escaped \\\"quote\\\""');
+    expect(formatted).toContain('9007199254740993');
+  });
+
+  it('exposes redaction, truncation, revision, and frozen-cost semantics', () => {
+    const preview = ready({
+      schemaVersion: 'session-snapshot/v1',
+      contentHash: 'sha256:test',
+      redactions: [{ path: '/session/firstPrompt', reason: 'credential_pattern' }],
+      truncation: [{ path: '/session/firstPrompt', reason: 'text_budget' }],
+      session: { usage: { estimatedCostMicroUsd: 0, unpricedModels: ['unknown'] } },
+    });
+    expect(previewNotices(preview)).toEqual([
+      { kind: 'redaction', path: '/session/firstPrompt', reason: 'credential_pattern' },
+      { kind: 'truncation', path: '/session/firstPrompt', reason: 'text_budget' },
+    ]);
+    expect(frozenCostDisclosure(preview)).toBe('$0.00 frozen priced estimate; 1 unpriced model excluded');
+    expect(previewRequestPath('session/id', 42)).toBe('/api/share-preview?id=session%2Fid&revision=42');
+  });
+
+  it('distinguishes a true zero from unpriced models', () => {
+    const preview = ready({
+      schemaVersion: 'session-snapshot/v1',
+      contentHash: 'sha256:test',
+      session: { usage: { estimatedCostMicroUsd: 0, unpricedModels: [] } },
+    });
+    expect(frozenCostDisclosure(preview)).toBe('$0.00 frozen estimate; all models priced');
+  });
+
+  it('enables the Team preview harness only through its explicit URL flag', () => {
+    expect(teamPreviewEnabled('?team-preview=1')).toBe(true);
+    expect(teamPreviewEnabled('?team-preview=0')).toBe(false);
+    expect(teamPreviewEnabled('?other=1')).toBe(false);
+  });
+});

--- a/frontend/src/pages/coslash/lib/preview.test.ts
+++ b/frontend/src/pages/coslash/lib/preview.test.ts
@@ -4,8 +4,11 @@ import {
   canonicalUploadBytes,
   formatCanonicalJson,
   frozenCostDisclosure,
+  isSnapshotPreview,
+  PREVIEW_PRIVACY_COPY,
   previewNotices,
   previewRequestPath,
+  STRUCTURALLY_EXCLUDED,
   teamPreviewEnabled,
   type SnapshotPreview,
 } from '@/pages/coslash/lib/preview';
@@ -38,6 +41,19 @@ describe('snapshot preview adapter', () => {
     });
     expect(new TextDecoder().decode(canonicalUploadBytes(preview))).toBe(canonicalPayloadText(preview));
     expect(canonicalPayloadText(preview)).toContain('github.com/centauri-ai/coslash');
+  });
+
+  it('rejects any displayed snapshot field that differs from the canonical bytes', () => {
+    const preview = ready({
+      schemaVersion: 'session-snapshot/v1',
+      contentHash: 'sha256:test',
+      repository: { canonical: 'github.com/centauri-ai/coslash' },
+    });
+    preview.snapshot = {
+      ...preview.snapshot,
+      repository: { canonical: 'github.com/centauri-ai/other' },
+    };
+    expect(() => canonicalUploadBytes(preview)).toThrow('does not match');
   });
 
   it('blocks bytes for every non-ready state', () => {
@@ -88,5 +104,12 @@ describe('snapshot preview adapter', () => {
     expect(teamPreviewEnabled('?team-preview=1')).toBe(true);
     expect(teamPreviewEnabled('?team-preview=0')).toBe(false);
     expect(teamPreviewEnabled('?other=1')).toBe(false);
+  });
+
+  it('validates preview responses and states the credential limit precisely', () => {
+    expect(isSnapshotPreview(null)).toBe(false);
+    expect(isSnapshotPreview(ready({ schemaVersion: 'session-snapshot/v1' }))).toBe(true);
+    expect(PREVIEW_PRIVACY_COPY).toContain('known credential patterns');
+    expect(STRUCTURALLY_EXCLUDED.join(' ')).not.toContain('Credentials');
   });
 });

--- a/frontend/src/pages/coslash/lib/preview.ts
+++ b/frontend/src/pages/coslash/lib/preview.ts
@@ -19,14 +19,34 @@ export type SnapshotPreview = {
 };
 
 export const PREVIEW_PRIVACY_COPY =
-  'When present, firstPrompt is shared up to 16 KiB after credential-pattern redaction. Prompt data can therefore be included; this preview shows the exact bounded value.';
+  'When present, firstPrompt is shared up to 16 KiB after known credential patterns are redacted. Other sensitive text can remain; review the exact bounded value below.';
 
 export const STRUCTURALLY_EXCLUDED = [
   'Raw transcripts and assistant reasoning',
   'Tool output and file diffs',
   'Raw top-level and subagent commands',
-  'Credentials, environment variables, and unresolved local paths',
+  'Environment variables and unresolved local paths',
 ] as const;
+
+const PREVIEW_STATES: PreviewState[] = [
+  'ready',
+  'invalid',
+  'unsupported_version',
+  'stale_source',
+  'oversized',
+];
+
+export function isSnapshotPreview(value: unknown): value is SnapshotPreview {
+  if (value == null || Array.isArray(value) || typeof value !== 'object') return false;
+  const preview = value as Record<string, unknown>;
+  return (
+    preview.adapterVersion === 'snapshot-preview/v1' &&
+    PREVIEW_STATES.includes(preview.state as PreviewState) &&
+    typeof preview.approvalAllowed === 'boolean' &&
+    typeof preview.sourceRevision === 'number' &&
+    typeof preview.maxPayloadBytes === 'number'
+  );
+}
 
 export function previewRequestPath(id: string, revision: number): string {
   return `/api/share-preview?${new URLSearchParams({ id, revision: String(revision) })}`;
@@ -52,11 +72,8 @@ export function canonicalUploadBytes(preview: SnapshotPreview): Uint8Array {
     throw new Error('Canonical preview payload length does not match its metadata.');
   }
   const text = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
-  const decoded = JSON.parse(text) as { schemaVersion?: unknown; contentHash?: unknown };
-  if (
-    decoded.schemaVersion !== preview.schemaVersion ||
-    decoded.contentHash !== preview.snapshot.contentHash
-  ) {
+  const decoded: unknown = JSON.parse(text);
+  if (JSON.stringify(decoded) !== JSON.stringify(preview.snapshot)) {
     throw new Error('Canonical preview payload does not match the displayed snapshot.');
   }
   return bytes;

--- a/frontend/src/pages/coslash/lib/preview.ts
+++ b/frontend/src/pages/coslash/lib/preview.ts
@@ -1,0 +1,140 @@
+export type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
+
+export type PreviewState = 'ready' | 'invalid' | 'unsupported_version' | 'stale_source' | 'oversized';
+
+export type PreviewProblem = { code: string; message: string; action: string };
+
+export type SnapshotPreview = {
+  adapterVersion: 'snapshot-preview/v1';
+  state: PreviewState;
+  approvalAllowed: boolean;
+  sourceRevision: number;
+  schemaVersion?: 'session-snapshot/v1';
+  mediaType?: 'application/vnd.coslash.session-snapshot.v1+json';
+  payloadBytes?: number;
+  maxPayloadBytes: number;
+  canonicalPayloadBase64?: string;
+  snapshot?: { [key: string]: JsonValue };
+  problem?: PreviewProblem;
+};
+
+export const PREVIEW_PRIVACY_COPY =
+  'When present, firstPrompt is shared up to 16 KiB after credential-pattern redaction. Prompt data can therefore be included; this preview shows the exact bounded value.';
+
+export const STRUCTURALLY_EXCLUDED = [
+  'Raw transcripts and assistant reasoning',
+  'Tool output and file diffs',
+  'Raw top-level and subagent commands',
+  'Credentials, environment variables, and unresolved local paths',
+] as const;
+
+export function previewRequestPath(id: string, revision: number): string {
+  return `/api/share-preview?${new URLSearchParams({ id, revision: String(revision) })}`;
+}
+
+export function teamPreviewEnabled(search: string): boolean {
+  return new URLSearchParams(search).get('team-preview') === '1';
+}
+
+export function canonicalUploadBytes(preview: SnapshotPreview): Uint8Array {
+  if (
+    preview.state !== 'ready' ||
+    !preview.approvalAllowed ||
+    preview.canonicalPayloadBase64 == null ||
+    preview.payloadBytes == null ||
+    preview.snapshot == null
+  ) {
+    throw new Error(`Preview state ${preview.state} is not approvable.`);
+  }
+  const binary = atob(preview.canonicalPayloadBase64);
+  const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+  if (bytes.byteLength !== preview.payloadBytes) {
+    throw new Error('Canonical preview payload length does not match its metadata.');
+  }
+  const text = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  const decoded = JSON.parse(text) as { schemaVersion?: unknown; contentHash?: unknown };
+  if (
+    decoded.schemaVersion !== preview.schemaVersion ||
+    decoded.contentHash !== preview.snapshot.contentHash
+  ) {
+    throw new Error('Canonical preview payload does not match the displayed snapshot.');
+  }
+  return bytes;
+}
+
+export function canonicalPayloadText(preview: SnapshotPreview): string {
+  return new TextDecoder('utf-8', { fatal: true }).decode(canonicalUploadBytes(preview));
+}
+
+export function formatCanonicalJson(text: string): string {
+  let result = '';
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  const indent = () => '  '.repeat(depth);
+  for (const character of text) {
+    if (inString) {
+      result += character;
+      if (escaped) escaped = false;
+      else if (character === '\\') escaped = true;
+      else if (character === '"') inString = false;
+      continue;
+    }
+    if (character === '"') {
+      inString = true;
+      result += character;
+    } else if (character === '{' || character === '[') {
+      depth += 1;
+      result += `${character}\n${indent()}`;
+    } else if (character === '}' || character === ']') {
+      depth -= 1;
+      result += `\n${indent()}${character}`;
+    } else if (character === ',') {
+      result += `,\n${indent()}`;
+    } else if (character === ':') {
+      result += ': ';
+    } else {
+      result += character;
+    }
+  }
+  return result;
+}
+
+export type PreviewNotice = { kind: 'redaction' | 'truncation'; path: string; reason: string };
+
+export function previewNotices(preview: SnapshotPreview): PreviewNotice[] {
+  if (preview.snapshot == null) return [];
+  return [
+    ...metadataRows(preview.snapshot.redactions, 'redaction'),
+    ...metadataRows(preview.snapshot.truncation, 'truncation'),
+  ];
+}
+
+function metadataRows(value: JsonValue | undefined, kind: PreviewNotice['kind']): PreviewNotice[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((row) => {
+    if (row == null || Array.isArray(row) || typeof row !== 'object') return [];
+    const path = row.path;
+    const reason = row.reason;
+    return typeof path === 'string' && typeof reason === 'string' ? [{ kind, path, reason }] : [];
+  });
+}
+
+export function frozenCostDisclosure(preview: SnapshotPreview): string {
+  const snapshot = preview.snapshot;
+  const session = objectValue(snapshot?.session);
+  const usage = objectValue(session?.usage);
+  const microUsd = typeof usage?.estimatedCostMicroUsd === 'number' ? usage.estimatedCostMicroUsd : 0;
+  const models = Array.isArray(usage?.unpricedModels)
+    ? usage.unpricedModels.filter((model): model is string => typeof model === 'string')
+    : [];
+  const cost = `$${(microUsd / 1_000_000).toFixed(2)}`;
+  if (models.length > 0) {
+    return `${cost} frozen priced estimate; ${models.length} unpriced ${models.length === 1 ? 'model' : 'models'} excluded`;
+  }
+  return `${cost} frozen estimate; all models priced`;
+}
+
+function objectValue(value: JsonValue | undefined): { [key: string]: JsonValue } | undefined {
+  return value != null && !Array.isArray(value) && typeof value === 'object' ? value : undefined;
+}


### PR DESCRIPTION
## What this changes

This PR adds an exact, local preview of the session snapshot that a future Team sharing flow will upload. The preview is created before any data leaves the machine and from the selected saved session revision.

| This PR introduces | This prevents |
| --- | --- |
| A pre-upload preview of the exact selected session snapshot | Sending session data to a server before the user can review it |
| One canonical serialization path whose unchanged bytes are displayed by the preview and can be passed to the future uploader | A separate preview payload builder drifting from the data that is actually uploaded |
| A controlled preview dialog with an explicit development-only test entry point | Showing Team sharing controls to users of the local-only application |

## What users see

The normal local-only experience is unchanged: no sharing button is shown.

When the development test entry point is enabled, a session has a **Team sharing preview** action. The dialog is labeled **PREVIEW ONLY · TEAM FEATURE** and shows:

- the canonical JSON snapshot and its byte size and content hash;
- repository identity, frozen cost, and any unpriced models;
- fields that were redacted or truncated, including known credential patterns; and
- data that is structurally excluded, including raw transcripts, assistant reasoning, tool output, file diffs, commands, environment variables, and unresolved local paths.

Other sensitive text can remain in the bounded `firstPrompt`, so the dialog shows its exact value for review rather than claiming that every possible credential format is removed.

The preview blocks approval when the snapshot is invalid, uses an unsupported format, no longer matches the selected revision, or exceeds the 256 KiB payload limit. This PR does not provide an approval or upload action.

## Implementation boundary

The local collector owns this preview because both the session source and the existing `session-snapshot/v1` serializer are local. The collector serializes the snapshot once, and the preview decodes those same bytes for display. A future Team sharing flow must upload those unchanged, already-reviewed bytes.

This PR includes:

- the local `/api/share-preview` endpoint for one session ID and revision;
- the versioned `snapshot-preview/v1` response and its fail-closed states;
- the controlled React preview dialog and byte-parity checks; and
- privacy documentation and public/server fixture conformance.

This PR does not include Team eligibility, authentication, destination selection, multi-session selection, consent submission, upload, retry, or success navigation. Those belong to the production Team sharing flow that will consume this preview.

## Try the preview

1. From `collector/`, run `make run`.
2. In another terminal, from `frontend/`, run `npm run dev`.
3. Open `http://127.0.0.1:5173/?team-preview=1`.
4. Select a session and click **Team sharing preview**.

Remove `?team-preview=1` to confirm that the local-only UI contains no sharing action.

<img width="886" height="951" alt="Exact Team sharing preview showing the canonical local session snapshot" src="https://github.com/user-attachments/assets/674081f9-a08b-448f-a8d2-5847529f0ca5" />

## Verification

- `go test ./...`
- `go vet ./...`
- 19 frontend tests
- frontend build, lint, and format checks
- snapshot fixture validation against coSlash Server commit `c0fabc8`

## Follow-up requirement

The production Team sharing flow must open this controlled preview only after the user enters a sharing flow and selects what to share. It must upload the exact canonical bytes the user reviewed, rather than rebuilding the snapshot.
