### PR TITLE
Fix OpenCode gateway pricing and float context windows in the model table

### DIFF
--- a/collector/Makefile
+++ b/collector/Makefile
@@ -91,7 +91,7 @@ models:
 		jq -e 'length > 50' $(MODELS).new > /dev/null || { \
 			echo "error: $$(jq length $(MODELS).new) models is too few; an upstream format changed"; exit 1; }; \
 		jq -e --slurpfile opencode $(MODELS).opencode \
-			'. as $$table | all($$opencode[0].opencode.models | keys[]; . as $$id | (($$table | has($$id)) or ($$table | has("opencode/" + $$id))))' \
+			'. as $$table | all($$opencode[0].opencode.models | keys[]; . as $$id | $$table | has("opencode/" + $$id))' \
 			$(MODELS).new > /dev/null || { echo "error: the OpenCode model merge is incomplete"; exit 1; }; \
 		mv $(MODELS).new $(MODELS); \
 		rm -f $(MODELS).opencode; \

--- a/collector/internal/session/models.go
+++ b/collector/internal/session/models.go
@@ -32,7 +32,8 @@ var models = loadModels()
 func loadModels() map[string]modelInfo {
 	loaded := map[string]modelInfo{}
 	if err := json.Unmarshal(modelsJSON, &loaded); err != nil {
-		log.Printf("model table: %v; costs and context windows are unavailable", err)
+		// A type error zeroes one field but still fills the map, so report the count.
+		log.Printf("model table: %v; %d models loaded", err, len(loaded))
 	}
 	// A model that publishes no cache price bills cached tokens as input, and
 	// one that publishes no 1-hour price bills a long write like a short one.

--- a/collector/internal/session/models.json
+++ b/collector/internal/session/models.json
@@ -8862,6 +8862,62 @@
     "max_input_tokens": 200000,
     "output_cost_per_token": 4e-06
   },
+  "opencode/claude-fable-5": {
+    "cache_creation_input_token_cost": 1.25e-05,
+    "cache_read_input_token_cost": 1e-06,
+    "input_cost_per_token": 1e-05,
+    "max_input_tokens": 1000000,
+    "output_cost_per_token": 5e-05
+  },
+  "opencode/claude-haiku-4-5": {
+    "cache_creation_input_token_cost": 1.25e-06,
+    "cache_read_input_token_cost": 1.0000000000000001e-07,
+    "input_cost_per_token": 1e-06,
+    "max_input_tokens": 200000,
+    "output_cost_per_token": 5e-06
+  },
+  "opencode/claude-opus-4-1": {
+    "cache_creation_input_token_cost": 1.875e-05,
+    "cache_read_input_token_cost": 1.5e-06,
+    "input_cost_per_token": 1.5e-05,
+    "max_input_tokens": 200000,
+    "output_cost_per_token": 7.5e-05
+  },
+  "opencode/claude-opus-4-5": {
+    "cache_creation_input_token_cost": 6.25e-06,
+    "cache_read_input_token_cost": 5e-07,
+    "input_cost_per_token": 5e-06,
+    "max_input_tokens": 200000,
+    "output_cost_per_token": 2.5e-05
+  },
+  "opencode/claude-opus-4-6": {
+    "cache_creation_input_token_cost": 6.25e-06,
+    "cache_read_input_token_cost": 5e-07,
+    "input_cost_per_token": 5e-06,
+    "max_input_tokens": 1000000,
+    "output_cost_per_token": 2.5e-05
+  },
+  "opencode/claude-opus-4-7": {
+    "cache_creation_input_token_cost": 6.25e-06,
+    "cache_read_input_token_cost": 5e-07,
+    "input_cost_per_token": 5e-06,
+    "max_input_tokens": 1000000,
+    "output_cost_per_token": 2.5e-05
+  },
+  "opencode/claude-opus-4-8": {
+    "cache_creation_input_token_cost": 6.25e-06,
+    "cache_read_input_token_cost": 5e-07,
+    "input_cost_per_token": 5e-06,
+    "max_input_tokens": 1000000,
+    "output_cost_per_token": 2.5e-05
+  },
+  "opencode/claude-opus-5": {
+    "cache_creation_input_token_cost": 6.25e-06,
+    "cache_read_input_token_cost": 5e-07,
+    "input_cost_per_token": 5e-06,
+    "max_input_tokens": 1000000,
+    "output_cost_per_token": 2.5e-05
+  },
   "opencode/claude-sonnet-4": {
     "cache_creation_input_token_cost": 3.75e-06,
     "cache_read_input_token_cost": 3e-07,
@@ -8869,11 +8925,44 @@
     "max_input_tokens": 1000000,
     "output_cost_per_token": 1.5e-05
   },
