### PR TITLE
Count only confirmed PRs in Codex sessions

### DIFF
--- a/collector/internal/vendors/codex/parse.go
+++ b/collector/internal/vendors/codex/parse.go
@@ -166,9 +166,10 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 	ownID := SessionIDFromRollout(file)
 	var metas []codexMeta
 	analysis := &codexSessionAnalysis{
-		spawns:    map[string]vendors.SpawnState{},
-		fileEdits: session.NewFileEditSet(),
-		commitLog: commitObservationsByCall(rows),
+		spawns:       map[string]vendors.SpawnState{},
+		fileEdits:    session.NewFileEditSet(),
+		commitLog:    commitObservationsByCall(rows),
+		pullRequests: len(pullRequestURLs(rows)),
 	}
 	for _, row := range rows {
 		var timestamp *int64
@@ -320,9 +321,6 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 				analysis.toolUseCount++
 				if command, ok := commandFrom(row.Payload); ok {
 					analysis.commands.Note(command, "")
-					if session.IsPullRequestCreate(command) {
-						analysis.pullRequests++
-					}
 				}
 				if questions := questionsFrom(row.Payload); len(questions) > 0 {
 					for _, question := range questions {
@@ -565,6 +563,12 @@ func unifiedDiffStat(diff string) (additions, deletions int) {
 var execCmdPattern = regexp.MustCompile(
 	`(?:^|[{,]\s*)(?:"cmd"|cmd)\s*:\s*("(?:[^"\\]|\\.)*")`,
 )
+var pullRequestURLPattern = regexp.MustCompile(
+	`https://github\.com/[^/\s"]+/[^/\s"]+/pull/[0-9]+`,
+)
+var pullRequestDirectivePattern = regexp.MustCompile(
+	`::git-create-pr\{[^}\n]*\burl="(https://github\.com/[^/\s"]+/[^/\s"]+/pull/[0-9]+)"[^}\n]*\}`,
+)
 var requestUserInputCallPattern = regexp.MustCompile(`\brequest_user_input\s*\(`)
 var questionIDPattern = regexp.MustCompile(`"id"\s*:\s*("(?:[^"\\]|\\.)*")`)
 var questionPattern = regexp.MustCompile(`"question"\s*:\s*("(?:[^"\\]|\\.)*")`)
@@ -697,6 +701,48 @@ func questionAnswersByCall(rows []codexRow) map[string]map[string]codexQuestionA
 type codexCommandResult struct {
 	output    string
 	succeeded bool
+}
+
+func pullRequestURLs(rows []codexRow) map[string]struct{} {
+	pending := map[string]struct{}{}
+	urls := map[string]struct{}{}
+	for _, row := range rows {
+		if row.Type != "response_item" {
+			continue
+		}
+		switch row.Payload.Type {
+		case "message":
+			if row.Payload.Role != "assistant" || row.Payload.Phase != "final_answer" {
+				continue
+			}
+			var content []codexText
+			if json.Unmarshal(row.Payload.Content, &content) != nil {
+				continue
+			}
+			for _, block := range content {
+				for _, match := range pullRequestDirectivePattern.FindAllStringSubmatch(block.Text, -1) {
+					urls[match[1]] = struct{}{}
+				}
+			}
+		case "function_call", "custom_tool_call":
+			if command, ok := commandFrom(row.Payload); ok &&
+				row.Payload.CallID != "" && session.IsPullRequestCreate(command) {
+				pending[row.Payload.CallID] = struct{}{}
+			}
+		case "function_call_output", "custom_tool_call_output":
+			if _, ok := pending[row.Payload.CallID]; !ok {
+				continue
+			}
+			result := decodeCodexCommandResult(row.Payload.Output)
+			if result.succeeded {
+				for _, url := range pullRequestURLPattern.FindAllString(result.output, -1) {
+					urls[url] = struct{}{}
+				}
+			}
+			delete(pending, row.Payload.CallID)
+		}
+	}
+	return urls
 }
 
 func commitObservationsByCall(rows []codexRow) []session.CommitObservation {

--- a/collector/internal/vendors/codex/parse.go
+++ b/collector/internal/vendors/codex/parse.go
@@ -704,42 +704,33 @@ type codexCommandResult struct {
 }
 
 func pullRequestURLs(rows []codexRow) map[string]struct{} {
-	pending := map[string]struct{}{}
 	urls := map[string]struct{}{}
 	for _, row := range rows {
-		if row.Type != "response_item" {
-			continue
-		}
-		switch row.Payload.Type {
-		case "message":
-			if row.Payload.Role != "assistant" || row.Payload.Phase != "final_answer" {
-				continue
-			}
-			var content []codexText
-			if json.Unmarshal(row.Payload.Content, &content) != nil {
-				continue
-			}
-			for _, block := range content {
-				for _, match := range pullRequestDirectivePattern.FindAllStringSubmatch(block.Text, -1) {
-					urls[match[1]] = struct{}{}
-				}
-			}
-		case "function_call", "custom_tool_call":
-			if command, ok := commandFrom(row.Payload); ok &&
-				row.Payload.CallID != "" && session.IsPullRequestCreate(command) {
-				pending[row.Payload.CallID] = struct{}{}
-			}
-		case "function_call_output", "custom_tool_call_output":
-			if _, ok := pending[row.Payload.CallID]; !ok {
-				continue
-			}
-			result := decodeCodexCommandResult(row.Payload.Output)
-			if result.succeeded {
-				for _, url := range pullRequestURLPattern.FindAllString(result.output, -1) {
+		if row.Type == "event_msg" {
+			item := row.Payload.Item
+			if item.Type == "CommandExecution" && item.ExitCode != nil && *item.ExitCode == 0 &&
+				len(item.Command) > 0 && session.IsPullRequestCreate(item.Command[len(item.Command)-1]) {
+				for _, url := range pullRequestURLPattern.FindAllString(item.AggregatedOutput, -1) {
 					urls[url] = struct{}{}
 				}
 			}
-			delete(pending, row.Payload.CallID)
+			continue
+		}
+		if row.Type != "response_item" {
+			continue
+		}
+		if row.Payload.Type != "message" || row.Payload.Role != "assistant" ||
+			row.Payload.Phase != "final_answer" {
+			continue
+		}
+		var content []codexText
+		if json.Unmarshal(row.Payload.Content, &content) != nil {
+			continue
+		}
+		for _, block := range content {
+			for _, match := range pullRequestDirectivePattern.FindAllStringSubmatch(block.Text, -1) {
+				urls[match[1]] = struct{}{}
+			}
 		}
 	}
 	return urls

--- a/collector/internal/vendors/codex/types.go
+++ b/collector/internal/vendors/codex/types.go
@@ -45,12 +45,15 @@ type codexPayload struct {
 }
 
 type codexItem struct {
-	Type          string            `json:"type"`
-	Phase         string            `json:"phase"`
-	Content       []codexText       `json:"content"`
-	Changes       codexPatchChanges `json:"changes"`
-	Kind          string            `json:"kind"`
-	AgentThreadID string            `json:"agent_thread_id"`
+	Type             string            `json:"type"`
+	Phase            string            `json:"phase"`
+	Content          []codexText       `json:"content"`
+	Changes          codexPatchChanges `json:"changes"`
+	Kind             string            `json:"kind"`
+	AgentThreadID    string            `json:"agent_thread_id"`
+	Command          []string          `json:"command"`
+	AggregatedOutput string            `json:"aggregated_output"`
+	ExitCode         *int              `json:"exit_code"`
 }
 
 func subagentRole(source json.RawMessage) string {

--- a/collector/internal/vendors/codex/types.go
+++ b/collector/internal/vendors/codex/types.go
@@ -15,6 +15,7 @@ type codexRow struct {
 
 type codexPayload struct {
 	Type           string            `json:"type"`
+	Role           string            `json:"role"`
 	SessionID      string            `json:"session_id"`
 	UserFacingHint string            `json:"user_facing_hint"`
 	ForkedFromID   string            `json:"forked_from_id"`


### PR DESCRIPTION
## Context

The Codex session inspector counts every `gh pr create` invocation, including failed retries. The artifact count should reflect only unique, confirmed pull requests.

## Changes

- Count successful PR creation results and assistant success directives.
- Ignore failed attempts, quoted instructions, and commentary.
- Deduplicate repeated evidence for the same PR.

## Test

- Targeted Codex parser regression tests — passed
- `go build ./...` — passed
- `git diff --check` — passed