### PR TITLE
feat: add opt-in Hub share build

### DIFF
--- a/docs/data-and-privacy.md
+++ b/docs/data-and-privacy.md
@@ -49,6 +49,21 @@ affected canonical paths. Raw transcripts, assistant reasoning, tool output,
 file diffs, raw commands, environment variables, and unresolved local paths are
 excluded.
 
+The fixture-backed Share flow is available to source builds with
+`?team-share=1`. It exercises eligibility, destination, selection, exact review,
+partial retry, and Hub route states, but is labeled **NO UPLOAD** and never
+contacts a cloud service. Use `&share-state=signed_out`, `pairing_required`,
+`credential_dormant`, or `credential_revoked` to inspect eligibility states,
+and `&share-result=partial` to inspect retry.
+
+The production flow will bind approval to the source revision, canonical hash
+and byte count, and displayed destination. Failures that require renewed review
+refresh the preview or destination and require explicit approval. Unchanged
+retries retain their idempotency key and canonical bytes; accepted items are
+not sent again. The server derives workspace authority from authenticated state
+or a workspace-bound device credential and never trusts the client assertion to
+select or retarget a workspace.
+
 ## Local server
 
 coSlash listens on IPv4 loopback and protects API requests with a new access token on every start. It rejects unexpected hosts, origins, and cross-site browser requests. The token is stored in `~/.coslash/token` with mode `0600`, so other processes running as your macOS user can still read it and access coSlash. Do not proxy or forward the port.

--- a/frontend/src/pages/coslash/CoslashPage.tsx
+++ b/frontend/src/pages/coslash/CoslashPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Search } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -28,6 +28,8 @@ import {
   type AgentVendor,
   type ViewMode,
 } from '@/pages/coslash/CoslashTabMenus';
+import { HUB_SHARE_VERSION, type DestinationResult } from '@/pages/coslash/features/sharing/model';
+import { ShareToHubDialog } from '@/pages/coslash/features/sharing/ShareToHubDialog';
 import { useDiagnostics } from '@/pages/coslash/hooks/use-diagnostics';
 import { useSessions } from '@/pages/coslash/hooks/use-sessions';
 import { useSettings } from '@/pages/coslash/hooks/use-settings';
@@ -46,6 +48,32 @@ const WINDOW_ACTIVITY_LABELS: Record<TimeWindow, string> = {
   '30d': 'active in the last 30 days',
   'all': 'across all time',
 };