+  "opencode/claude-sonnet-4-5": {
+    "cache_creation_input_token_cost": 3.75e-06,
+    "cache_read_input_token_cost": 3e-07,
+    "input_cost_per_token": 3e-06,
+    "max_input_tokens": 1000000,
+    "output_cost_per_token": 1.5e-05
+  },
+  "opencode/claude-sonnet-4-6": {
+    "cache_creation_input_token_cost": 3.75e-06,
+    "cache_read_input_token_cost": 3e-07,
+    "input_cost_per_token": 3e-06,
+    "max_input_tokens": 1000000,
+    "output_cost_per_token": 1.5e-05
+  },
+  "opencode/claude-sonnet-5": {
+    "cache_creation_input_token_cost": 2.5e-06,
+    "cache_read_input_token_cost": 2.0000000000000002e-07,
+    "input_cost_per_token": 2e-06,
+    "max_input_tokens": 1000000,
+    "output_cost_per_token": 1e-05
+  },
+  "opencode/deepseek-v4-flash": {
+    "cache_read_input_token_cost": 2.8e-08,
+    "input_cost_per_token": 1.4e-07,
+    "max_input_tokens": 1000000,
+    "output_cost_per_token": 2.8e-07
+  },
   "opencode/deepseek-v4-flash-free": {
     "cache_read_input_token_cost": 0,
     "input_cost_per_token": 0,
     "max_input_tokens": 200000,
     "output_cost_per_token": 0
+  },
+  "opencode/deepseek-v4-pro": {
+    "cache_read_input_token_cost": 1.45e-07,
+    "input_cost_per_token": 1.74e-06,
+    "max_input_tokens": 1000000,
+    "output_cost_per_token": 3.84e-06
   },
   "opencode/gemini-3-flash": {
     "cache_read_input_token_cost": 5.0000000000000004e-08,
@@ -8892,6 +8981,30 @@
     "input_cost_per_token": 2e-06,
     "max_input_tokens": 1048576,
     "output_cost_per_token": 1.2e-05
+  },
+  "opencode/gemini-3.5-flash": {
+    "cache_read_input_token_cost": 1.5e-07,
+    "input_cost_per_token": 1.5e-06,
+    "max_input_tokens": 1048576,
+    "output_cost_per_token": 9e-06
+  },
+  "opencode/gemini-3.5-flash-lite": {
+    "cache_read_input_token_cost": 3e-08,
+    "input_cost_per_token": 3e-07,
+    "max_input_tokens": 1048576,
+    "output_cost_per_token": 2.5e-06
+  },
+  "opencode/gemini-3.6-flash": {
+    "cache_read_input_token_cost": 1.5e-07,
+    "input_cost_per_token": 1.5e-06,
+    "max_input_tokens": 1048576,
+    "output_cost_per_token": 7.5e-06
+  },
+  "opencode/gemini-3.7-flash": {
+    "cache_read_input_token_cost": 1.5e-07,
+    "input_cost_per_token": 1.5e-06,
+    "max_input_tokens": 1048576,
+    "output_cost_per_token": 7.5e-06
   },
   "opencode/glm-4.6": {
     "cache_read_input_token_cost": 1.0000000000000001e-07,
@@ -8935,11 +9048,128 @@
     "max_input_tokens": 1000000,
     "output_cost_per_token": 4.4e-06
   },
