### PR TITLE
fix: unblock first-run synthesis consent when no CLI is available

### DIFF
--- a/frontend/src/pages/coslash/components/SettingsDialog.tsx
+++ b/frontend/src/pages/coslash/components/SettingsDialog.tsx
@@ -6,9 +6,11 @@ import { setTheme } from '@/lib/theme';
 import { cn } from '@/lib/utils';
 import {
   availableSynthesisBackends,
+  enableSynthesisDraft,
   initialSettingsDraft,
   modelForBackend,
   requiresFirstRunConsent,
+  settingsForSave,
   type BackendOption,
   type CoslashSettings,
   type SettingsResponse,
@@ -64,17 +66,22 @@ function SelectControl({
 
 function SynthesisPreference({
   enabled,
+  canEnable,
   onChange,
 }: {
   enabled: boolean;
+  canEnable: boolean;
   onChange: (enabled: boolean) => void;
 }) {
+  const enableBlocked = !enabled && !canEnable;
   return (
     <div className="flex items-center justify-between gap-4 p-4">
       <div className="flex min-w-0 flex-col gap-1">
         <div className="text-sm font-semibold">AI synthesis</div>
         <div className="text-muted-foreground text-xs text-pretty">
-          Summarize eligible session transcripts through a local CLI.
+          {enableBlocked
+            ? 'Install a supported CLI (claude, codex, or opencode) to turn this on.'
+            : 'Summarize eligible session transcripts through a local CLI.'}
         </div>
       </div>
       <button
@@ -82,8 +89,14 @@ function SynthesisPreference({
         role="switch"
         aria-label="AI synthesis"
         aria-checked={enabled}
-        onClick={() => onChange(!enabled)}
-        className="bg-input focus-visible:border-ring focus-visible:ring-ring aria-checked:bg-primary relative inline-flex h-6 w-10 shrink-0 cursor-pointer items-center rounded-full p-0.5 transition-colors outline-none focus-visible:ring-3"
+        aria-disabled={enableBlocked}
+        title={enableBlocked ? 'No supported CLI detected on PATH' : undefined}
+        disabled={enableBlocked}
+        onClick={() => {
+          if (enabled) onChange(false);
+          else if (canEnable) onChange(true);
+        }}
+        className="bg-input focus-visible:border-ring focus-visible:ring-ring aria-checked:bg-primary relative inline-flex h-6 w-10 shrink-0 cursor-pointer items-center rounded-full p-0.5 transition-colors outline-none focus-visible:ring-3 disabled:cursor-not-allowed disabled:opacity-50"
       >
         <span
           className={cn(
@@ -215,13 +228,14 @@ export function SettingsDialog({
   const selectedBackend = synthesisBackends.find((option) => option.id === draft?.synthesis.backend);
   const selectedModel = selectedBackend?.models.find((option) => option.id === draft?.synthesis.model);
   const selectedTerminal = response?.options.terminals.find((option) => option.id === draft?.launch.terminal);
-  const synthesisBackendAvailable = draft?.synthesis.enabled !== true || selectedBackend?.available === true;
-  const canSave = (isFirstRun || response?.valid === false || isDirty) && synthesisBackendAvailable;
+  // Persist is always allowed: settingsForSave turns synthesis off when no CLI is usable.
+  const canSave = isFirstRun || response?.valid === false || isDirty;
 
   const save = async () => {
-    if (!draft || !synthesisBackendAvailable) return;
-    if (await onSave(draft)) {
-      setTheme(draft.appearance.theme);
+    if (!draft || !response) return;
+    const toSave = settingsForSave(draft, response);
+    if (await onSave(toSave)) {
+      setTheme(toSave.appearance.theme);
       onOpenChange(false);
     }
   };
@@ -235,8 +249,8 @@ export function SettingsDialog({
     ? { label: 'Save failed', className: 'text-destructive' }
     : isSaving
       ? { label: 'Saving…', className: 'text-muted-foreground' }
-      : !synthesisBackendAvailable
-        ? { label: 'Backend unavailable', className: 'text-warning-fg' }
+      : draft?.synthesis.enabled === true && selectedBackend == null
+        ? { label: 'Will save with synthesis off', className: 'text-warning-fg' }
         : response?.valid === false
           ? { label: 'Repair required', className: 'text-warning-fg' }
           : isDirty
@@ -290,7 +304,15 @@ export function SettingsDialog({
                 <div className="border-border bg-card overflow-hidden rounded-xl border">
                   <SynthesisPreference
                     enabled={draft.synthesis.enabled}
-                    onChange={(enabled) => setDraft({ ...draft, synthesis: { ...draft.synthesis, enabled } })}
+                    canEnable={hasSynthesisBackends}
+                    onChange={(enabled) => {
+                      if (!enabled) {
+                        setDraft({ ...draft, synthesis: { ...draft.synthesis, enabled: false } });
+                        return;
+                      }
+                      const next = enableSynthesisDraft(draft, response);
+                      if (next) setDraft(next);
+                    }}
                   />
 
                   {draft.synthesis.enabled ? (

--- a/frontend/src/pages/coslash/lib/settings.test.ts
+++ b/frontend/src/pages/coslash/lib/settings.test.ts
@@ -1,8 +1,44 @@
 import { describe, expect, it } from 'vitest';
-import { availableSynthesisBackends, type BackendOption } from '@/pages/coslash/lib/settings';
+import {
+  availableSynthesisBackends,
+  enableSynthesisDraft,
+  settingsForSave,
+  type BackendOption,
+  type CoslashSettings,
+  type SettingsResponse,
+} from '@/pages/coslash/lib/settings';
 
 function backend(id: string, available: boolean): BackendOption {
-  return { id, label: id, models: [], available };
+  return {
+    id,
+    label: `${id} CLI`,
+    models: [{ id: `${id}-model`, label: `${id}-model`, default: true }],
+    available,
+  };
+}
+
+function draft(overrides: Partial<CoslashSettings['synthesis']> = {}): CoslashSettings {
+  return {
+    $schema: 'https://coslash.io/settings.schema.json',
+    version: 1,
+    synthesis: {
+      enabled: false,
+      backend: 'claude-cli',
+      model: 'claude-cli-model',
+      ...overrides,
+    },
+    appearance: { theme: 'light' },
+    launch: { terminal: 'terminal' },
+  };
+}
+
+function response(backends: BackendOption[]): SettingsResponse {
+  return {
+    settings: draft(),
+    persisted: false,
+    valid: true,
+    options: { synthesisBackends: backends, terminals: [] },
+  };
 }
 
 describe('availableSynthesisBackends', () => {
@@ -10,5 +46,52 @@ describe('availableSynthesisBackends', () => {
     const options = [backend('claude-cli', true), backend('codex_exec', false)];
 
     expect(availableSynthesisBackends(options).map(({ id }) => id)).toEqual(['claude-cli']);
+  });
+});
+
+describe('enableSynthesisDraft', () => {
+  it('returns null when no CLI is available', () => {
+    const loaded = response([backend('claude-cli', false), backend('codex_exec', false)]);
+
+    expect(enableSynthesisDraft(draft(), loaded)).toBeNull();
+  });
+
+  it('enables synthesis on the first available CLI', () => {
+    const loaded = response([backend('claude-cli', false), backend('codex_exec', true)]);
+
+    expect(enableSynthesisDraft(draft({ backend: 'claude-cli' }), loaded)).toEqual(
+      draft({
+        enabled: true,
+        backend: 'codex_exec',
+        model: 'codex_exec-model',
+      }),
+    );
+  });
+});
+
+describe('settingsForSave', () => {
+  it('turns synthesis off when no CLI is available', () => {
+    const loaded = response([backend('claude-cli', false)]);
+
+    expect(settingsForSave(draft({ enabled: true, backend: 'claude-cli' }), loaded).synthesis.enabled).toBe(
+      false,
+    );
+  });
+
+  it('rewrites an unavailable backend to the first detected CLI', () => {
+    const loaded = response([backend('claude-cli', false), backend('codex_exec', true)]);
+
+    expect(settingsForSave(draft({ enabled: true, backend: 'claude-cli' }), loaded).synthesis).toEqual({
+      enabled: true,
+      backend: 'codex_exec',
+      model: 'codex_exec-model',
+    });
+  });
+
+  it('leaves a valid synthesis selection unchanged', () => {
+    const loaded = response([backend('claude-cli', true)]);
+    const current = draft({ enabled: true, backend: 'claude-cli', model: 'claude-cli-model' });
+
+    expect(settingsForSave(current, loaded)).toBe(current);
   });
 });

--- a/frontend/src/pages/coslash/lib/settings.ts
+++ b/frontend/src/pages/coslash/lib/settings.ts
@@ -53,6 +53,46 @@ export function modelForBackend(response: SettingsResponse, backend: string): st
   return option?.models.find((model) => model.default)?.id ?? option?.models[0]?.id ?? '';
 }
 
+/** Turn synthesis on only when a detected CLI exists; otherwise return null. */
+export function enableSynthesisDraft(
+  draft: CoslashSettings,
+  response: SettingsResponse,
+): CoslashSettings | null {
+  const availableBackend = availableSynthesisBackends(response.options.synthesisBackends)[0];
+  if (availableBackend == null) return null;
+  return {
+    ...draft,
+    synthesis: {
+      ...draft.synthesis,
+      enabled: true,
+      backend: availableBackend.id,
+      model: modelForBackend(response, availableBackend.id),
+    },
+  };
+}
+
+/**
+ * Settings that are safe to persist: synthesis stays on only with a detected
+ * backend. Used so first-run consent can always Save instead of getting stuck.
+ */
+export function settingsForSave(draft: CoslashSettings, response: SettingsResponse): CoslashSettings {
+  if (!draft.synthesis.enabled) return draft;
+  const backends = availableSynthesisBackends(response.options.synthesisBackends);
+  const selected = backends.find((option) => option.id === draft.synthesis.backend) ?? backends[0];
+  if (selected == null) {
+    return { ...draft, synthesis: { ...draft.synthesis, enabled: false } };
+  }
+  if (selected.id === draft.synthesis.backend) return draft;
+  return {
+    ...draft,
+    synthesis: {
+      ...draft.synthesis,
+      backend: selected.id,
+      model: modelForBackend(response, selected.id),
+    },
+  };
+}
+
 export function initialSettingsDraft(response: SettingsResponse): CoslashSettings {
   const synthesis = { ...response.settings.synthesis };
 


### PR DESCRIPTION
## Summary
- First-run synthesis consent could trap users: turning AI synthesis on with no detected CLI disabled Save while Cancel/Escape/outside-click were blocked
- Disable enabling synthesis unless a supported CLI is on PATH, and normalize unavailable selections on Save so the dialog can always complete

## Test plan
- [ ] Fresh machine / no `claude`/`codex`/`opencode` on PATH: open an eligible session, confirm consent dialog appears, AI synthesis toggle is disabled, **Save settings** dismisses and writes `~/.coslash/settings.json`
- [ ] With a CLI on PATH: confirm synthesis can be enabled, backend is selected, Save works
- [ ] With synthesis somehow enabled and no CLI: status shows it will save with synthesis off; Save succeeds
- [ ] `npx vitest run src/pages/coslash/lib/settings.test.ts`


Made with [Cursor](https://cursor.com)