### PR TITLE
Show Codex sessions as Waiting when user action is required

### DIFF
--- a/collector/internal/vendors/codex/parse.go
+++ b/collector/internal/vendors/codex/parse.go
@@ -340,7 +340,9 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 				}
 				if questions := questionsFrom(row.Payload); len(questions) > 0 {
 					answers, answered := questionAnswers[row.Payload.CallID]
-					analysis.waitingForInput = analysis.waitingForInput || !answered
+					_, completed := completedCalls[row.Payload.CallID]
+					analysis.waitingForInput = analysis.waitingForInput ||
+						(!answered && (row.Payload.Name == "request_user_input" || !completed))
 					for _, question := range questions {
 						answer := strings.Join(answers[question.id].values(), ", ")
 						ts := int64(0)

--- a/collector/internal/vendors/codex/parse.go
+++ b/collector/internal/vendors/codex/parse.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -43,6 +46,7 @@ type codexSessionAnalysis struct {
 	plan             []planStep
 	turnDepth        int
 	waitingForInput  bool
+	approvalPending  bool
 	lastTurnAborted  bool
 	inReview         bool
 }
@@ -50,6 +54,7 @@ type codexSessionAnalysis struct {
 // Review mode's own generated instruction is not a user turn
 func (analysis *codexSessionAnalysis) notePrompt(prompt string, timestamp *int64) {
 	analysis.waitingForInput = false
+	analysis.approvalPending = false
 	analysis.prompts++
 	if analysis.firstUserPrompt == "" {
 		analysis.firstUserPrompt = prompt
@@ -146,7 +151,7 @@ func parse(path string) (*parsedSession, error) {
 		Spawns:   analysis.spawns,
 		Commands: analysis.commands.Labelled(),
 	}
-	if analysis.waitingForInput && parsed.InTurn {
+	if (analysis.waitingForInput || analysis.approvalPending) && parsed.InTurn {
 		status := "waiting"
 		parsed.Session.Status = &status
 	}
@@ -169,6 +174,7 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 		return nil, err
 	}
 	questionAnswers := questionAnswersByCall(rows)
+	completedCalls := completedCallIDs(rows)
 	ownID := SessionIDFromRollout(file)
 	var metas []codexMeta
 	analysis := &codexSessionAnalysis{
@@ -339,6 +345,11 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 						}
 						analysis.digest.PushQuestion(analysis.prompts, question.text, answer, ts)
 					}
+				}
+				if prefix, escalated := execApprovalPrefix(row.Payload); escalated {
+					_, completed := completedCalls[row.Payload.CallID]
+					analysis.approvalPending = analysis.approvalPending ||
+						(!completed && prefixNeedsApproval(prefix))
 				}
 				analysis.notePlan(row.Payload, timestamp)
 			case "function_call_output":
@@ -578,6 +589,12 @@ var pullRequestDirectivePattern = regexp.MustCompile(
 	`::git-create-pr\{[^}\n]*\burl="(https://github\.com/[^/\s"]+/[^/\s"]+/pull/[0-9]+)"[^}\n]*\}`,
 )
 var requestUserInputCallPattern = regexp.MustCompile(`\brequest_user_input\s*\(`)
+var escalatedSandboxPattern = regexp.MustCompile(
+	`(?:"sandbox_permissions"|sandbox_permissions)\s*:\s*"require_escalated"`,
+)
+var prefixRulePattern = regexp.MustCompile(
+	`(?:"prefix_rule"|prefix_rule)\s*:\s*(\[[^]]*\])`,
+)
 var questionIDPattern = regexp.MustCompile(`"id"\s*:\s*("(?:[^"\\]|\\.)*")`)
 var questionPattern = regexp.MustCompile(`"question"\s*:\s*("(?:[^"\\]|\\.)*")`)
 var planStepPattern = regexp.MustCompile(
@@ -704,6 +721,65 @@ func questionAnswersByCall(rows []codexRow) map[string]map[string]codexQuestionA
 		}
 	}
 	return answersByCall
+}
+
+func completedCallIDs(rows []codexRow) map[string]struct{} {
+	completed := make(map[string]struct{})
+	for _, row := range rows {
+		if row.Type == "response_item" &&
+			(row.Payload.Type == "function_call_output" || row.Payload.Type == "custom_tool_call_output") &&
+			row.Payload.CallID != "" {
+			completed[row.Payload.CallID] = struct{}{}
+		}
+	}
+	return completed
+}
+
+func execApprovalPrefix(payload codexPayload) ([]string, bool) {
+	if payload.Name != "exec_command" {
+		text := payloadText(payload)
+		if payload.Name != "exec" || !strings.Contains(text, "tools.exec_command(") ||
+			!escalatedSandboxPattern.MatchString(text) {
+			return nil, false
+		}
+		var prefix []string
+		if match := prefixRulePattern.FindStringSubmatch(text); len(match) == 2 {
+			_ = json.Unmarshal([]byte(match[1]), &prefix)
+		}
+		return prefix, true
+	}
+	var arguments struct {
+		SandboxPermissions string   `json:"sandbox_permissions"`
+		PrefixRule         []string `json:"prefix_rule"`
+	}
+	if json.Unmarshal([]byte(payloadText(payload)), &arguments) != nil ||
+		arguments.SandboxPermissions != "require_escalated" {
+		return nil, false
+	}
+	return arguments.PrefixRule, true
+}
+
+func prefixNeedsApproval(prefix []string) bool {
+	if len(prefix) == 0 {
+		return true
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return true
+	}
+	rules := filepath.Join(home, ".codex", "rules", "default.rules")
+	arguments := append([]string{"execpolicy", "check", "--rules", rules}, prefix...)
+	output, err := exec.Command("codex", arguments...).Output()
+	if err != nil {
+		return true
+	}
+	var result struct {
+		Decision string `json:"decision"`
+	}
+	if json.Unmarshal(output, &result) != nil {
+		return true
+	}
+	return result.Decision != "allow" && result.Decision != "forbidden"
 }
 
 type codexCommandResult struct {

--- a/collector/internal/vendors/codex/parse.go
+++ b/collector/internal/vendors/codex/parse.go
@@ -2,9 +2,11 @@ package codex
 
 import (
 	"cmp"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,6 +15,7 @@ import (
 
 	"github.com/centauri-ai/coslash/collector/internal/session"
 	"github.com/centauri-ai/coslash/collector/internal/vendors"
+	_ "modernc.org/sqlite"
 )
 
 type codexSessionAnalysis struct {
@@ -47,6 +50,7 @@ type codexSessionAnalysis struct {
 	turnDepth        int
 	waitingForInput  bool
 	approvalPending  bool
+	approvalTurnID   string
 	lastTurnAborted  bool
 	inReview         bool
 }
@@ -350,6 +354,9 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 					_, completed := completedCalls[row.Payload.CallID]
 					analysis.approvalPending = analysis.approvalPending ||
 						(!completed && prefixNeedsApproval(prefix))
+					if analysis.approvalPending {
+						analysis.approvalTurnID = row.Payload.ChatMetadata.TurnID
+					}
 				}
 				analysis.notePlan(row.Payload, timestamp)
 			case "function_call_output":
@@ -383,7 +390,42 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 	if own.entrypoint != "" {
 		analysis.entrypoint = &own.entrypoint
 	}
+	if analysis.approvalPending && approvalDecisionLogged(
+		approvalLogPath(), analysis.sessionID, analysis.approvalTurnID,
+	) {
+		analysis.approvalPending = false
+	}
 	return analysis, nil
+}
+
+func approvalLogPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".codex", "logs_2.sqlite")
+}
+
+func approvalDecisionLogged(path, sessionID, turnID string) bool {
+	if path == "" || sessionID == "" || turnID == "" {
+		return false
+	}
+	dsn := (&url.URL{Scheme: "file", Path: path, RawQuery: "mode=ro&_query_only=1&_busy_timeout=100"}).String()
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return false
+	}
+	defer db.Close()
+	var found bool
+	err = db.QueryRow(`
+		SELECT EXISTS (
+			SELECT 1 FROM logs
+			WHERE thread_id = ?
+				AND instr(feedback_log_body, 'op: ExecApproval') > 0
+				AND instr(feedback_log_body, 'turn_id: Some("' || ? || '")') > 0
+		)
+	`, sessionID, turnID).Scan(&found)
+	return err == nil && found
 }
 
 func ownMeta(metas []codexMeta, ownID string) codexMeta {

--- a/collector/internal/vendors/codex/parse.go
+++ b/collector/internal/vendors/codex/parse.go
@@ -342,7 +342,7 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 					answers, answered := questionAnswers[row.Payload.CallID]
 					_, completed := completedCalls[row.Payload.CallID]
 					analysis.waitingForInput = analysis.waitingForInput ||
-						(!answered && (row.Payload.Name == "request_user_input" || !completed))
+						(!answered && !completed)
 					for _, question := range questions {
 						answer := strings.Join(answers[question.id].values(), ", ")
 						ts := int64(0)

--- a/collector/internal/vendors/codex/parse.go
+++ b/collector/internal/vendors/codex/parse.go
@@ -2,11 +2,9 @@ package codex
 
 import (
 	"cmp"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"log"
-	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,7 +13,6 @@ import (
 
 	"github.com/centauri-ai/coslash/collector/internal/session"
 	"github.com/centauri-ai/coslash/collector/internal/vendors"
-	_ "modernc.org/sqlite"
 )
 
 type codexSessionAnalysis struct {
@@ -50,7 +47,6 @@ type codexSessionAnalysis struct {
 	turnDepth        int
 	waitingForInput  bool
 	approvalPending  bool
-	approvalTurnID   string
 	lastTurnAborted  bool
 	inReview         bool
 }
@@ -354,12 +350,11 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 				}
 				if commands := execApprovalCommands(row.Payload); len(commands) > 0 {
 					_, completed := completedCalls[row.Payload.CallID]
+					// allow-once decisions are not in the rollout, so keep Waiting until
+					// tool output. Consume serverRequest/resolved if live events are added.
 					for _, command := range commands {
 						analysis.approvalPending = analysis.approvalPending ||
 							(!completed && commandNeedsApproval(command, analysis.workingDirectory))
-					}
-					if analysis.approvalPending {
-						analysis.approvalTurnID = row.Payload.ChatMetadata.TurnID
 					}
 				}
 				analysis.notePlan(row.Payload, timestamp)
@@ -394,42 +389,7 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 	if own.entrypoint != "" {
 		analysis.entrypoint = &own.entrypoint
 	}
-	if analysis.approvalPending && approvalDecisionLogged(
-		approvalLogPath(), analysis.sessionID, analysis.approvalTurnID,
-	) {
-		analysis.approvalPending = false
-	}
 	return analysis, nil
-}
-
-func approvalLogPath() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
-	}
-	return filepath.Join(home, ".codex", "logs_2.sqlite")
-}
-
-func approvalDecisionLogged(path, sessionID, turnID string) bool {
-	if path == "" || sessionID == "" || turnID == "" {
-		return false
-	}
-	dsn := (&url.URL{Scheme: "file", Path: path, RawQuery: "mode=ro&_query_only=1&_busy_timeout=100"}).String()
-	db, err := sql.Open("sqlite", dsn)
-	if err != nil {
-		return false
-	}
-	defer db.Close()
-	var found bool
-	err = db.QueryRow(`
-		SELECT EXISTS (
-			SELECT 1 FROM logs
-			WHERE thread_id = ?
-				AND instr(feedback_log_body, 'op: ExecApproval') > 0
-				AND instr(feedback_log_body, 'turn_id: Some("' || ? || '")') > 0
-		)
-	`, sessionID, turnID).Scan(&found)
-	return err == nil && found
 }
 
 func ownMeta(metas []codexMeta, ownID string) codexMeta {
@@ -927,7 +887,8 @@ func commitObservationsByCall(rows []codexRow) []session.CommitObservation {
 			}
 			continue
 		}