+
+function fixtureDestination(search: string): DestinationResult {
+  const state = new URLSearchParams(search).get('share-state');
+  if (
+    state === 'signed_out' ||
+    state === 'pairing_required' ||
+    state === 'credential_dormant' ||
+    state === 'credential_revoked'
+  ) {
+    return { contractVersion: HUB_SHARE_VERSION, state };
+  }
+  return {
+    contractVersion: HUB_SHARE_VERSION,
+    state: 'ready',
+    destination: {
+      workspaceId: '10000000-0000-4000-8000-000000000001',
+      workspaceName: 'Compiler Team',
+      currentMemberCount: 2,
+      resultingMemberCount: 2,
+      currentApprovedSessionCount: 3,
+      historyDisclosure:
+        "Sharing this revision makes it visible to the workspace's current members. Membership and approved-session counts are current when viewed.",
+      credentialState: 'paired',
+    },
+  };
+}
 
 function CoslashPageHeader({
   onOpenSettings,
@@ -238,7 +266,11 @@ function CoslashContent({
 export function CoslashPage() {
   const [vendor, setVendor] = useState<AgentVendor>('all');
   const [timeWindow, setTimeWindow] = useState<TimeWindow>('week');
-  const { sessions, isLoading, loadError, sessionsVersion, retrySessions } = useSessions(timeWindow);
+  const shareParams = new URLSearchParams(window.location.search);
+  const shareBuildEnabled = shareParams.get('team-share') === '1';
+  const { sessions, isLoading, loadError, sessionsVersion, retrySessions } = useSessions(
+    shareBuildEnabled ? 'all' : timeWindow,
+  );
   const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
   const diagnosticsEnabled = diagnosticsOpen || (!isLoading && loadError == null && sessions.length === 0);
   const {
@@ -253,8 +285,19 @@ export function CoslashPage() {
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
   const [settingsDialogMode, setSettingsDialogMode] = useState<SettingsDialogMode | null>(null);
+  const [shareDialogOpen, setShareDialogOpen] = useState(false);
   const settingsState = useSettings();
   const settingsHaveError = settingsState.loadError != null || settingsState.response?.valid === false;
+  const shareDestination = fixtureDestination(window.location.search);
+  const shareFixtureOutcome = shareParams.get('share-result') === 'partial' ? 'partial' : 'success';
+  const shareCandidates = useMemo(
+    () =>
+      sessions.map((session, index) => ({
+        session,
+        previouslyShared: index === 0,
+      })),
+    [sessions],
+  );
 
   useEffect(() => {
     if (settingsState.response) setTheme(settingsState.response.settings.appearance.theme);
@@ -277,8 +320,7 @@ export function CoslashPage() {
       setSettingsDialogMode((current) => current ?? 'synthesis-consent');
     }
   }, [selectedSession, settingsState.response]);
-  // The API returns every session, so the window is applied here — switching it
-  // never refetches. A live session shows regardless of how old its log is.
+  // Keep live sessions visible even when their logs predate the window.
   const windowStart = timeWindowStart(timeWindow);
   const sessionsInWindow =
     windowStart == null
@@ -345,6 +387,11 @@ export function CoslashPage() {
               loadFailed={diagnosticsLoadFailed}
               onRefresh={refreshDiagnostics}
             />
+            {shareBuildEnabled && (
+              <Button variant="outline" size="sm" onClick={() => setShareDialogOpen(true)}>
+                Share to Hub
+              </Button>
+            )}
           </div>
         </div>
       </div>
@@ -355,7 +402,7 @@ export function CoslashPage() {
               loadError={loadError}
               onRetry={retrySessions}
               visibleSessions={visibleSessions}
-              hasSessions={sessions.length > 0}
+              hasSessions={sessionsInWindow.length > 0}
               searchTerm={searchTerm}
               timeWindow={timeWindow}
               view={view}
@@ -374,6 +421,19 @@ export function CoslashPage() {
         synthesisSettingsKey={synthesisSettingsKey}
         onClose={() => setSelectedSessionId(null)}
       />
+      {shareBuildEnabled && (
+        <ShareToHubDialog
+          open={shareDialogOpen}
+          onOpenChange={setShareDialogOpen}
+          candidates={shareCandidates}
+          destinationResult={shareDestination}
+          fixtureOutcome={shareFixtureOutcome}
+          onOpenSettings={() => {
+            setShareDialogOpen(false);
+            setSettingsDialogMode('full-settings');
+          }}
+        />
+      )}
       <SettingsDialog
         open={settingsDialogMode != null}
         mode={settingsDialogMode ?? 'full-settings'}

--- a/frontend/src/pages/coslash/features/sharing/ShareToHubDialog.tsx
+++ b/frontend/src/pages/coslash/features/sharing/ShareToHubDialog.tsx
@@ -1,0 +1,571 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { AlertTriangleIcon, CheckIcon, ExternalLinkIcon, SearchIcon, ShieldCheckIcon } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { apiFetch } from '@/pages/coslash/lib/api';
+import {
+  canonicalPayloadText,
+  formatCanonicalJson,
+  previewRequestPath,
+  type SnapshotPreview,
+} from '@/pages/coslash/lib/preview';
+import {
+  bindPreviewConsent,
+  consentStillCurrent,
+  filterShareCandidates,
+  HUB_SHARE_VERSION,
+  localSessionId,
+  planShareRetry,
+  primarySuccessRoute,
+  reconcileVisibleSelection,
+  RETRY_RULES,
+  toggleCandidate,
+  toggleCandidateGroup,
+  type DestinationResult,
+  type ShareCandidate,
+  type ShareItemRequest,
+  type ShareResult,
+  type ShareWindow,
+} from './model';
+
+type ReviewRecord = {
+  candidate: ShareCandidate;
+  preview: SnapshotPreview;
+  item: ShareItemRequest;
+  payload: string;
+};
+
+type Phase = 'select' | 'loading' | 'review' | 'result';
+
+const ELIGIBILITY_COPY: Record<
+  Exclude<DestinationResult['state'], 'ready'>,
+  { title: string; detail: string; action: string }
+> = {
+  signed_out: {
+    title: 'Sign in to share',
+    detail: 'Sharing stays off. Sign in, choose a workspace, and pair this device before selecting sessions.',
+    action: 'Open cloud settings',
+  },
+  pairing_required: {
+    title: 'Pair this device',
+    detail:
+      'No workspace-bound device credential is available. Pairing must finish before a destination can be approved.',
+    action: 'Open pairing settings',
+  },
+  credential_dormant: {
+    title: 'Paired workspace is not active',
+    detail: 'Select the paired workspace, then verify the refreshed destination and member count.',
+    action: 'Open workspace settings',
+  },
+  credential_revoked: {
+    title: 'Device access was revoked',
+    detail:
+      'This credential cannot be retried. Pair the device again; no selected session has been uploaded.',
+    action: 'Open pairing settings',
+  },
+};
+
+export function ShareToHubDialog({
+  open,
+  onOpenChange,
+  candidates,
+  destinationResult,
+  onOpenSettings,
+  fixtureOutcome = 'success',
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  candidates: ShareCandidate[];
+  destinationResult: DestinationResult;
+  onOpenSettings: () => void;
+  fixtureOutcome?: 'success' | 'partial';
+}) {
+  const [search, setSearch] = useState('');
+  const [window, setWindow] = useState<ShareWindow>('7d');
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [phase, setPhase] = useState<Phase>('select');
+  const [records, setRecords] = useState<ReviewRecord[]>([]);
+  const [reviewed, setReviewed] = useState(false);
+  const [problem, setProblem] = useState<string | null>(null);
+  const [result, setResult] = useState<ShareResult | null>(null);
+  const [fixtureAttempt, setFixtureAttempt] = useState(0);
+  const previewGeneration = useRef(0);
+
+  const visible = useMemo(
+    () => filterShareCandidates(candidates, search, window),
+    [candidates, search, window],
+  );
+  const selectedCandidates = candidates.filter(({ session }) => selected.has(localSessionId(session)));
+  const currentSelection = new Set(selectedCandidates.map(({ session }) => localSessionId(session)));
+  const destination = destinationResult.state === 'ready' ? destinationResult.destination : null;
+  const reviewStillCurrent =
+    destination != null &&
+    records.every((record) => {
+      const current = candidates.find(
+        ({ session }) => localSessionId(session) === record.item.localSessionId,
+      );
+      return (
+        current != null && consentStillCurrent(record.item, current.session, record.preview, destination)
+      );
+    });
+  const groups = useMemo(() => {
+    const values = new Map<string, ShareCandidate[]>();
+    for (const candidate of visible) {
+      const repository = candidate.session.repo ?? '(no repository)';
+      values.set(repository, [...(values.get(repository) ?? []), candidate]);
+    }
+    return [...values.entries()];
+  }, [visible]);
+
+  useEffect(() => {
+    if (open) return;
+    previewGeneration.current += 1;
+    setSearch('');
+    setWindow('7d');
+    setSelected(new Set());
+    setPhase('select');
+    setRecords([]);
+    setReviewed(false);
+    setProblem(null);
+    setResult(null);
+    setFixtureAttempt(0);
+  }, [open]);
+
+  useEffect(() => {
+    setSelected((current) => {
+      const next = reconcileVisibleSelection(current, candidates);
+      return next.size === current.size ? current : next;
+    });
+  }, [candidates]);
+
+  useEffect(() => {
+    if (phase !== 'review' || records.length === 0 || reviewStillCurrent) return;
+    setRecords([]);
+    setReviewed(false);
+    setProblem('The source revision or destination changed. Review the current selection again.');
+    setPhase('select');
+  }, [phase, records.length, reviewStillCurrent]);
+
+  const replaceSelection = (next: Set<string>) => {
+    setSelected(next);
+    setRecords((current) => current.filter((record) => next.has(record.item.localSessionId)));
+    setReviewed(false);
+    setProblem(null);
+    setResult(null);
+    setPhase('select');
+    setFixtureAttempt(0);
+  };
+
+  const narrow = (nextSearch: string, nextWindow: ShareWindow) => {
+    const nextVisible = filterShareCandidates(candidates, nextSearch, nextWindow);
+    replaceSelection(reconcileVisibleSelection(currentSelection, nextVisible));
+    setSearch(nextSearch);
+    setWindow(nextWindow);
+  };
+
+  const reviewExactPayloads = async () => {
+    if (destination == null || selectedCandidates.length === 0) return;
+    const generation = ++previewGeneration.current;
+    const prior = new Map(records.map((record) => [record.item.localSessionId, record]));
+    setPhase('loading');
+    setProblem(null);
+    try {
+      const nextRecords = await Promise.all(
+        selectedCandidates.map(async (candidate) => {
+          const { session } = candidate;
+          const existing = prior.get(localSessionId(session));
+          if (existing && consentStillCurrent(existing.item, session, existing.preview, destination)) {
+            return existing;
+          }
+          const response = await apiFetch(previewRequestPath(session.id, session.mtime));
+          if (!response.ok) throw new Error(`Preview request failed (${response.status}).`);
+          const preview = (await response.json()) as SnapshotPreview;
+          const item = bindPreviewConsent(
+            session,
+            preview,
+            destination,
+            `${HUB_SHARE_VERSION}:${crypto.randomUUID()}`,
+          );
+          return { candidate, preview, item, payload: formatCanonicalJson(canonicalPayloadText(preview)) };
+        }),
+      );
+      if (generation !== previewGeneration.current) return;
+      setRecords(nextRecords);
+      setReviewed(false);
+      setPhase('review');
+    } catch (error) {
+      if (generation !== previewGeneration.current) return;
+      setProblem(error instanceof Error ? error.message : 'The exact preview could not be built.');
+      setPhase('select');
+    }
+  };
+
+  const exerciseFixtureResult = () => {
+    if (!reviewed || records.length === 0 || !reviewStillCurrent) return;
+    const partial = fixtureOutcome === 'partial' && fixtureAttempt === 0 && records.length > 1;
+    const results: ShareResult['results'] = records.map((record, index) => {
+      if (partial && index === records.length - 1) {
+        return {
+          localSessionId: record.item.localSessionId,
+          idempotencyKey: record.item.idempotencyKey,
+          state: 'failed',
+          deduplicated: false,
+          error: { code: 'temporary_unavailable', retryable: true, retryAfterSeconds: 5 },
+        };
+      }
+      const suffix = String(index + 1).padStart(12, '0');
+      const repositoryId = `80000000-0000-4000-8000-${suffix}`;
+      const alreadyAccepted = record.candidate.previouslyShared;
+      return {
+        localSessionId: record.item.localSessionId,
+        idempotencyKey: record.item.idempotencyKey,
+        state: alreadyAccepted ? 'already_accepted' : 'accepted',
+        sessionId: `60000000-0000-4000-8000-${suffix}`,
+        revisionId: `70000000-0000-4000-8000-${suffix}`,
+        deduplicated: alreadyAccepted,
+        sharedAt: '2026-08-18T18:00:00Z',
+        briefState: 'pending',
+        route: {
+          hubContractVersion: 'hub-read/v1',
+          repositoryId,
+          canonicalWeekStart: '2026-08-17',
+          path: `/repos/${repositoryId}/sessions/2026-08-17`,
+        },
+      };
+    });
+    setResult({
+      contractVersion: HUB_SHARE_VERSION,
+      requestId: crypto.randomUUID(),
+      state: partial ? 'partial' : 'succeeded',
+      results,
+    });
+    setPhase('result');
+  };
+
+  const retryPartial = () => {
+    if (!result) return;
+    const plan = planShareRetry(result);
+    const retry = new Set([...plan.unchanged, ...plan.renewedReview]);
+    if (retry.size === 0) return;
+    setSelected(retry);
+    setRecords((current) => current.filter((record) => plan.unchanged.has(record.item.localSessionId)));
+    setReviewed(plan.renewedReview.size === 0);
+    setProblem(
+      plan.renewedReview.size > 0
+        ? 'The failed sessions require a refreshed preview and explicit approval.'
+        : null,
+    );
+    setResult(null);
+    setFixtureAttempt((current) => current + 1);
+    setPhase(plan.renewedReview.size > 0 ? 'select' : 'review');
+  };
+
+  const eligibility = destinationResult.state === 'ready' ? null : ELIGIBILITY_COPY[destinationResult.state];
+  const route = result ? primarySuccessRoute(result) : null;
+  const retryPlan = result ? planShareRetry(result) : null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[calc(100vh-2rem)] w-[min(56rem,calc(100vw-2rem))] max-w-none! flex-col overflow-hidden">
+        <DialogHeader>
+          <div className="flex items-center gap-2">
+            <DialogTitle>Share to Hub</DialogTitle>
+            <Badge variant="secondary">FIXTURE BUILD · NO UPLOAD</Badge>
+          </div>
+          <DialogDescription>
+            Select sessions, review C2's exact canonical bytes, and exercise the T2-I4 retry/result states.
+          </DialogDescription>
+        </DialogHeader>
+
+        {destination == null ? (
+          <div
+            role="status"
+            className="flex min-h-72 flex-col items-center justify-center rounded-xl border p-8 text-center"
+          >
+            <AlertTriangleIcon className="text-warning-fg size-7" />
+            <h3 className="mt-3 font-semibold">{eligibility?.title}</h3>
+            <p className="text-muted-foreground mt-2 max-w-md text-sm">{eligibility?.detail}</p>
+            <Button className="mt-5" onClick={onOpenSettings}>
+              {eligibility?.action}
+            </Button>
+          </div>
+        ) : (
+          <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden">
+            <div className="bg-info-bg text-info-fg flex flex-wrap items-center justify-between gap-3 rounded-lg border p-3">
+              <div>
+                <div className="text-sm font-semibold">{destination.workspaceName}</div>
+                <div className="pt-0.5 text-xs">
+                  {destination.currentMemberCount}{' '}
+                  {destination.currentMemberCount === 1 ? 'member' : 'members'} can see approved revisions
+                </div>
+              </div>
+              <div className="flex items-center gap-1.5 text-xs font-semibold">
+                <ShieldCheckIcon className="size-4" /> Paired destination
+              </div>
+            </div>
+
+            {phase === 'select' && (
+              <>
+                <div className="flex flex-wrap items-center gap-2">
+                  <div className="relative min-w-48 flex-1">
+                    <SearchIcon className="text-muted-foreground pointer-events-none absolute top-2 left-2.5 size-4" />
+                    <Input
+                      aria-label="Filter shareable sessions"
+                      className="pl-8"
+                      placeholder="Filter sessions"
+                      value={search}
+                      onChange={(event) => narrow(event.target.value, window)}
+                    />
+                  </div>
+                  <div className="bg-muted flex rounded-lg p-1" aria-label="Share time window">
+                    {(['7d', '30d', 'all'] as const).map((value) => (
+                      <Button
+                        key={value}
+                        size="sm"
+                        variant={window === value ? 'secondary' : 'ghost'}
+                        onClick={() => narrow(search, value)}
+                      >
+                        {value === '7d' ? '7 days' : value === '30d' ? '30 days' : 'All time'}
+                      </Button>
+                    ))}
+                  </div>
+                </div>
+
+                {problem && (
+                  <div role="alert" className="bg-warning-bg text-warning-fg rounded-lg border p-3 text-sm">
+                    {problem} Sharing remains off.
+                  </div>
+                )}
+
+                <div className="flex items-center justify-between gap-3 text-sm">
+                  <span>
+                    {selectedCandidates.length ? `${selectedCandidates.length} selected` : 'Nothing selected'}
+                  </span>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => replaceSelection(toggleCandidateGroup(currentSelection, visible))}
+                    disabled={visible.length === 0}
+                  >
+                    {visible.length > 0 &&
+                    visible.every(({ session }) => currentSelection.has(localSessionId(session)))
+                      ? 'Clear filtered'
+                      : 'Select all filtered'}
+                  </Button>
+                </div>
+
+                <div className="min-h-0 flex-1 overflow-y-auto rounded-lg border">
+                  {groups.length === 0 && (
+                    <div className="text-muted-foreground p-8 text-center text-sm">
+                      No sessions match this filter.
+                    </div>
+                  )}
+                  {groups.map(([repository, rows]) => {
+                    const allSelected = rows.every(({ session }) =>
+                      currentSelection.has(localSessionId(session)),
+                    );
+                    return (
+                      <section key={repository} className="border-b last:border-b-0">
+                        <div className="bg-muted/60 flex items-center justify-between gap-3 px-3 py-2">
+                          <span className="font-mono text-xs font-semibold">{repository}</span>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => replaceSelection(toggleCandidateGroup(currentSelection, rows))}
+                          >
+                            {allSelected ? 'Clear repository' : 'Select repository'}
+                          </Button>
+                        </div>
+                        {rows.map((candidate) => {
+                          const key = localSessionId(candidate.session);
+                          return (
+                            <label
+                              key={key}
+                              className="hover:bg-muted/30 flex cursor-pointer items-start gap-3 border-t px-3 py-3 first:border-t-0"
+                            >
+                              <input
+                                type="checkbox"
+                                className="mt-1 size-4"
+                                checked={currentSelection.has(key)}
+                                onChange={() => replaceSelection(toggleCandidate(currentSelection, key))}
+                              />
+                              <span className="min-w-0 flex-1">
+                                <span className="block truncate text-sm font-medium">
+                                  {candidate.session.name ?? candidate.session.id}
+                                </span>
+                                <span className="text-muted-foreground block truncate pt-0.5 text-xs">
+                                  {candidate.session.agent} · {candidate.session.branch ?? 'no branch'} ·
+                                  revision {candidate.session.mtime}
+                                </span>
+                              </span>
+                              {candidate.previouslyShared && (
+                                <Badge variant="secondary">Previously shared · re-share</Badge>
+                              )}
+                            </label>
+                          );
+                        })}
+                      </section>
+                    );
+                  })}
+                </div>
+              </>
+            )}
+
+            {phase === 'loading' && (
+              <div role="status" className="grid min-h-72 place-items-center text-sm">
+                Building exact canonical previews…
+              </div>
+            )}
+
+            {phase === 'review' && (
+              <div className="min-h-0 flex-1 overflow-y-auto">
+                <div className="bg-warning-bg text-warning-fg rounded-lg border p-3 text-sm">
+                  Review binds these exact source revisions and payload hashes to {destination.workspaceName}.
+                  Any change requires a new review.
+                </div>
+                <div className="mt-3 space-y-3">
+                  {records.map((record) => (
+                    <details
+                      key={record.item.localSessionId}
+                      className="rounded-lg border p-3"
+                      open={records.length === 1}
+                    >
+                      <summary className="cursor-pointer text-sm font-semibold">
+                        {record.candidate.session.name ?? record.candidate.session.id} ·{' '}
+                        {record.preview.payloadBytes?.toLocaleString()} bytes
+                      </summary>
+                      <div className="text-muted-foreground mt-2 font-mono text-xs break-all">
+                        {record.item.consent.contentHash}
+                      </div>
+                      <pre className="bg-muted mt-3 max-h-72 overflow-auto rounded-lg border p-3 font-mono text-[11px] leading-relaxed whitespace-pre">
+                        {record.payload}
+                      </pre>
+                    </details>
+                  ))}
+                </div>
+                <label className="mt-4 flex cursor-pointer items-start gap-3 rounded-lg border p-3 text-sm">
+                  <input
+                    type="checkbox"
+                    className="mt-0.5 size-4"
+                    checked={reviewed}
+                    onChange={(event) => setReviewed(event.target.checked)}
+                  />
+                  <span>
+                    I approve these exact {records.length} {records.length === 1 ? 'revision' : 'revisions'}{' '}
+                    for {destination.workspaceName} and its {destination.currentMemberCount}{' '}
+                    {destination.currentMemberCount === 1 ? 'member' : 'members'}.
+                  </span>
+                </label>
+              </div>
+            )}
+
+            {phase === 'result' && result && (
+              <div className="min-h-0 flex-1 overflow-y-auto">
+                <div
+                  className={
+                    result.state === 'succeeded'
+                      ? 'bg-success-bg text-success-fg rounded-lg border p-4'
+                      : 'bg-warning-bg text-warning-fg rounded-lg border p-4'
+                  }
+                >
+                  <div className="flex items-center gap-2 font-semibold">
+                    {result.state === 'succeeded' ? (
+                      <CheckIcon className="size-4" />
+                    ) : (
+                      <AlertTriangleIcon className="size-4" />
+                    )}
+                    {result.state === 'succeeded'
+                      ? 'Fixture share accepted'
+                      : 'Fixture batch partially accepted'}
+                  </div>
+                  <p className="pt-2 text-sm">
+                    Accepted uploads are visible immediately; their brief remains pending. No synthesis
+                    completion is claimed.
+                  </p>
+                </div>
+                <div className="mt-3 rounded-lg border">
+                  {result.results.map((item) => (
+                    <div
+                      key={item.localSessionId}
+                      className="flex items-center justify-between gap-3 border-b p-3 text-sm last:border-b-0"
+                    >
+                      <span className="min-w-0 truncate font-mono text-xs">{item.localSessionId}</span>
+                      {item.state === 'failed' ? (
+                        <Badge variant="secondary">
+                          {item.error.code} ·{' '}
+                          {!item.error.retryable || !RETRY_RULES[item.error.code].retryable
+                            ? 'not retryable'
+                            : RETRY_RULES[item.error.code].renewedReview
+                              ? 'review required'
+                              : 'retry preserved'}
+                        </Badge>
+                      ) : (
+                        <Badge variant="secondary">
+                          {item.state} · brief {item.briefState}
+                        </Badge>
+                      )}
+                    </div>
+                  ))}
+                </div>
+                {route && (
+                  <div className="mt-3 rounded-lg border p-3 text-sm">
+                    <div className="flex items-center gap-2 font-semibold">
+                      <ExternalLinkIcon className="size-4" /> Canonical Hub handoff
+                    </div>
+                    <div className="text-muted-foreground mt-2 font-mono text-xs break-all">{route.path}</div>
+                    <p className="text-muted-foreground mt-2 text-xs">
+                      The integrated client will navigate to this C3-owned route. This fixture build does not
+                      leave the local app.
+                    </p>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
+        <DialogFooter>
+          {phase === 'select' && destinationResult.state === 'ready' && (
+            <Button onClick={reviewExactPayloads} disabled={selectedCandidates.length === 0}>
+              See what gets shared
+            </Button>
+          )}
+          {phase === 'review' && destinationResult.state === 'ready' && (
+            <>
+              <Button variant="outline" onClick={() => setPhase('select')}>
+                Back to selection
+              </Button>
+              <Button onClick={exerciseFixtureResult} disabled={!reviewed}>
+                Exercise fixture result
+              </Button>
+            </>
+          )}
+          {phase === 'result' &&
+            result?.state === 'partial' &&
+            retryPlan != null &&
+            retryPlan.unchanged.size + retryPlan.renewedReview.size > 0 && (
+              <Button onClick={retryPartial}>
+                {retryPlan.renewedReview.size > 0
+                  ? 'Review failed sessions again'
+                  : 'Retry failed with same key'}
+              </Button>
+            )}
+          {phase === 'result' && result?.state === 'succeeded' && (
+            <Button variant="outline" onClick={() => onOpenChange(false)}>
+              Done
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/pages/coslash/features/sharing/model.test.ts
+++ b/frontend/src/pages/coslash/features/sharing/model.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+import type { SnapshotPreview } from '@/pages/coslash/lib/preview';
+import type { Session } from '@/pages/coslash/lib/session';
+import {
+  bindPreviewConsent,
+  consentStillCurrent,
+  filterShareCandidates,
+  localSessionId,
+  planShareRetry,
+  primarySuccessRoute,
+  reconcileVisibleSelection,
+  RETRY_RULES,
+  toggleCandidateGroup,
+  type ShareCandidate,
+  type ShareDestination,
+  type ShareResult,
+} from './model';
+
+const destination: ShareDestination = {
+  workspaceId: '10000000-0000-4000-8000-000000000001',
+  workspaceName: 'Compiler Team',
+  currentMemberCount: 2,
+  resultingMemberCount: 2,
+  currentApprovedSessionCount: 3,
+  historyDisclosure: 'Current members can see approved revisions.',
+  credentialState: 'paired',
+};
+
+function session(id: string, repo: string, mtime: number): Session {
+  return {
+    agent: 'codex',
+    id,
+    name: `Session ${id}`,
+    summary: null,
+    status: null,
+    cwd: `/src/${repo}`,
+    branch: 'main',
+    repo,
+    repoLocalOnly: false,
+    files: 1,
+    durationMs: 1,
+    tokens: {},
+    cost: 0,
+    unpricedModels: [],
+    subagents: [],
+    mtime,
+    entrypoint: null,
+    synthesis: null,
+    synthesisPending: false,
+    declaredGoal: null,
+    model: null,
+    contextTokens: null,
+    contextWindow: null,
+    turns: 1,
+    toolUses: 1,
+    errors: 0,
+    compactions: 0,
+    firstPrompt: null,
+    commands: [],
+    commits: [],
+    prs: 0,
+    todos: [],
+    digest: [],
+    fileEdits: [],
+    git: null,
+    lastEditAt: null,
+  };
+}
+
+function preview(sourceRevision: number, hash = `sha256:${'a'.repeat(64)}`): SnapshotPreview {
+  const snapshot = { schemaVersion: 'session-snapshot/v1', contentHash: hash } as SnapshotPreview['snapshot'];
+  const payload = JSON.stringify(snapshot);
+  return {
+    adapterVersion: 'snapshot-preview/v1',
+    state: 'ready',
+    approvalAllowed: true,
+    sourceRevision,
+    schemaVersion: 'session-snapshot/v1',
+    mediaType: 'application/vnd.coslash.session-snapshot.v1+json',
+    payloadBytes: new TextEncoder().encode(payload).byteLength,
+    maxPayloadBytes: 262_144,
+    canonicalPayloadBase64: btoa(payload),
+    snapshot,
+  };
+}
+
+describe('hub-share/v1 public consumer', () => {
+  const now = Date.UTC(2026, 7, 18);
+  const candidates: ShareCandidate[] = [
+    { session: session('new', 'alpha', now - 2 * 86_400_000), previouslyShared: false },
+    { session: session('old', 'beta', now - 20 * 86_400_000), previouslyShared: true },
+  ];
+
+  it('filters deterministically and deselects newly hidden approvals', () => {
+    const all = filterShareCandidates(candidates, '', 'all', now);
+    const selected = toggleCandidateGroup(new Set(), all);
+    expect(selected.size).toBe(2);
+    const narrowed = filterShareCandidates(candidates, 'alpha', '7d', now);
+    expect([...reconcileVisibleSelection(selected, narrowed)]).toEqual([
+      localSessionId(candidates[0]!.session),
+    ]);
+  });
+
+  it('binds approval to exact canonical bytes, source revision, and destination', () => {
+    const chosen = candidates[0]!.session;
+    const exact = preview(chosen.mtime);
+    const item = bindPreviewConsent(chosen, exact, destination, 'synthetic-idempotency-key-0001');
+    expect(item.consent.contentHash).toBe('a'.repeat(64));
+    expect(consentStillCurrent(item, chosen, exact, destination)).toBe(true);
+    expect(
+      consentStillCurrent(item, chosen, preview(chosen.mtime, `sha256:${'b'.repeat(64)}`), destination),
+    ).toBe(false);
+    expect(consentStillCurrent(item, chosen, exact, { ...destination, workspaceId: 'changed' })).toBe(false);
+    expect(consentStillCurrent(item, { ...chosen, mtime: chosen.mtime + 1 }, exact, destination)).toBe(false);
+    expect(() =>
+      bindPreviewConsent(chosen, preview(chosen.mtime + 1), destination, 'synthetic-idempotency-key-0001'),
+    ).toThrow(/source revision/);
+  });
+
+  it('preserves only retryable partial failures and returns the canonical success route', () => {
+    const result: ShareResult = {
+      contractVersion: 'hub-share/v1',
+      requestId: 'request',
+      state: 'partial',
+      results: [
+        {
+          localSessionId: 'codex:new',
+          idempotencyKey: 'key-accepted-0000001',
+          state: 'accepted',
+          sessionId: 'session',
+          revisionId: 'revision',
+          deduplicated: false,
+          sharedAt: '2026-08-18T18:00:00Z',
+          briefState: 'pending',
+          route: {
+            hubContractVersion: 'hub-read/v1',
+            repositoryId: 'repo',
+            canonicalWeekStart: '2026-08-17',
+            path: '/repos/repo/sessions/2026-08-17',
+          },
+        },
+        {
+          localSessionId: 'codex:old',
+          idempotencyKey: 'key-failed-00000001',
+          state: 'failed',
+          deduplicated: false,
+          error: { code: 'temporary_unavailable', retryable: true },
+        },
+        {
+          localSessionId: 'codex:stale',
+          idempotencyKey: 'key-stale-0000000001',
+          state: 'failed',
+          deduplicated: false,
+          error: { code: 'consent_stale', retryable: true },
+        },
+      ],
+    };
+    const plan = planShareRetry(result);
+    expect([...plan.unchanged]).toEqual(['codex:old']);
+    expect([...plan.renewedReview]).toEqual(['codex:stale']);
+    expect(primarySuccessRoute(result)?.path).toBe('/repos/repo/sessions/2026-08-17');
+    expect(result.results[0]!.state !== 'failed' && result.results[0]!.briefState).toBe('pending');
+  });
+
+  it('publishes a complete retry decision for every stable error', () => {
+    expect(Object.keys(RETRY_RULES)).toHaveLength(15);
+    expect(RETRY_RULES.timeout).toEqual(expect.objectContaining({ retryable: true, renewedReview: false }));
+    expect(RETRY_RULES.destination_changed).toEqual(expect.objectContaining({ renewedReview: true }));
+    expect(RETRY_RULES.credential_revoked).toEqual(expect.objectContaining({ retryable: false }));
+  });
+});

--- a/frontend/src/pages/coslash/features/sharing/model.ts
+++ b/frontend/src/pages/coslash/features/sharing/model.ts
@@ -1,0 +1,308 @@
+import { canonicalUploadBytes, type SnapshotPreview } from '@/pages/coslash/lib/preview';
+import type { Session } from '@/pages/coslash/lib/session';
+
+// C4 contract; provider fixtures live in coslash-server/testdata/hub-share-v1.
+export const HUB_SHARE_VERSION = 'hub-share/v1' as const;
+
+export type EligibilityState =
+  'signed_out' | 'pairing_required' | 'credential_dormant' | 'credential_revoked' | 'ready';
+
+export type ShareDestination = {
+  workspaceId: string;
+  workspaceName: string;
+  currentMemberCount: number;
+  resultingMemberCount: number;
+  currentApprovedSessionCount: number;
+  historyDisclosure: string;
+  credentialState: 'paired' | 'dormant' | 'revoked';
+};
+
+export type DestinationResult =
+  | { contractVersion: typeof HUB_SHARE_VERSION; state: 'ready'; destination: ShareDestination }
+  | { contractVersion: typeof HUB_SHARE_VERSION; state: Exclude<EligibilityState, 'ready'> };
+
+export type ConsentBinding = {
+  previewContractVersion: 'snapshot-preview/v1';
+  sourceRevision: number;
+  contentHash: string;
+  payloadBytes: number;
+  destinationWorkspaceId: string;
+};
+
+export type ShareItemRequest = {
+  localSessionId: string;
+  idempotencyKey: string;
+  consent: ConsentBinding;
+};
+
+export type ShareRequest = {
+  contractVersion: typeof HUB_SHARE_VERSION;
+  requestId: string;
+  items: ShareItemRequest[];
+};
+
+export type ShareError =
+  | 'invalid_share_request'
+  | 'unsupported_snapshot_version'
+  | 'snapshot_invalid'
+  | 'snapshot_too_large'
+  | 'unauthorized'
+  | 'credential_dormant'
+  | 'credential_revoked'
+  | 'consent_stale'
+  | 'destination_changed'
+  | 'idempotency_conflict'
+  | 'rate_limited'
+  | 'network_unavailable'
+  | 'timeout'
+  | 'temporary_unavailable'
+  | 'share_failed';
+
+export type ItemError = { code: ShareError; retryable: boolean; retryAfterSeconds?: number };
+
+export type RouteHandoff = {
+  hubContractVersion: 'hub-read/v1';
+  repositoryId: string;
+  canonicalWeekStart: string;
+  path: string;
+};
+
+export type ShareItemResult =
+  | {
+      localSessionId: string;
+      idempotencyKey: string;
+      state: 'accepted' | 'already_accepted';
+      sessionId: string;
+      revisionId: string;
+      deduplicated: boolean;
+      sharedAt: string;
+      briefState: 'pending' | 'ready' | 'failed' | 'unavailable';
+      route: RouteHandoff;
+    }
+  | {
+      localSessionId: string;
+      idempotencyKey: string;
+      state: 'failed';
+      deduplicated: false;
+      error: ItemError;
+    };
+
+export type ShareResult = {
+  contractVersion: typeof HUB_SHARE_VERSION;
+  requestId: string;
+  state: 'succeeded' | 'partial' | 'failed';
+  results: ShareItemResult[];
+};
+
+export type ShareWindow = '7d' | '30d' | 'all';
+export type ShareCandidate = { session: Session; previouslyShared: boolean };
+
+export const RETRY_RULES: Record<ShareError, { retryable: boolean; renewedReview: boolean; action: string }> =
+  {
+    invalid_share_request: {
+      retryable: false,
+      renewedReview: true,
+      action: 'Review the selected sessions again.',
+    },
+    unsupported_snapshot_version: {
+      retryable: false,
+      renewedReview: true,
+      action: 'Update coSlash and build a new preview.',
+    },
+    snapshot_invalid: {
+      retryable: false,
+      renewedReview: true,
+      action: 'Refresh the source and build a new preview.',
+    },
+    snapshot_too_large: {
+      retryable: false,
+      renewedReview: true,
+      action: 'Reduce the source evidence and build a new preview.',
+    },
+    unauthorized: {
+      retryable: true,
+      renewedReview: false,
+      action: 'Sign in or pair again, then retry the unchanged selection.',
+    },
+    credential_dormant: {
+      retryable: true,
+      renewedReview: true,
+      action: 'Select the paired workspace and review the destination again.',
+    },
+    credential_revoked: {
+      retryable: false,
+      renewedReview: true,
+      action: 'Pair this device again before sharing.',
+    },
+    consent_stale: {
+      retryable: true,
+      renewedReview: true,
+      action: 'Review the changed source revision and approve it again.',
+    },
+    destination_changed: {
+      retryable: true,
+      renewedReview: true,
+      action: 'Review the current workspace destination and approve it again.',
+    },
+    idempotency_conflict: {
+      retryable: false,
+      renewedReview: true,
+      action: 'Stop retrying this key and build a new preview.',
+    },
+    rate_limited: {
+      retryable: true,
+      renewedReview: false,
+      action: 'Keep the selection and retry after the server delay.',
+    },
+    network_unavailable: {
+      retryable: true,
+      renewedReview: false,
+      action: 'Keep the selection and retry when the network returns.',
+    },
+    timeout: {
+      retryable: true,
+      renewedReview: false,
+      action: 'Check upload status with the same key before retrying.',
+    },
+    temporary_unavailable: {
+      retryable: true,
+      renewedReview: false,
+      action: 'Keep failed items selected and retry with their original keys.',
+    },
+    share_failed: {
+      retryable: true,
+      renewedReview: false,
+      action: 'Keep failed items selected and retry with their original keys.',
+    },
+  };
+
+export function localSessionId(session: Pick<Session, 'agent' | 'id'>): string {
+  return `${session.agent}:${session.id}`;
+}
+
+export function filterShareCandidates(
+  candidates: ShareCandidate[],
+  search: string,
+  window: ShareWindow,
+  now = Date.now(),
+): ShareCandidate[] {
+  const normalized = search.trim().toLowerCase();
+  const minimum = window === 'all' ? null : now - (window === '7d' ? 7 : 30) * 24 * 60 * 60 * 1000;
+  return candidates.filter(({ session }) => {
+    if (minimum != null && session.status == null && session.mtime < minimum) return false;
+    if (!normalized) return true;
+    return [session.name, session.repo, session.branch, session.id, session.agent]
+      .filter((value): value is string => value != null)
+      .some((value) => value.toLowerCase().includes(normalized));
+  });
+}
+
+// Hidden approval is unsafe. Narrowing either filter removes newly hidden rows.
+export function reconcileVisibleSelection(
+  selected: ReadonlySet<string>,
+  visible: ShareCandidate[],
+): Set<string> {
+  const visibleKeys = new Set(visible.map(({ session }) => localSessionId(session)));
+  return new Set([...selected].filter((key) => visibleKeys.has(key)));
+}
+
+export function toggleCandidate(selected: ReadonlySet<string>, key: string): Set<string> {
+  const next = new Set(selected);
+  if (next.has(key)) next.delete(key);
+  else next.add(key);
+  return next;
+}
+
+export function toggleCandidateGroup(
+  selected: ReadonlySet<string>,
+  candidates: ShareCandidate[],
+): Set<string> {
+  const next = new Set(selected);
+  const keys = candidates.map(({ session }) => localSessionId(session));
+  const allSelected = keys.length > 0 && keys.every((key) => next.has(key));
+  for (const key of keys) {
+    if (allSelected) next.delete(key);
+    else next.add(key);
+  }
+  return next;
+}
+
+export function bindPreviewConsent(
+  session: Pick<Session, 'id' | 'agent' | 'mtime'>,
+  preview: SnapshotPreview,
+  destination: ShareDestination,
+  idempotencyKey: string,
+): ShareItemRequest {
+  canonicalUploadBytes(preview);
+  const contentHash = hubContentHash(preview);
+  if (
+    preview.adapterVersion !== 'snapshot-preview/v1' ||
+    preview.sourceRevision !== session.mtime ||
+    contentHash == null ||
+    preview.payloadBytes == null
+  ) {
+    throw new Error('The preview no longer matches the selected source revision.');
+  }
+  if (destination.credentialState !== 'paired') {
+    throw new Error('The destination credential is not ready.');
+  }
+  if (idempotencyKey.length < 16 || idempotencyKey.length > 200) {
+    throw new Error('The idempotency key is outside the contract bounds.');
+  }
+  return {
+    localSessionId: localSessionId(session),
+    idempotencyKey,
+    consent: {
+      previewContractVersion: preview.adapterVersion,
+      sourceRevision: preview.sourceRevision,
+      contentHash,
+      payloadBytes: preview.payloadBytes,
+      destinationWorkspaceId: destination.workspaceId,
+    },
+  };
+}
+
+export function consentStillCurrent(
+  item: ShareItemRequest,
+  session: Pick<Session, 'id' | 'agent' | 'mtime'>,
+  preview: SnapshotPreview,
+  destination: ShareDestination,
+): boolean {
+  const hash = hubContentHash(preview);
+  return (
+    preview.state === 'ready' &&
+    preview.approvalAllowed &&
+    item.localSessionId === localSessionId(session) &&
+    item.consent.previewContractVersion === preview.adapterVersion &&
+    item.consent.sourceRevision === session.mtime &&
+    item.consent.sourceRevision === preview.sourceRevision &&
+    item.consent.contentHash === hash &&
+    item.consent.payloadBytes === preview.payloadBytes &&
+    item.consent.destinationWorkspaceId === destination.workspaceId &&
+    destination.credentialState === 'paired'
+  );
+}
+
+function hubContentHash(preview: SnapshotPreview): string | null {
+  const value = preview.snapshot?.contentHash;
+  const match = typeof value === 'string' ? /^sha256:([0-9a-f]{64})$/.exec(value) : null;
+  return match?.[1] ?? null;
+}
+
+export function planShareRetry(result: ShareResult): {
+  unchanged: Set<string>;
+  renewedReview: Set<string>;
+} {
+  const plan = { unchanged: new Set<string>(), renewedReview: new Set<string>() };
+  for (const item of result.results) {
+    if (item.state !== 'failed' || !item.error.retryable) continue;
+    const rule = RETRY_RULES[item.error.code];
+    if (!rule.retryable) continue;
+    plan[rule.renewedReview ? 'renewedReview' : 'unchanged'].add(item.localSessionId);
+  }
+  return plan;
+}
+
+export function primarySuccessRoute(result: ShareResult): RouteHandoff | null {
+  return result.results.find((item) => item.state !== 'failed')?.route ?? null;
+}


### PR DESCRIPTION
## Summary

This PR adds a fixture-backed **Share to Hub** flow for reviewing the future opt-in sharing experience.

- select sessions by repository and time window
- review the exact canonical payload before approval
- bind consent to the source revision, payload hash and size, and destination workspace
- invalidate stale reviews and ignore late preview responses
- preserve unchanged retries while requiring renewed approval when the source or destination changes
- exclude accepted items from partial retries and expose the canonical Hub route after success

## Try it locally

Append `?team-share=1` to the local coSlash URL.

- `&share-state=signed_out`
- `&share-state=pairing_required`
- `&share-state=credential_dormant`
- `&share-state=credential_revoked`
- `&share-result=partial`

## Scope

This is a clearly labeled **NO UPLOAD** build harness. It does not add real authentication, credential storage, ingestion, persistence, or navigation. Production acceptance remains gated on the end-to-end cloud integration.

## Verification

- 23 frontend tests
- production frontend build
- frontend lint and format checks
- `go test ./...`
- `go vet ./...`
- `git diff --check`
- no Go `*_test.go` files changed

Browser QA remains pending.

<img width="979" height="541" alt="image" src="https://github.com/user-attachments/assets/5627b776-cb62-4a15-b3a6-7c49f54669e2" />

