### PR TITLE
Show OpenCode sessions as Waiting for pending approvals

### DIFF
--- a/collector/cmd/coslash/main.go
+++ b/collector/cmd/coslash/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/centauri-ai/coslash/collector/internal/session"
 	"github.com/centauri-ai/coslash/collector/internal/settings"
 	"github.com/centauri-ai/coslash/collector/internal/synthesis"
+	"github.com/centauri-ai/coslash/collector/internal/vendors/opencode"
 	"github.com/centauri-ai/coslash/collector/internal/web"
 )
 
@@ -79,6 +80,9 @@ func main() {
 	}
 
 	settingsStore := settings.Open()
+	if err := opencode.EnsureWaitingPlugin(); err != nil {
+		log.Printf("install OpenCode status plugin: %v", err)
+	}
 	settingsState := settingsStore.State()
 	var runner synthesis.Runner
 	if !settingsState.Valid {

--- a/collector/internal/vendors/opencode/coslash-waiting.js
+++ b/collector/internal/vendors/opencode/coslash-waiting.js
@@ -1,0 +1,36 @@
+// managed by coSlash; changes are overwritten
+import { chmod, mkdir, rename, unlink, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+
+const directory = path.join(os.homedir(), ".coslash", "opencode-permissions")
+
+async function record(properties) {
+  if (typeof properties.id !== "string" || typeof properties.sessionID !== "string") return
+  await mkdir(directory, { recursive: true, mode: 0o700 })
+  await chmod(directory, 0o700)
+  const target = path.join(directory, `${properties.id}.json`)
+  const temporary = `${target}.${process.pid}.tmp`
+  await writeFile(
+    temporary,
+    JSON.stringify({ sessionID: properties.sessionID, pid: process.pid }),
+    { mode: 0o600 },
+  )
+  await rename(temporary, target)
+}
+
+async function clear(properties) {
+  if (typeof properties.requestID !== "string") return
+  await unlink(path.join(directory, `${properties.requestID}.json`)).catch(() => {})
+}
+
+export const CoslashWaitingPlugin = async () => ({
+  event: async ({ event }) => {
+    try {
+      if (event?.type === "permission.asked") await record(event.properties ?? {})
+      if (event?.type === "permission.replied") await clear(event.properties ?? {})
+    } catch {
+      // Status reporting must never interrupt OpenCode.
+    }
+  },
+})

--- a/collector/internal/vendors/opencode/coslash-waiting.js
+++ b/collector/internal/vendors/opencode/coslash-waiting.js
@@ -4,6 +4,8 @@ import os from "node:os"
 import path from "node:path"
 
 const directory = path.join(os.homedir(), ".coslash", "opencode-permissions")
+const requestsBySession = new Map()
+let lifecycle = Promise.resolve()
 
 async function record(properties) {
   if (typeof properties.id !== "string" || typeof properties.sessionID !== "string") return
@@ -17,20 +19,37 @@ async function record(properties) {
     { mode: 0o600 },
   )
   await rename(temporary, target)
+  const requests = requestsBySession.get(properties.sessionID) ?? new Set()
+  requests.add(properties.id)
+  requestsBySession.set(properties.sessionID, requests)
 }
 
 async function clear(properties) {
   if (typeof properties.requestID !== "string") return
   await unlink(path.join(directory, `${properties.requestID}.json`)).catch(() => {})
+  requestsBySession.get(properties.sessionID)?.delete(properties.requestID)
+}
+
+async function clearSession(properties) {
+  if (typeof properties.sessionID !== "string") return
+  const requests = requestsBySession.get(properties.sessionID)
+  requestsBySession.delete(properties.sessionID)
+  await Promise.all(
+    [...(requests ?? [])].map((requestID) =>
+      unlink(path.join(directory, `${requestID}.json`)).catch(() => {}),
+    ),
+  )
 }
 
 export const CoslashWaitingPlugin = async () => ({
-  event: async ({ event }) => {
-    try {
+  event: ({ event }) => {
+    lifecycle = lifecycle.then(async () => {
       if (event?.type === "permission.asked") await record(event.properties ?? {})
       if (event?.type === "permission.replied") await clear(event.properties ?? {})
-    } catch {
+      if (event?.type === "session.idle") await clearSession(event.properties ?? {})
+    }).catch(() => {
       // Status reporting must never interrupt OpenCode.
-    }
+    })
+    return lifecycle
   },
 })

--- a/collector/internal/vendors/opencode/metadata.go
+++ b/collector/internal/vendors/opencode/metadata.go
@@ -2,12 +2,16 @@ package opencode
 
 import (
 	"database/sql"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/centauri-ai/coslash/collector/internal/vendors"
@@ -76,7 +80,58 @@ func loadMetadata(db *sql.DB) (*vendors.SessionMetadata, error) {
 	for id := range matchLiveSessions(processes, candidates) {
 		metadata.Live[id] = "interactive"
 	}
+	markPendingPermissions(db, metadata, permissionStateDir())
 	return metadata, nil
+}
+
+type pendingPermission struct {
+	SessionID string `json:"sessionID"`
+	PID       int    `json:"pid"`
+}
+
+func permissionStateDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".coslash", "opencode-permissions")
+}
+
+func markPendingPermissions(db *sql.DB, metadata *vendors.SessionMetadata, directory string) {
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		path := filepath.Join(directory, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var pending pendingPermission
+		if json.Unmarshal(data, &pending) != nil || pending.SessionID == "" || !processAlive(pending.PID) {
+			os.Remove(path)
+			continue
+		}
+		var rootID string
+		if db.QueryRow(
+			`SELECT COALESCE(parent_id, id) FROM session WHERE id = ? AND time_archived IS NULL`,
+			pending.SessionID,
+		).Scan(&rootID) == nil {
+			metadata.Live[rootID] = "waiting"
+		}
+	}
+}
+
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
 }
 
 func parseTUIProcesses(output string) []tuiProcess {

--- a/collector/internal/vendors/opencode/plugin.go
+++ b/collector/internal/vendors/opencode/plugin.go
@@ -1,0 +1,62 @@
+package opencode
+
+import (
+	_ "embed"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const pluginName = "coslash-waiting.js"
+
+//go:embed coslash-waiting.js
+var waitingPlugin []byte
+
+func EnsureWaitingPlugin() error {
+	root := os.Getenv("XDG_CONFIG_HOME")
+	if root == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return err
+		}
+		root = filepath.Join(home, ".config")
+	}
+	return installWaitingPlugin(filepath.Join(root, "opencode", "plugins"))
+}
+
+func installWaitingPlugin(directory string) error {
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		return err
+	}
+	path := filepath.Join(directory, pluginName)
+	current, err := os.ReadFile(path)
+	if err == nil && !strings.HasPrefix(string(current), "// managed by coSlash;") {
+		return fmt.Errorf("refusing to overwrite unmanaged OpenCode plugin %s", path)
+	}
+	if err == nil && string(current) == string(waitingPlugin) {
+		return nil
+	}
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	temporary, err := os.CreateTemp(directory, ".coslash-waiting-*")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	if err := temporary.Chmod(0o600); err != nil {
+		temporary.Close()
+		return err
+	}
+	if _, err := temporary.Write(waitingPlugin); err != nil {
+		temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	return os.Rename(temporaryPath, path)
+}


### PR DESCRIPTION
## Context

OpenCode keeps pending permission requests in memory. It does not store this state in the transcript database. The default TUI does not expose its permission API to other processes. Therefore, the collector cannot distinguish a permission wait from an ordinary running tool. The plugin sends the permission lifecycle to coSlash.

## Changes

- Install a global OpenCode event plugin when coSlash starts. The global plugin also covers manually launched OpenCode sessions.
- Record only request IDs, session IDs, and process IDs. Do not record prompts, tool arguments, or decisions.
- Mark root sessions as Waiting for pending child or root approvals. Clear the state after a reply and ignore records from stopped processes.

## Test

- `go build ./...` — passed
- `node --check internal/vendors/opencode/coslash-waiting.js` — passed
- `git diff --check cvu/claude-wait...HEAD` — passed
- Manual: pending approval showed Waiting; rejection returned the session to Busy.

### Screenshots

- [x] Session board — OpenCode session shows Waiting during a pending approval.
<img width="1978" height="650" alt="Screenshot 2026-08-18 at 13 02 14" src="https://github.com/user-attachments/assets/ad764405-4704-426c-86d8-6ff1c18ad3c4" />