### PR TITLE
Derive waiting status for Claude sessions from transcript

### DIFF
--- a/collector/internal/vendors/claude/parse.go
+++ b/collector/internal/vendors/claude/parse.go
@@ -25,6 +25,8 @@ type claudeSessionAnalysis struct {
 	customName               string
 	generatedName            string
 	inTurn                   bool
+	waitingForQuestion       bool
+	pendingQuestionToolUseID string
 	awaySummary              string
 	compactionSeed           string
 	declaredGoal             string
@@ -86,6 +88,10 @@ func parse(path string) (*parsedSession, error) {
 		InTurn:   analysis.inTurn,
 		Spawns:   analysis.spawns,
 		Commands: analysis.commands.Labelled(),
+	}
+	if analysis.waitingForQuestion && analysis.inTurn {
+		status := "waiting"
+		parsed.Session.Status = &status
 	}
 	if parsed.ParentID != "" {
 		metaPath := strings.TrimSuffix(path, ".jsonl") + ".meta.json"
@@ -173,6 +179,8 @@ func analyzeClaudeSession(file string) (*claudeSessionAnalysis, error) {
 	pendingCommand := ""
 	emitPrompt := func(text string, timestamp int64) {
 		analysis.inTurn = true
+		analysis.waitingForQuestion = false
+		analysis.pendingQuestionToolUseID = ""
 		pendingAssistantText = ""
 		analysis.userPromptCount++
 		if analysis.firstUserPrompt == "" {
@@ -292,12 +300,20 @@ func analyzeClaudeSession(file string) (*claudeSessionAnalysis, error) {
 							analysis.digest.PushSubagent(analysis.userPromptCount, block.ID, rowTimestamp)
 						}
 					}
+					if block.Name == "AskUserQuestion" && block.ID != "" {
+						analysis.waitingForQuestion = true
+						analysis.pendingQuestionToolUseID = block.ID
+					}
 				}
 				if block.Type == "tool_result" && block.ToolUseID != "" {
 					spawn := analysis.spawns[block.ToolUseID]
 					spawn.Completed = true
 					analysis.spawns[block.ToolUseID] = spawn
 					resultToolUseID = block.ToolUseID
+					if block.ToolUseID == analysis.pendingQuestionToolUseID {
+						analysis.waitingForQuestion = false
+						analysis.pendingQuestionToolUseID = ""
+					}
 				}
 				if block.IsError {
 					analysis.errors++


### PR DESCRIPTION
## Context

Sessions that are blocked on the user (unanswered questions, pending approvals) show as "Waiting" in the UI. Claude Code sessions relied on the live session file to report this status. The transcript parser did not derive waiting status from `AskUserQuestion` tool calls independently, so if the live file was stale or missing, the status fell back to active.

## Changes

- Detect unanswered `AskUserQuestion` tool calls in the Claude transcript parser and set status to "waiting"
- Clear waiting state when the tool result arrives (question answered) or a new user prompt supersedes it
- Follow the same pattern that Codex uses for `request_user_input` detection

## Test

- `go test ./internal/vendors/claude/ -run TestAskUserQuestion` - passed (unanswered, answered, superseded cases)
- Manual: triggered `AskUserQuestion` in a live Claude Code session and confirmed "waiting" status in the UI

### Screenshots
<img width="2317" height="707" alt="Screenshot 2026-08-18 at 11 44 50" src="https://github.com/user-attachments/assets/2bcb6d1e-5406-43ee-a4d2-d78760caedb1" />
<img width="2317" height="696" alt="Screenshot 2026-08-18 at 11 46 51" src="https://github.com/user-attachments/assets/f860e96a-c11e-4cee-8fb8-d1f1c0789478" />