-		if row.Payload.Type != "function_call_output" && row.Payload.Type != "custom_tool_call_output" {
+		if row.Payload.Type != "function_call_output" &&
+			row.Payload.Type != "custom_tool_call_output" {
 			continue
 		}
 		command, ok := commands[row.Payload.CallID]

--- a/collector/internal/vendors/codex/parse.go
+++ b/collector/internal/vendors/codex/parse.go
@@ -352,10 +352,12 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 						analysis.digest.PushQuestion(analysis.prompts, question.text, answer, ts)
 					}
 				}
-				if command, escalated := execApprovalCommand(row.Payload); escalated {
+				if commands := execApprovalCommands(row.Payload); len(commands) > 0 {
 					_, completed := completedCalls[row.Payload.CallID]
-					analysis.approvalPending = analysis.approvalPending ||
-						(!completed && commandNeedsApproval(command, analysis.workingDirectory))
+					for _, command := range commands {
+						analysis.approvalPending = analysis.approvalPending ||
+							(!completed && commandNeedsApproval(command, analysis.workingDirectory))
+					}
 					if analysis.approvalPending {
 						analysis.approvalTurnID = row.Payload.ChatMetadata.TurnID
 					}
@@ -636,6 +638,7 @@ var requestUserInputCallPattern = regexp.MustCompile(`\brequest_user_input\s*\(`
 var escalatedSandboxPattern = regexp.MustCompile(
 	`(?:"sandbox_permissions"|sandbox_permissions)\s*:\s*"require_escalated"`,
 )
+var execCommandCallPattern = regexp.MustCompile(`\btools\.exec_command\s*\(`)
 var questionIDPattern = regexp.MustCompile(`"id"\s*:\s*("(?:[^"\\]|\\.)*")`)
 var questionPattern = regexp.MustCompile(`"question"\s*:\s*("(?:[^"\\]|\\.)*")`)
 var planStepPattern = regexp.MustCompile(
@@ -776,25 +779,37 @@ func completedCallIDs(rows []codexRow) map[string]struct{} {
 	return completed
 }
 
-func execApprovalCommand(payload codexPayload) (string, bool) {
+func execApprovalCommands(payload codexPayload) []string {
 	if payload.Name != "exec_command" {
-		text := payloadText(payload)
-		if payload.Name != "exec" || !strings.Contains(text, "tools.exec_command(") ||
-			!escalatedSandboxPattern.MatchString(text) {
-			return "", false
+		if payload.Name != "exec" {
+			return nil
 		}
-		command, _ := commandFrom(payload)
-		return command, true
+		text := payloadText(payload)
+		starts := execCommandCallPattern.FindAllStringIndex(text, -1)
+		commands := []string{}
+		for i, start := range starts {
+			end := len(text)
+			if i+1 < len(starts) {
+				end = starts[i+1][0]
+			}
+			segment := text[start[0]:end]
+			if !escalatedSandboxPattern.MatchString(segment) {
+				continue
+			}
+			command, _ := commandFrom(codexPayload{Input: segment})
+			commands = append(commands, command)
+		}
+		return commands
 	}
 	var arguments struct {
 		SandboxPermissions string `json:"sandbox_permissions"`
 	}
 	if json.Unmarshal([]byte(payloadText(payload)), &arguments) != nil ||
 		arguments.SandboxPermissions != "require_escalated" {
-		return "", false
+		return nil
 	}
 	command, _ := commandFrom(payload)
-	return command, true
+	return []string{command}
 }
 
 func commandNeedsApproval(command, cwd string) bool {

--- a/collector/internal/vendors/codex/parse.go
+++ b/collector/internal/vendors/codex/parse.go
@@ -42,12 +42,14 @@ type codexSessionAnalysis struct {
 	digest           session.DigestLog
 	plan             []planStep
 	turnDepth        int
+	waitingForInput  bool
 	lastTurnAborted  bool
 	inReview         bool
 }
 
 // Review mode's own generated instruction is not a user turn
 func (analysis *codexSessionAnalysis) notePrompt(prompt string, timestamp *int64) {
+	analysis.waitingForInput = false
 	analysis.prompts++
 	if analysis.firstUserPrompt == "" {
 		analysis.firstUserPrompt = prompt
@@ -143,6 +145,10 @@ func parse(path string) (*parsedSession, error) {
 		Stopped:  analysis.lastTurnAborted,
 		Spawns:   analysis.spawns,
 		Commands: analysis.commands.Labelled(),
+	}
+	if analysis.waitingForInput && parsed.InTurn {
+		status := "waiting"
+		parsed.Session.Status = &status
 	}
 	if parsed.ParentID != "" {
 		// Codex does not ship agent description
@@ -323,8 +329,10 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 					analysis.commands.Note(command, "")
 				}
 				if questions := questionsFrom(row.Payload); len(questions) > 0 {
+					answers, answered := questionAnswers[row.Payload.CallID]
+					analysis.waitingForInput = analysis.waitingForInput || !answered
 					for _, question := range questions {
-						answer := strings.Join(questionAnswers[row.Payload.CallID][question.id].values(), ", ")
+						answer := strings.Join(answers[question.id].values(), ", ")
 						ts := int64(0)
 						if timestamp != nil {
 							ts = *timestamp

--- a/collector/internal/vendors/codex/parse.go
+++ b/collector/internal/vendors/codex/parse.go
@@ -350,10 +350,10 @@ func analyzeCodexSession(file string) (*codexSessionAnalysis, error) {
 						analysis.digest.PushQuestion(analysis.prompts, question.text, answer, ts)
 					}
 				}
-				if prefix, escalated := execApprovalPrefix(row.Payload); escalated {
+				if command, escalated := execApprovalCommand(row.Payload); escalated {
 					_, completed := completedCalls[row.Payload.CallID]
 					analysis.approvalPending = analysis.approvalPending ||
-						(!completed && prefixNeedsApproval(prefix))
+						(!completed && commandNeedsApproval(command, analysis.workingDirectory))
 					if analysis.approvalPending {
 						analysis.approvalTurnID = row.Payload.ChatMetadata.TurnID
 					}
@@ -634,9 +634,6 @@ var requestUserInputCallPattern = regexp.MustCompile(`\brequest_user_input\s*\(`
 var escalatedSandboxPattern = regexp.MustCompile(
 	`(?:"sandbox_permissions"|sandbox_permissions)\s*:\s*"require_escalated"`,
 )
-var prefixRulePattern = regexp.MustCompile(
-	`(?:"prefix_rule"|prefix_rule)\s*:\s*(\[[^]]*\])`,
-)
 var questionIDPattern = regexp.MustCompile(`"id"\s*:\s*("(?:[^"\\]|\\.)*")`)
 var questionPattern = regexp.MustCompile(`"question"\s*:\s*("(?:[^"\\]|\\.)*")`)
 var planStepPattern = regexp.MustCompile(
@@ -777,40 +774,40 @@ func completedCallIDs(rows []codexRow) map[string]struct{} {
 	return completed
 }
 
-func execApprovalPrefix(payload codexPayload) ([]string, bool) {
+func execApprovalCommand(payload codexPayload) (string, bool) {
 	if payload.Name != "exec_command" {
 		text := payloadText(payload)
 		if payload.Name != "exec" || !strings.Contains(text, "tools.exec_command(") ||
 			!escalatedSandboxPattern.MatchString(text) {
-			return nil, false
+			return "", false
 		}
-		var prefix []string
-		if match := prefixRulePattern.FindStringSubmatch(text); len(match) == 2 {
-			_ = json.Unmarshal([]byte(match[1]), &prefix)
-		}
-		return prefix, true
+		command, _ := commandFrom(payload)
+		return command, true
 	}
 	var arguments struct {
-		SandboxPermissions string   `json:"sandbox_permissions"`
-		PrefixRule         []string `json:"prefix_rule"`
+		SandboxPermissions string `json:"sandbox_permissions"`
 	}
 	if json.Unmarshal([]byte(payloadText(payload)), &arguments) != nil ||
 		arguments.SandboxPermissions != "require_escalated" {
-		return nil, false
+		return "", false
 	}
-	return arguments.PrefixRule, true
+	command, _ := commandFrom(payload)
+	return command, true
 }
 
-func prefixNeedsApproval(prefix []string) bool {
-	if len(prefix) == 0 {
+func commandNeedsApproval(command, cwd string) bool {
+	if command == "" {
 		return true
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return true
 	}
-	rules := filepath.Join(home, ".codex", "rules", "default.rules")
-	arguments := append([]string{"execpolicy", "check", "--rules", rules}, prefix...)
+	rules := activeRuleFiles(home, cwd)
+	if len(rules) == 0 {
+		return true
+	}
+	arguments := execPolicyArguments(rules, command)
 	output, err := exec.Command("codex", arguments...).Output()
 	if err != nil {
 		return true
@@ -822,6 +819,44 @@ func prefixNeedsApproval(prefix []string) bool {
 		return true
 	}
 	return result.Decision != "allow" && result.Decision != "forbidden"
+}
+
+func activeRuleFiles(home, cwd string) []string {
+	directories := []string{
+		filepath.Join(home, ".codex", "rules"),
+		filepath.Join(string(filepath.Separator), "etc", "codex", "rules"),
+	}
+	projectDirectories := []string{}
+	for directory := filepath.Clean(cwd); directory != "."; directory = filepath.Dir(directory) {
+		projectDirectories = append(projectDirectories, filepath.Join(directory, ".codex", "rules"))
+		if parent := filepath.Dir(directory); parent == directory {
+			break
+		}
+	}
+	for i := len(projectDirectories) - 1; i >= 0; i-- {
+		directories = append(directories, projectDirectories[i])
+	}
+	files := []string{}
+	seen := map[string]struct{}{}
+	for _, directory := range directories {
+		matches, _ := filepath.Glob(filepath.Join(directory, "*.rules"))
+		for _, match := range matches {
+			if _, exists := seen[match]; exists {
+				continue
+			}
+			seen[match] = struct{}{}
+			files = append(files, match)
+		}
+	}
+	return files
+}
+
+func execPolicyArguments(rules []string, command string) []string {
+	arguments := []string{"execpolicy", "check"}
+	for _, rule := range rules {
+		arguments = append(arguments, "--rules", rule)
+	}
+	return append(arguments, strings.Fields(command)...)
 }
 
 type codexCommandResult struct {

--- a/collector/internal/vendors/codex/types.go
+++ b/collector/internal/vendors/codex/types.go
@@ -42,6 +42,11 @@ type codexPayload struct {
 	AgentThreadID  string            `json:"agent_thread_id"`
 	Kind           string            `json:"kind"`
 	Item           codexItem         `json:"item"`
+	ChatMetadata   codexChatMetadata `json:"internal_chat_message_metadata_passthrough"`
+}
+
+type codexChatMetadata struct {
+	TurnID string `json:"turn_id"`
 }
 
 type codexItem struct {

--- a/collector/internal/vendors/codex/types.go
+++ b/collector/internal/vendors/codex/types.go
@@ -42,11 +42,6 @@ type codexPayload struct {
 	AgentThreadID  string            `json:"agent_thread_id"`
 	Kind           string            `json:"kind"`
 	Item           codexItem         `json:"item"`
-	ChatMetadata   codexChatMetadata `json:"internal_chat_message_metadata_passthrough"`
-}
-
-type codexChatMetadata struct {
-	TurnID string `json:"turn_id"`
 }
 
 type codexItem struct {


### PR DESCRIPTION
## Context

Codex sessions can remain Active while they wait for a user response or command approval. This change marks those sessions as Waiting until the user responds or the approval completes.

## Changes

- Mark an open Codex turn as Waiting for an unanswered `request_user_input` call.
- Mark an open Codex turn as Waiting for a pending sandbox approval.
- Clear Waiting after an answer, completed approval, or newer user message.
- Keep sessions Active for saved approval rules and ordinary commands.

## Test

- `go test parse.go source.go fork.go types.go metadata.go discovery.go waiting_test.go` — passed
- `go build ./...` — passed
- `git diff --check origin/main...HEAD` — passed
- Manual: An unanswered `request_user_input` prompt showed Waiting.

### Screenshots

- [x] Session board — Codex session shows Waiting during an unanswered question.
<img width="2323" height="702" alt="Screenshot 2026-08-18 at 10 49 59" src="https://github.com/user-attachments/assets/1e52403f-4e3f-4c6b-a2a5-59c94bb1833b" />

- [x] Session board — Codex session shows Waiting during a pending approval.
<img width="2321" height="657" alt="Screenshot 2026-08-18 at 11 21 49" src="https://github.com/user-attachments/assets/e09f09a2-49bf-4509-a4e4-e8ceeb948162" />