+  "opencode/gpt-5": {
+    "cache_read_input_token_cost": 1.0699999999999999e-07,
+    "input_cost_per_token": 1.0700000000000001e-06,
+    "max_input_tokens": 400000,
+    "output_cost_per_token": 8.5e-06
+  },
+  "opencode/gpt-5-codex": {
+    "cache_read_input_token_cost": 1.0699999999999999e-07,
+    "input_cost_per_token": 1.0700000000000001e-06,
+    "max_input_tokens": 400000,
+    "output_cost_per_token": 8.5e-06
+  },
+  "opencode/gpt-5-nano": {
+    "cache_read_input_token_cost": 5e-09,
+    "input_cost_per_token": 5.0000000000000004e-08,
+    "max_input_tokens": 400000,
+    "output_cost_per_token": 4.0000000000000003e-07
+  },
+  "opencode/gpt-5.1": {
+    "cache_read_input_token_cost": 1.0699999999999999e-07,
+    "input_cost_per_token": 1.0700000000000001e-06,
+    "max_input_tokens": 400000,
+    "output_cost_per_token": 8.5e-06
+  },
+  "opencode/gpt-5.1-codex": {
+    "cache_read_input_token_cost": 1.0699999999999999e-07,
+    "input_cost_per_token": 1.0700000000000001e-06,
+    "max_input_tokens": 400000,
+    "output_cost_per_token": 8.5e-06
+  },
+  "opencode/gpt-5.1-codex-max": {
+    "cache_read_input_token_cost": 1.25e-07,
+    "input_cost_per_token": 1.25e-06,
+    "max_input_tokens": 400000,
+    "output_cost_per_token": 1e-05
+  },
+  "opencode/gpt-5.1-codex-mini": {
+    "cache_read_input_token_cost": 2.5000000000000002e-08,
+    "input_cost_per_token": 2.5e-07,
+    "max_input_tokens": 400000,
+    "output_cost_per_token": 2e-06
+  },
+  "opencode/gpt-5.2": {
+    "cache_read_input_token_cost": 1.75e-07,
+    "input_cost_per_token": 1.75e-06,
+    "max_input_tokens": 400000,
+    "output_cost_per_token": 1.4e-05
+  },
+  "opencode/gpt-5.2-codex": {
+    "cache_read_input_token_cost": 1.75e-07,
+    "input_cost_per_token": 1.75e-06,
+    "max_input_tokens": 400000,
+    "output_cost_per_token": 1.4e-05
+  },
+  "opencode/gpt-5.3-codex": {
+    "cache_read_input_token_cost": 1.75e-07,
+    "input_cost_per_token": 1.75e-06,
+    "max_input_tokens": 400000,
+    "output_cost_per_token": 1.4e-05
+  },
   "opencode/gpt-5.3-codex-spark": {
     "cache_read_input_token_cost": 1.75e-07,
     "input_cost_per_token": 1.75e-06,
     "max_input_tokens": 128000,
     "output_cost_per_token": 1.4e-05
+  },
+  "opencode/gpt-5.4": {
+    "cache_read_input_token_cost": 2.5e-07,
+    "input_cost_per_token": 2.5e-06,
+    "max_input_tokens": 1050000,
+    "output_cost_per_token": 1.5e-05
+  },
+  "opencode/gpt-5.4-mini": {
+    "cache_read_input_token_cost": 7.5e-08,
+    "input_cost_per_token": 7.5e-07,
+    "max_input_tokens": 400000,
+    "output_cost_per_token": 4.5e-06
+  },
+  "opencode/gpt-5.4-nano": {
+    "cache_read_input_token_cost": 2e-08,
+    "input_cost_per_token": 2.0000000000000002e-07,
+    "max_input_tokens": 400000,
+    "output_cost_per_token": 1.25e-06
+  },
+  "opencode/gpt-5.4-pro": {
+    "cache_read_input_token_cost": 3e-05,
+    "input_cost_per_token": 3e-05,
+    "max_input_tokens": 1050000,
+    "output_cost_per_token": 0.00018
+  },
+  "opencode/gpt-5.5": {
+    "cache_read_input_token_cost": 5e-07,
+    "input_cost_per_token": 5e-06,
+    "max_input_tokens": 1050000,
+    "output_cost_per_token": 3e-05
+  },
+  "opencode/gpt-5.5-pro": {
+    "cache_read_input_token_cost": 3e-05,
+    "input_cost_per_token": 3e-05,
+    "max_input_tokens": 1050000,
+    "output_cost_per_token": 0.00018
+  },
+  "opencode/gpt-5.6-luna": {
+    "cache_creation_input_token_cost": 2.5e-07,
+    "cache_read_input_token_cost": 2e-08,
+    "input_cost_per_token": 2.0000000000000002e-07,
+    "max_input_tokens": 1050000,
+    "output_cost_per_token": 1.2e-06
+  },
+  "opencode/gpt-5.6-sol": {
+    "cache_creation_input_token_cost": 6.25e-06,
+    "cache_read_input_token_cost": 5e-07,
+    "input_cost_per_token": 5e-06,
+    "max_input_tokens": 1050000,
+    "output_cost_per_token": 3e-05
+  },
+  "opencode/gpt-5.6-terra": {
+    "cache_creation_input_token_cost": 3.125e-06,
+    "cache_read_input_token_cost": 2.5e-07,
+    "input_cost_per_token": 2.5e-06,
+    "max_input_tokens": 1050000,
+    "output_cost_per_token": 1.5e-05
   },
   "opencode/grok-4.5": {
     "cache_read_input_token_cost": 5e-07,

--- a/collector/internal/session/models.json
+++ b/collector/internal/session/models.json
@@ -12676,43 +12676,43 @@
   "xai/grok-4-1-fast": {
     "cache_read_input_token_cost": 5E-8,
     "input_cost_per_token": 2E-7,
-    "max_input_tokens": 2000000.0,
+    "max_input_tokens": 2000000,
     "output_cost_per_token": 5E-7
   },
   "xai/grok-4-1-fast-non-reasoning": {
     "cache_read_input_token_cost": 5E-8,
     "input_cost_per_token": 2E-7,
-    "max_input_tokens": 2000000.0,
+    "max_input_tokens": 2000000,
     "output_cost_per_token": 5E-7
   },
   "xai/grok-4-1-fast-non-reasoning-latest": {
     "cache_read_input_token_cost": 5E-8,
     "input_cost_per_token": 2E-7,
-    "max_input_tokens": 2000000.0,
+    "max_input_tokens": 2000000,
     "output_cost_per_token": 5E-7
   },
   "xai/grok-4-1-fast-reasoning": {
     "cache_read_input_token_cost": 5E-8,
     "input_cost_per_token": 2E-7,
-    "max_input_tokens": 2000000.0,
+    "max_input_tokens": 2000000,
     "output_cost_per_token": 5E-7
   },
   "xai/grok-4-1-fast-reasoning-latest": {
     "cache_read_input_token_cost": 5E-8,
     "input_cost_per_token": 2E-7,
-    "max_input_tokens": 2000000.0,
+    "max_input_tokens": 2000000,
     "output_cost_per_token": 5E-7
   },
   "xai/grok-4-fast-non-reasoning": {
     "cache_read_input_token_cost": 5E-8,
     "input_cost_per_token": 2E-7,
-    "max_input_tokens": 2000000.0,
+    "max_input_tokens": 2000000,
     "output_cost_per_token": 5E-7
   },
   "xai/grok-4-fast-reasoning": {
     "cache_read_input_token_cost": 5E-8,
     "input_cost_per_token": 2E-7,
-    "max_input_tokens": 2000000.0,
+    "max_input_tokens": 2000000,
     "output_cost_per_token": 5E-7
   },
   "xai/grok-4-latest": {

--- a/collector/scripts/models.jq
+++ b/collector/scripts/models.jq
@@ -5,6 +5,9 @@
 # LiteLLM costs are already dollars per token. Run through `make models`.
 def per_token: if . == null then null else . / 1000000 end;
 
+# LiteLLM writes some context windows as floats (2000000.0); Go decodes an int.
+def whole: if . == null then null else floor end;
+
 with_entries(
   select(
     (.value.mode == "chat" or .value.mode == "responses")
@@ -17,7 +20,7 @@ with_entries(
         cache_creation_input_token_cost,
         cache_creation_input_token_cost_above_1hr,
         cache_read_input_token_cost,
-        max_input_tokens,
+        max_input_tokens: (.max_input_tokens | whole),
       }
       | with_entries(select(.value != null))
     )
@@ -31,7 +34,7 @@ with_entries(
           output_cost_per_token: (.cost.output | per_token),
           cache_creation_input_token_cost: (.cost.cache_write | per_token),
           cache_read_input_token_cost: (.cost.cache_read | per_token),
-          max_input_tokens: .limit.context,
+          max_input_tokens: (.limit.context | whole),
         }
       | with_entries(select(.value != null))
     )

--- a/collector/scripts/models.jq
+++ b/collector/scripts/models.jq
@@ -1,7 +1,8 @@
 # Prunes LiteLLM's model_prices_and_context_window.json to priced chat models,
-# then adds OpenCode models missing from that table. OpenCode costs are dollars
-# per million tokens; LiteLLM costs are already dollars per token. Run through
-# `make models`.
+# then adds every OpenCode gateway model under `opencode/`, the provider-qualified
+# id coslash records for them -- including ids LiteLLM also lists, since the
+# gateway prices them differently. OpenCode costs are dollars per million tokens;
+# LiteLLM costs are already dollars per token. Run through `make models`.
 def per_token: if . == null then null else . / 1000000 end;
 
 with_entries(
@@ -21,22 +22,17 @@ with_entries(
       | with_entries(select(.value != null))
     )
 )
-| . as $litellm
 | reduce ($opencode[0].opencode.models | to_entries[]) as $model (
     .;
-    if ($litellm | has($model.key)) then
-      .
-    else
-      .["opencode/\($model.key)"] = (
-        $model.value
-        | {
-            input_cost_per_token: (.cost.input | per_token),
-            output_cost_per_token: (.cost.output | per_token),
-            cache_creation_input_token_cost: (.cost.cache_write | per_token),
-            cache_read_input_token_cost: (.cost.cache_read | per_token),
-            max_input_tokens: .limit.context,
-          }
-        | with_entries(select(.value != null))
-      )
-    end
+    .["opencode/\($model.key)"] = (
+      $model.value
+      | {
+          input_cost_per_token: (.cost.input | per_token),
+          output_cost_per_token: (.cost.output | per_token),
+          cache_creation_input_token_cost: (.cost.cache_write | per_token),
+          cache_read_input_token_cost: (.cost.cache_read | per_token),
+          max_input_tokens: .limit.context,
+        }
+      | with_entries(select(.value != null))
+    )
   )


### PR DESCRIPTION
## Context

coslash prices sessions and reports context windows from an embedded table generated
from LiteLLM's price file plus OpenCode's gateway registry. Two defects in that table:
OpenCode models whose bare id also appeared in LiteLLM were dropped from the merge, so
`opencode/<id>` sessions silently fell back to the direct provider's numbers; and
LiteLLM publishes some context windows as floats, which the Go `int` field rejects at
load. The table grows from 2325 to 2361 entries.

## Changes

- **OpenCode gateway ids**
  - Every model in the registry now gets an `opencode/<id>` entry.
  - Previously skipped when the bare id also existed in LiteLLM — 36 of 91 models.
  - That prefix is the id the OpenCode collector records, so those sessions fell through
    to the direct provider's row.
  - Six of the 36 diverge:
    - `gpt-5` family — $1.07/$8.50 per Mtok and a 400k window, not $1.25/$10 at 272k.
    - `deepseek-v4-pro` — off by 4x.
    - `gemini-3.7-flash` — off by 2x.
  - Bare ids keep LiteLLM's numbers, so direct-provider sessions are unaffected.
  - The duplicate keys are deliberate.
- **Float context windows**
  - Windows are floored during generation.
  - Fixes seven `xai/grok-4-*-fast*` models that loaded with a 0 window.
  - All seven upstream values are whole numbers, so flooring loses nothing.
- **Guard rails**
  - `make models` now fails unless every registry model has a prefixed entry.
  - The old assertion accepted the bare id, which let the gap pass CI daily.
  - On a decode error the loader now reports how many models parsed.
  - It previously claimed all costs and windows were unavailable, which overstated a
    partial failure.

## Test

- `go test ./...` — passed
- `go vet ./...` — passed
- Manual: decoded the regenerated table — no error, 2361 entries, `xai/grok-4-1-fast` at
  a 2000000 window, `opencode/gpt-5` and `gpt-5` resolving to their own prices.
- Manual: `make models` on top of this branch is a no-op, so the daily Models workflow
  won't open a churn PR.
