### PR TITLE
Show OpenCode Waiting plugin health in diagnostics

### DIFF
--- a/collector/internal/diagnostics/checks.go
+++ b/collector/internal/diagnostics/checks.go
@@ -69,6 +69,7 @@ func derive(snapshot *Snapshot) []Check {
 		synthesis.Detail = "Enabled with " + snapshot.Synthesis.Model + "."
 	}
 	checks = append(checks, synthesis)
+	checks = append(checks, openCodePluginCheck(snapshot))
 
 	if !snapshot.Platform.TerminalLaunchSupported {
 		checks = append(checks, Check{
@@ -80,6 +81,35 @@ func derive(snapshot *Snapshot) []Check {
 		})
 	}
 	return checks
+}
+
+func openCodePluginCheck(snapshot *Snapshot) Check {
+	plugin := snapshot.openCodePlugin
+	check := Check{
+		ID:     "opencode.waiting-plugin",
+		Title:  "OpenCode Waiting plugin",
+		Status: StatusOK,
+		Detail: "Installed at " + plugin.Path + ".",
+	}
+	switch {
+	case plugin.Err != nil:
+		check.Status = StatusWarn
+		check.Detail = "coSlash could not inspect the OpenCode Waiting plugin: " + snapshot.openCodePluginError
+		if plugin.Path == "" {
+			check.Fix = "Check that the current user has a valid home directory, then restart coSlash."
+		} else {
+			check.Fix = "Check the permissions for " + plugin.Path + ", then restart coSlash."
+		}
+	case !plugin.Installed:
+		check.Status = StatusWarn
+		check.Detail = "The OpenCode Waiting plugin is not installed. Pending approvals can appear Active."
+		check.Fix = "Restart coSlash to install the plugin, then restart OpenCode."
+	case plugin.RestartRequired:
+		check.Status = StatusWarn
+		check.Detail = "The plugin changed after a running OpenCode session started."
+		check.Fix = "Restart OpenCode to load the current plugin."
+	}
+	return check
 }
 
 func sourceCheck(source Source) Check {

--- a/collector/internal/diagnostics/snapshot.go
+++ b/collector/internal/diagnostics/snapshot.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/centauri-ai/coslash/collector/internal/collector"
 	"github.com/centauri-ai/coslash/collector/internal/settings"
+	"github.com/centauri-ai/coslash/collector/internal/vendors/opencode"
 )
 
 type Status string
@@ -32,14 +33,16 @@ const (
 )
 
 type Snapshot struct {
-	Version     string    `json:"version"`
-	GeneratedAt int64     `json:"generatedAt"`
-	Platform    Platform  `json:"platform"`
-	Storage     Storage   `json:"storage"`
-	Synthesis   Synthesis `json:"synthesis"`
-	Sources     []Source  `json:"sources"`
-	Checks      []Check   `json:"checks"`
-	homeError   string
+	Version             string    `json:"version"`
+	GeneratedAt         int64     `json:"generatedAt"`
+	Platform            Platform  `json:"platform"`
+	Storage             Storage   `json:"storage"`
+	Synthesis           Synthesis `json:"synthesis"`
+	Sources             []Source  `json:"sources"`
+	Checks              []Check   `json:"checks"`
+	openCodePlugin      opencode.WaitingPluginHealth
+	openCodePluginError string
+	homeError           string
 }
 
 type Platform struct {
@@ -113,6 +116,11 @@ func Collect(ctx context.Context, version string, includeVersions bool) *Snapsho
 	}
 	if userHomeErr != nil {
 		snapshot.homeError = userHomeErr.Error()
+	}
+	snapshot.openCodePlugin = opencode.WaitingPluginDiagnostics()
+	snapshot.openCodePlugin.Path = displayPath(userHome, snapshot.openCodePlugin.Path)
+	if snapshot.openCodePlugin.Err != nil {
+		snapshot.openCodePluginError = displayError(userHome, snapshot.openCodePlugin.Err.Error())
 	}
 
 	storageHome := settings.Home()

--- a/collector/internal/vendors/opencode/plugin.go
+++ b/collector/internal/vendors/opencode/plugin.go
@@ -1,10 +1,12 @@
 package opencode
 
 import (
+	"bytes"
 	_ "embed"
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -15,15 +17,68 @@ const pluginName = "coslash-waiting.js"
 var waitingPlugin []byte
 
 func EnsureWaitingPlugin() error {
+	path, err := waitingPluginPath()
+	if err != nil {
+		return err
+	}
+	return installWaitingPlugin(filepath.Dir(path))
+}
+
+type WaitingPluginHealth struct {
+	Path            string
+	Installed       bool
+	RestartRequired bool
+	Err             error
+}
+
+func WaitingPluginDiagnostics() WaitingPluginHealth {
+	path, err := waitingPluginPath()
+	if err != nil {
+		return WaitingPluginHealth{Err: err}
+	}
+	health := WaitingPluginHealth{Path: path}
+	current, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return health
+	}
+	if err != nil {
+		health.Err = err
+		return health
+	}
+	if !bytes.Equal(current, waitingPlugin) {
+		health.Err = errors.New("installed plugin differs from the coSlash plugin")
+		return health
+	}
+	health.Installed = true
+	info, err := os.Stat(path)
+	if err != nil {
+		health.Err = err
+		return health
+	}
+	output, err := exec.Command("ps", "-ww", "-axo", "pid=,lstart=,command=").Output()
+	if err != nil {
+		health.Err = fmt.Errorf("list OpenCode processes: %w", err)
+		return health
+	}
+	for _, process := range parseTUIProcesses(string(output)) {
+		if processWorkingDirectory(process.pid) != "" && process.startedAt < info.ModTime().UnixMilli() {
+			health.RestartRequired = true
+			break
+		}
+	}
+	return health
+}
+
+func waitingPluginPath() (string, error) {
 	root := os.Getenv("XDG_CONFIG_HOME")
 	if root == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			return err
+			return "", err
 		}
 		root = filepath.Join(home, ".config")
 	}
-	return installWaitingPlugin(filepath.Join(root, "opencode", "plugins"))
+	return filepath.Join(root, "opencode", "plugins", pluginName), nil
 }
 
 func installWaitingPlugin(directory string) error {


### PR DESCRIPTION
## Context

OpenCode approval status depends on the Waiting plugin installed by coSlash. Diagnostics did not show whether the plugin was installed or whether running OpenCode sessions needed a restart.

## Changes

- Show the OpenCode Waiting plugin status in the existing diagnostics checklist and copied diagnostics.
- Warn when the plugin is missing, differs from the managed version, cannot be inspected, or requires an OpenCode restart.

## Test

- `go build ./...` — passed
- `go run ./cmd/coslash doctor --json | jq -e '.checks[] | select(.id == "opencode.waiting-plugin" and .status == "ok")'` — passed\n- `git diff --check cvu/opencode-wait...HEAD` — passed\n- Manual: `/api/diagnostics` reported the installed plugin as OK.\n\n### Screenshots\n\n- [ ] Diagnostics dialog — OpenCode Waiting plugin shows its current status.

### Screenshots
<img width="575" height="687" alt="Screenshot 2026-08-18 at 13 39 17" src="https://github.com/user-attachments/assets/a38500b0-e6d9-424c-a0ea-c5bf3c129065" />
