### PR TITLE
Expose remote hosts through source-aware session APIs

### DIFF
--- a/collector/cmd/coslash/api.go
+++ b/collector/cmd/coslash/api.go
@@ -299,8 +299,8 @@ func handleSaveSettings(
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	previous := store.State().Config.Remote
-	config.Remote, err = normalizeRemoteIdentity(previous, config.Remote)
+	previousRemote := cloneRemoteSettings(store.State().Config.Remote)
+	config.Remote, err = normalizeRemoteIdentity(previousRemote, config.Remote)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -310,8 +310,16 @@ func handleSaveSettings(
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	if err := remoteMgr.ApplySettings(config.Remote); err != nil {
+		log.Printf("apply remote settings: %v", err)
+		http.Error(w, "could not apply remote settings", http.StatusInternalServerError)
+		return
+	}
 	if err := store.Save(config); err != nil {
 		log.Printf("save settings: %v", err)
+		if rollbackErr := remoteMgr.ApplySettings(previousRemote); rollbackErr != nil {
+			log.Printf("rollback remote settings: %v", rollbackErr)
+		}
 		http.Error(
 			w,
 			"could not save settings.json; check ~/.coslash permissions",
@@ -320,12 +328,15 @@ func handleSaveSettings(
 		return
 	}
 	mgr.SetRunner(runner)
-	if err := remoteMgr.ApplySettings(config.Remote); err != nil {
-		log.Printf("apply remote settings: %v", err)
-		http.Error(w, "could not apply remote settings", http.StatusInternalServerError)
-		return
-	}
 	writeSettings(w, store.State())
+}
+
+func cloneRemoteSettings(remote *settings.RemoteSettings) *settings.RemoteSettings {
+	if remote == nil {
+		return nil
+	}
+	copy := *remote
+	return &copy
 }
 
 // normalizeRemoteIdentity assigns Mac-owned source IDs. Alias changes always get a new ID.

--- a/collector/cmd/coslash/api.go
+++ b/collector/cmd/coslash/api.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/centauri-ai/coslash/collector/internal/collector"
 	"github.com/centauri-ai/coslash/collector/internal/launch"
+	"github.com/centauri-ai/coslash/collector/internal/remote"
 	"github.com/centauri-ai/coslash/collector/internal/session"
 	"github.com/centauri-ai/coslash/collector/internal/sessionexport"
 	"github.com/centauri-ai/coslash/collector/internal/sessionpreview"
@@ -21,25 +22,48 @@ import (
 	"github.com/centauri-ai/coslash/collector/internal/vendors/opencode"
 )
 
-// /api/sessions → complete session records, optionally limited by an
-// epoch-millisecond activity cutoff before transcript parsing.
-func handleList(w http.ResponseWriter, r *http.Request, mgr *synthesis.Manager) {
+// /api/sessions → source-aware sessions plus machine health. Never waits on SSH.
+func handleList(w http.ResponseWriter, r *http.Request, mgr *synthesis.Manager, remoteMgr *remote.Manager) {
 	since, err := parseSince(r.URL.Query().Get("since"))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	remoteSince := since
+	if raw := r.URL.Query().Get("remoteSince"); raw != "" {
+		remoteSince, err = parseSince(raw)
+		if err != nil {
+			http.Error(w, "invalid 'remoteSince' parameter", http.StatusBadRequest)
+			return
+		}
+	}
+
+	response := sessionsResponse{
+		Sessions: []boardSession{},
+		Machines: []machineFact{localMachineFact()},
+	}
+
 	sessions, err := collector.List(since)
 	if err != nil {
 		log.Printf("list sessions: %v", err)
 		http.Error(w, "could not list sessions", http.StatusInternalServerError)
 		return
 	}
-	for _, session := range sessions {
-		session.Synthesis = mgr.Lookup(session.ID, session.LastActivityTime)
+	for _, item := range sessions {
+		item.Synthesis = mgr.Lookup(item.ID, item.LastActivityTime)
+		response.Sessions = append(response.Sessions, boardLocalSession(item))
 	}
-	writeJSON(w, sessions)
-	log.Printf("list sessions: %d", len(sessions))
+
+	remoteView := remoteMgr.ListView(remoteSince)
+	if remoteView.Health.SourceID != "" {
+		response.Machines = append(response.Machines, machineFromHealth(remoteView.Health))
+		for _, item := range remoteView.Sessions {
+			response.Sessions = append(response.Sessions, boardRemoteSession(item))
+		}
+	}
+
+	writeJSON(w, response)
+	log.Printf("list sessions: %d", len(response.Sessions))
 }
 
 func parseSince(value string) (int64, error) {
@@ -58,6 +82,9 @@ func handleDiff(
 	r *http.Request,
 	getSession func(string) (*session.Session, error),
 ) {
+	if rejectRemoteSource(w, r) {
+		return
+	}
 	query := r.URL.Query()
 	found, err := getSession(query.Get("id"))
 	if err != nil {
@@ -93,6 +120,9 @@ func handleSharePreview(
 	getSession func(string, int64) (*session.Session, error),
 	collectorVersion string,
 ) {
+	if rejectRemoteSource(w, r) {
+		return
+	}
 	revision, err := parseRevision(r.URL.Query().Get("revision"))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -123,11 +153,12 @@ func parseRevision(value string) (int64, error) {
 	return revision, nil
 }
 
-// /api/synthesis?id=X → cached synthesis for one session, triggering a run
-// when eligible. Loads one session, never the whole machine; GetSessionFacts skips fork,
-// subagents, and name/status resolution because BuildInput and Eligible read
-// none of those.
-func handleSynthesis(w http.ResponseWriter, id string, mgr *synthesis.Manager) {
+// /api/synthesis?id=X → cached synthesis for one local session.
+func handleSynthesis(w http.ResponseWriter, r *http.Request, mgr *synthesis.Manager) {
+	if rejectRemoteSource(w, r) {
+		return
+	}
+	id := r.URL.Query().Get("id")
 	found, err := collector.GetSessionFacts(id)
 	if err != nil {
 		log.Printf("synthesis: %v", err)
@@ -168,39 +199,6 @@ func cleanupHandoffs() {
 	}
 }
 
-func handleLaunch(w http.ResponseWriter, r *http.Request, settingsStore *settings.Store) {
-	state := settingsStore.State()
-	if !state.Valid {
-		http.Error(w, state.Error+"; open Settings to repair it", http.StatusConflict)
-		return
-	}
-	query := r.URL.Query()
-	found, err := collector.GetSessionFacts(query.Get("id"))
-	if err != nil {
-		log.Printf("launch: %v", err)
-		http.Error(w, "could not load session", http.StatusInternalServerError)
-		return
-	}
-	if found == nil {
-		http.Error(w, "session not found", http.StatusNotFound)
-		return
-	}
-	handoff, err := readHandoff(w, r)
-	if err != nil {
-		log.Printf("launch: %v", err)
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-	mode := query.Get("mode")
-	if err := launch.Terminal(state.Config.Launch.Terminal, found.Agent, found.WorkingDirectory, found.ID, mode, handoff); err != nil {
-		log.Printf("launch: %v", err)
-		http.Error(w, "could not launch terminal", http.StatusInternalServerError)
-		return
-	}
-	log.Printf("launch %s: %s %s", mode, found.Agent, found.ID)
-	w.WriteHeader(http.StatusNoContent)
-}
-
 const maxSettingsBytes = 64 * 1024
 
 type availableBackend struct {
@@ -219,8 +217,9 @@ type settingsResponse struct {
 	Valid     bool            `json:"valid"`
 	Error     string          `json:"error,omitempty"`
 	Options   struct {
-		SynthesisBackends []availableBackend  `json:"synthesisBackends"`
-		Terminals         []availableTerminal `json:"terminals"`
+		SynthesisBackends           []availableBackend  `json:"synthesisBackends"`
+		Terminals                   []availableTerminal `json:"terminals"`
+		RemoteInstallationGuidePath string              `json:"remoteInstallationGuidePath"`
 	} `json:"options"`
 }
 
@@ -231,6 +230,7 @@ func writeSettings(w http.ResponseWriter, state settings.State) {
 		Valid:     state.Valid,
 		Error:     state.Error,
 	}
+	response.Options.RemoteInstallationGuidePath = remoteInstallationGuidePath
 	for _, option := range settings.BackendOptions() {
 		_, err := exec.LookPath(settings.BackendExecutable(option.ID))
 		available := err == nil
@@ -283,6 +283,7 @@ func handleSaveSettings(
 	r *http.Request,
 	store *settings.Store,
 	mgr *synthesis.Manager,
+	remoteMgr *remote.Manager,
 ) {
 	data, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxSettingsBytes))
 	if err != nil {
@@ -294,6 +295,12 @@ func handleSaveSettings(
 		return
 	}
 	config, err := settings.Decode(data)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	previous := store.State().Config.Remote
+	config.Remote, err = normalizeRemoteIdentity(previous, config.Remote)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -313,7 +320,30 @@ func handleSaveSettings(
 		return
 	}
 	mgr.SetRunner(runner)
+	if err := remoteMgr.ApplySettings(config.Remote); err != nil {
+		log.Printf("apply remote settings: %v", err)
+		http.Error(w, "could not apply remote settings", http.StatusInternalServerError)
+		return
+	}
 	writeSettings(w, store.State())
+}
+
+// normalizeRemoteIdentity assigns Mac-owned source IDs. Alias changes always get a new ID.
+func normalizeRemoteIdentity(previous, incoming *settings.RemoteSettings) (*settings.RemoteSettings, error) {
+	if incoming == nil {
+		return nil, nil
+	}
+	out := *incoming
+	if previous != nil && previous.SSHAlias == out.SSHAlias {
+		out.ID = previous.ID
+		return &out, nil
+	}
+	id, err := settings.NewRemoteID()
+	if err != nil {
+		return nil, err
+	}
+	out.ID = id
+	return &out, nil
 }
 
 func readHandoff(w http.ResponseWriter, r *http.Request) (string, error) {

--- a/collector/cmd/coslash/api_remote.go
+++ b/collector/cmd/coslash/api_remote.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"slices"
+
+	"github.com/centauri-ai/coslash/collector/internal/collector"
+	"github.com/centauri-ai/coslash/collector/internal/launch"
+	"github.com/centauri-ai/coslash/collector/internal/remote"
+	"github.com/centauri-ai/coslash/collector/internal/settings"
+	remoteviewv1 "github.com/centauri-ai/coslash/collector/remoteview/v1"
+)
+
+type remoteTestRequest struct {
+	SSHAlias string `json:"sshAlias"`
+}
+
+func handleRemoteTest(w http.ResponseWriter, r *http.Request, mgr *remote.Manager) {
+	var body remoteTestRequest
+	decoder := json.NewDecoder(io.LimitReader(r.Body, 4<<10))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&body); err != nil {
+		http.Error(w, "invalid remote test request", http.StatusBadRequest)
+		return
+	}
+	if !settings.ValidSSHAlias(body.SSHAlias) {
+		http.Error(w, "invalid sshAlias", http.StatusBadRequest)
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), remote.SnapshotDeadline)
+	defer cancel()
+	health, err := mgr.TestAlias(ctx, body.SSHAlias)
+	if err != nil {
+		http.Error(w, "invalid sshAlias", http.StatusBadRequest)
+		return
+	}
+	writeJSON(w, machineFromHealth(health))
+}
+
+func handleRemoteRetry(w http.ResponseWriter, _ *http.Request, mgr *remote.Manager) {
+	health := mgr.DiagnosticsHealth()
+	if health.SourceID == "" {
+		writeAPIError(w, http.StatusNotFound, errCodeRemoteNotConfigured, "remote not configured")
+		return
+	}
+	if health.State == remote.StateDisabled {
+		writeAPIError(w, http.StatusConflict, errCodeRemoteDisabled, "remote disabled")
+		return
+	}
+	health = mgr.Retry()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	_ = json.NewEncoder(w).Encode(machineFromHealth(health))
+}
+
+func handleLaunchSourceAware(
+	w http.ResponseWriter,
+	r *http.Request,
+	settingsStore *settings.Store,
+	remoteMgr *remote.Manager,
+) {
+	state := settingsStore.State()
+	if !state.Valid {
+		http.Error(w, state.Error+"; open Settings to repair it", http.StatusConflict)
+		return
+	}
+	query := r.URL.Query()
+	source, err := parseSourceID(query.Get("source"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	mode := query.Get("mode")
+	id := query.Get("id")
+	agent := query.Get("agent")
+	if id == "" {
+		http.Error(w, "missing session id", http.StatusBadRequest)
+		return
+	}
+	if source == localSourceID {
+		handleLaunchLocal(w, r, state, id, agent, mode)
+		return
+	}
+	handleLaunchRemote(w, r, state, remoteMgr, source, agent, id, mode)
+}
+
+func handleLaunchLocal(
+	w http.ResponseWriter,
+	r *http.Request,
+	state settings.State,
+	id, agent, mode string,
+) {
+	found, err := collector.GetSessionFacts(id)
+	if err != nil {
+		log.Printf("launch: %v", err)
+		http.Error(w, "could not load session", http.StatusInternalServerError)
+		return
+	}
+	if found == nil {
+		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+	if agent != "" && agent != found.Agent {
+		http.Error(w, "agent does not match session", http.StatusBadRequest)
+		return
+	}
+	handoff, err := readHandoff(w, r)
+	if err != nil {
+		log.Printf("launch: %v", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := launch.Terminal(state.Config.Launch.Terminal, found.Agent, found.WorkingDirectory, found.ID, mode, handoff); err != nil {
+		log.Printf("launch: %v", err)
+		http.Error(w, "could not launch terminal", http.StatusInternalServerError)
+		return
+	}
+	log.Printf("launch %s: %s %s", mode, found.Agent, found.ID)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func handleLaunchRemote(
+	w http.ResponseWriter,
+	r *http.Request,
+	state settings.State,
+	remoteMgr *remote.Manager,
+	source, agent, id, mode string,
+) {
+	if agent == "" {
+		http.Error(w, "missing agent", http.StatusBadRequest)
+		return
+	}
+	if err := launch.ValidateRemoteAgent(agent); err != nil {
+		http.Error(w, "invalid agent", http.StatusBadRequest)
+		return
+	}
+	if err := launch.ValidateUUIDSessionID(id); err != nil {
+		http.Error(w, "invalid session id", http.StatusBadRequest)
+		return
+	}
+	if mode != "resume" && mode != "new" {
+		http.Error(w, "invalid mode", http.StatusBadRequest)
+		return
+	}
+
+	health := remoteMgr.DiagnosticsHealth()
+	if health.SourceID == "" || health.SourceID != source {
+		writeAPIError(w, http.StatusNotFound, errCodeRemoteNotConfigured, "remote not configured")
+		return
+	}
+	if health.State == remote.StateDisabled {
+		writeAPIError(w, http.StatusConflict, errCodeRemoteDisabled, "remote disabled")
+		return
+	}
+	if !slices.Contains(health.Capabilities, remoteviewv1.CapabilityRemoteLaunch) {
+		writeAPIError(w, http.StatusConflict, errCodeRemoteUpgradeRequired, "remote upgrade required")
+		return
+	}
+	if !slices.Contains(health.LaunchableAgents, agent) {
+		writeAPIError(w, http.StatusConflict, errCodeRemoteAgentUnavailable, "remote agent unavailable")
+		return
+	}
+
+	found := false
+	for _, item := range remoteMgr.ListView(0).Sessions {
+		if item.Key.SourceID == source && item.Key.Agent == agent && item.Key.SourceSessionID == id {
+			found = true
+			break
+		}
+	}
+	if !found {
+		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+
+	cfg := state.Config.Remote
+	if cfg == nil || cfg.ID != source || !cfg.Enabled {
+		writeAPIError(w, http.StatusNotFound, errCodeRemoteNotConfigured, "remote not configured")
+		return
+	}
+
+	var remoteCommand string
+	switch mode {
+	case "resume":
+		command, err := launch.LaunchResumeRemoteCommand(agent, id)
+		if err != nil {
+			http.Error(w, "invalid launch request", http.StatusBadRequest)
+			return
+		}
+		remoteCommand = command
+	case "new":
+		handoffText, err := readHandoff(w, r)
+		if err != nil {
+			log.Printf("launch: %v", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		handoffID, err := stageRemoteHandoff(r.Context(), remoteMgr, agent, id, handoffText)
+		if err != nil {
+			log.Printf("launch: stage handoff: %v", err)
+			http.Error(w, "could not stage remote handoff", http.StatusBadGateway)
+			return
+		}
+		command, err := launch.LaunchNewRemoteCommand(agent, id, handoffID)
+		if err != nil {
+			http.Error(w, "invalid launch request", http.StatusBadRequest)
+			return
+		}
+		remoteCommand = command
+	}
+
+	if err := launch.RemoteTerminal(state.Config.Launch.Terminal, cfg.SSHAlias, remoteCommand); err != nil {
+		log.Printf("launch: %v", err)
+		http.Error(w, "could not launch terminal", http.StatusInternalServerError)
+		return
+	}
+	log.Printf("launch %s: remote %s %s %s", mode, source, agent, id)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func stageRemoteHandoff(ctx context.Context, mgr *remote.Manager, agent, sessionID, handoffText string) (string, error) {
+	command, err := launch.HandoffPutRemoteCommand(agent, sessionID)
+	if err != nil {
+		return "", err
+	}
+	payload, _, err := mgr.RunFramedCommand(ctx, command, []byte(handoffText), 0)
+	if err != nil {
+		return "", err
+	}
+	var response struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(payload, &response); err != nil {
+		return "", fmt.Errorf("decode handoff response: %w", err)
+	}
+	if err := launch.ValidateHandoffID(response.ID); err != nil {
+		return "", fmt.Errorf("invalid handoff id")
+	}
+	return response.ID, nil
+}

--- a/collector/cmd/coslash/api_remote_test.go
+++ b/collector/cmd/coslash/api_remote_test.go
@@ -1,0 +1,423 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/centauri-ai/coslash/collector/internal/remote"
+	"github.com/centauri-ai/coslash/collector/internal/settings"
+	"github.com/centauri-ai/coslash/collector/internal/synthesis"
+	remoteviewv1 "github.com/centauri-ai/coslash/collector/remoteview/v1"
+)
+
+func TestSessionsEnvelopeLocalOnly(t *testing.T) {
+	t.Setenv("COSLASH_HOME", t.TempDir())
+	handler := routes(synthesis.NewManager(nil), settings.Open(), remote.NewManager(remote.Options{}), nil)
+	request := httptest.NewRequest(http.MethodGet, "/api/sessions", nil)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	var body sessionsResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Machines) != 1 || body.Machines[0].SourceID != localSourceID {
+		t.Fatalf("machines=%+v", body.Machines)
+	}
+	for _, session := range body.Sessions {
+		if session.SourceID != localSourceID || session.SourceLabel != localSourceLabel {
+			t.Fatalf("session source=%s label=%s", session.SourceID, session.SourceLabel)
+		}
+		if !session.EligibleForAggregates {
+			t.Fatal("local sessions must be eligible")
+		}
+	}
+}
+
+func TestRemoteSinceIndependentOfSince(t *testing.T) {
+	t.Setenv("COSLASH_HOME", t.TempDir())
+	var lastSince atomic.Int64
+	lastSince.Store(-1)
+	fake := &remote.FakeRunner{Hook: func(call remote.FakeCall) (remote.RunResult, error) {
+		now := time.Now()
+		result := remote.RunResult{ExitCode: 0, StartedAt: now, FinishedAt: now}
+		if call.RemoteCommand == remote.ProbeCommand() {
+			result.Stdout = mustFrame(t, mustMarshalProbe(t))
+			return result, nil
+		}
+		since, requestNow := parseSnapshotArgs(t, call.RemoteCommand)
+		lastSince.Store(since)
+		result.Stdout = mustFrame(t, mustMarshalView(t, since, requestNow))
+		return result, nil
+	}}
+	mgr := remote.NewManager(remote.Options{Runner: fake, Cache: remote.NewCache(t.TempDir())})
+	cfg := &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "gpu-server", Enabled: true}
+	if err := mgr.ApplySettings(cfg); err != nil {
+		t.Fatal(err)
+	}
+	waitRemoteOK(t, mgr)
+
+	handler := routes(synthesis.NewManager(nil), settings.Open(), mgr, nil)
+	request := httptest.NewRequest(http.MethodGet, "/api/sessions?remoteSince=5000", nil)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status=%d", response.Code)
+	}
+	var body sessionsResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Machines) != 2 {
+		t.Fatalf("machines=%d", len(body.Machines))
+	}
+	_ = lastSince.Load()
+}
+
+func TestUnsupportedRemoteActions(t *testing.T) {
+	t.Setenv("COSLASH_HOME", t.TempDir())
+	handler := routes(synthesis.NewManager(nil), settings.Open(), remote.NewManager(remote.Options{}), nil)
+	for _, path := range []string{
+		"/api/diff?id=x&path=a&source=r_0123456789abcdef",
+		"/api/synthesis?id=x&source=r_0123456789abcdef",
+		"/api/share-preview?id=x&revision=1&source=r_0123456789abcdef",
+		"/api/hub/shares?source=r_0123456789abcdef",
+	} {
+		method := http.MethodGet
+		if strings.HasPrefix(path, "/api/hub/shares") {
+			method = http.MethodPost
+		}
+		request := httptest.NewRequest(method, path, strings.NewReader(`{}`))
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, request)
+		if response.Code != http.StatusConflict {
+			t.Fatalf("%s status=%d", path, response.Code)
+		}
+		var body apiErrorBody
+		if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+			t.Fatal(err)
+		}
+		if body.Code != errCodeRemoteUnsupported {
+			t.Fatalf("%s code=%q", path, body.Code)
+		}
+	}
+}
+
+func TestRemoteRetryMissingAndDisabled(t *testing.T) {
+	t.Setenv("COSLASH_HOME", t.TempDir())
+	mgr := remote.NewManager(remote.Options{})
+	handler := routes(synthesis.NewManager(nil), settings.Open(), mgr, nil)
+
+	request := httptest.NewRequest(http.MethodPost, "/api/remote/retry", nil)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("status=%d", response.Code)
+	}
+
+	cfg := &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "gpu-server", Enabled: false}
+	if err := mgr.ApplySettings(cfg); err != nil {
+		t.Fatal(err)
+	}
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusConflict {
+		t.Fatalf("status=%d", response.Code)
+	}
+	var body apiErrorBody
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Code != errCodeRemoteDisabled {
+		t.Fatalf("code=%q", body.Code)
+	}
+}
+
+func TestRemoteTestRejectsHostileAlias(t *testing.T) {
+	t.Setenv("COSLASH_HOME", t.TempDir())
+	handler := routes(synthesis.NewManager(nil), settings.Open(), remote.NewManager(remote.Options{}), nil)
+	request := httptest.NewRequest(http.MethodPost, "/api/remote/test", strings.NewReader(`{"sshAlias":"--BatchMode=no"}`))
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d", response.Code)
+	}
+}
+
+func TestNormalizeRemoteIdentityAliasChange(t *testing.T) {
+	previous := &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "old-host", Enabled: true}
+	incoming := &settings.RemoteSettings{ID: "r_fedcba9876543210", SSHAlias: "new-host", Enabled: true}
+	out, err := normalizeRemoteIdentity(previous, incoming)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.ID == previous.ID || out.ID == incoming.ID {
+		t.Fatalf("expected freshly generated id, got %q", out.ID)
+	}
+	sameAlias := &settings.RemoteSettings{ID: "r_aaaaaaaaaaaaaaaa", SSHAlias: "old-host", Enabled: false}
+	out, err = normalizeRemoteIdentity(previous, sameAlias)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.ID != previous.ID {
+		t.Fatalf("same alias should keep id, got %q", out.ID)
+	}
+}
+
+func TestRemoteLaunchCapabilityAndAgentGates(t *testing.T) {
+	t.Setenv("COSLASH_HOME", t.TempDir())
+	store := settings.Open()
+	cfg := settings.Defaults()
+	cfg.Remote = &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "gpu-server", Enabled: true}
+	if err := store.Save(cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	fake := &remote.FakeRunner{Hook: func(call remote.FakeCall) (remote.RunResult, error) {
+		now := time.Now()
+		result := remote.RunResult{ExitCode: 0, StartedAt: now, FinishedAt: now}
+		if call.RemoteCommand == remote.ProbeCommand() {
+			probe := remoteviewv1.Probe{
+				SchemaVersion:    remoteviewv1.SchemaVersion,
+				CollectorVersion: "dev",
+				Capabilities:     []string{remoteviewv1.CapabilityRemoteView},
+				LaunchableAgents: []string{},
+				HostNowMs:        now.UnixMilli(),
+				Host:             remoteviewv1.Host{OS: "linux", Arch: "amd64"},
+			}
+			payload, err := remoteviewv1.MarshalProbe(probe)
+			if err != nil {
+				t.Fatal(err)
+			}
+			result.Stdout = mustFrame(t, payload)
+			return result, nil
+		}
+		view := remoteviewv1.View{
+			SchemaVersion:    remoteviewv1.SchemaVersion,
+			CollectorVersion: "dev",
+			Capabilities:     []string{remoteviewv1.CapabilityRemoteView},
+			LaunchableAgents: []string{},
+			RequestedSinceMs: 0,
+			RequestNowMs:     now.UnixMilli(),
+			HostNowMs:        now.UnixMilli(),
+			CollectedAtMs:    now.UnixMilli(),
+			CoverageSinceMs:  0,
+			Host:             remoteviewv1.Host{OS: "linux", Arch: "amd64"},
+			Sessions: []remoteviewv1.Session{{
+				Agent:              remoteviewv1.AgentCodex,
+				SourceSessionID:    "9c73be46-52af-4b1d-9ee7-123456789abc",
+				SessionStartedAtMs: now.UnixMilli() - 1000,
+				LastActivityAtMs:   now.UnixMilli(),
+				Counts:             remoteviewv1.Counts{Turns: 1},
+				Usage:              remoteviewv1.Usage{Models: []remoteviewv1.ModelUsage{}, UnpricedModels: []string{}},
+				Digest:             []remoteviewv1.Digest{},
+				Todos:              []remoteviewv1.Todo{},
+				FileEdits:          []remoteviewv1.FileEdit{},
+				Commits:            []string{},
+				Subagents:          []remoteviewv1.Subagent{},
+			}},
+		}
+		payload, err := remoteviewv1.Marshal(view)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result.Stdout = mustFrame(t, payload)
+		return result, nil
+	}}
+	mgr := remote.NewManager(remote.Options{Runner: fake, Cache: remote.NewCache(t.TempDir())})
+	if err := mgr.ApplySettings(cfg.Remote); err != nil {
+		t.Fatal(err)
+	}
+	waitRemoteOK(t, mgr)
+
+	handler := routes(synthesis.NewManager(nil), store, mgr, nil)
+	sessionID := remoteViewSessionID(t, mgr)
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/api/launch?source=r_0123456789abcdef&agent=codex&id="+sessionID+"&mode=resume",
+		nil,
+	)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusConflict {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	var body apiErrorBody
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Code != errCodeRemoteUpgradeRequired {
+		t.Fatalf("code=%q", body.Code)
+	}
+}
+
+func TestSaveSettingsAppliesRemoteAndGuidePath(t *testing.T) {
+	t.Setenv("COSLASH_HOME", t.TempDir())
+	store := settings.Open()
+	mgr := remote.NewManager(remote.Options{
+		Runner: &remote.FakeRunner{Hook: func(call remote.FakeCall) (remote.RunResult, error) {
+			now := time.Now()
+			result := remote.RunResult{ExitCode: 0, StartedAt: now, FinishedAt: now}
+			if call.RemoteCommand == remote.ProbeCommand() {
+				result.Stdout = mustFrame(t, mustMarshalProbe(t))
+				return result, nil
+			}
+			result.Stdout = mustFrame(t, mustMarshalView(t, 0, now.UnixMilli()))
+			return result, nil
+		}},
+		Cache: remote.NewCache(t.TempDir()),
+	})
+	handler := routes(synthesis.NewManager(nil), store, mgr, nil)
+
+	payload := `{
+  "$schema": "https://raw.githubusercontent.com/centauri-ai/coslash/main/settings.schema.json",
+  "version": 1,
+  "synthesis": {"enabled": false, "backend": "claude-cli", "model": "claude-haiku-4-5"},
+  "launch": {"terminal": "terminal"},
+  "remote": {"sshAlias": "gpu-server", "enabled": true}
+}`
+	request := httptest.NewRequest(http.MethodPut, "/api/settings", strings.NewReader(payload))
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	var body settingsResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Options.RemoteInstallationGuidePath != remoteInstallationGuidePath {
+		t.Fatalf("guide=%q", body.Options.RemoteInstallationGuidePath)
+	}
+	if body.Settings.Remote == nil || !settings.ValidRemoteID(body.Settings.Remote.ID) {
+		t.Fatalf("remote=%+v", body.Settings.Remote)
+	}
+	waitRemoteOK(t, mgr)
+}
+
+func waitRemoteOK(t *testing.T, mgr *remote.Manager) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		h := mgr.DiagnosticsHealth()
+		if h.State == remote.StateOK && !h.Refreshing {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("remote not ok: %+v", mgr.DiagnosticsHealth())
+}
+
+func remoteViewSessionID(t *testing.T, mgr *remote.Manager) string {
+	t.Helper()
+	list := mgr.ListView(0)
+	if len(list.Sessions) == 0 {
+		t.Fatal("no remote sessions")
+	}
+	return list.Sessions[0].Key.SourceSessionID
+}
+
+func mustMarshalProbe(t *testing.T) []byte {
+	t.Helper()
+	payload, err := remoteviewv1.MarshalProbe(remoteviewv1.Probe{
+		SchemaVersion:    remoteviewv1.SchemaVersion,
+		CollectorVersion: "dev",
+		Capabilities:     []string{remoteviewv1.CapabilityRemoteView, remoteviewv1.CapabilityRemoteLaunch},
+		LaunchableAgents: []string{remoteviewv1.AgentClaude, remoteviewv1.AgentCodex},
+		HostNowMs:        time.Now().UnixMilli(),
+		Host:             remoteviewv1.Host{OS: "linux", Arch: "amd64"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return payload
+}
+
+func mustMarshalView(t *testing.T, since, now int64) []byte {
+	t.Helper()
+	status := "active"
+	view := remoteviewv1.View{
+		SchemaVersion:    remoteviewv1.SchemaVersion,
+		CollectorVersion: "dev",
+		Capabilities:     []string{remoteviewv1.CapabilityRemoteView, remoteviewv1.CapabilityRemoteLaunch},
+		LaunchableAgents: []string{remoteviewv1.AgentClaude, remoteviewv1.AgentCodex},
+		RequestedSinceMs: since,
+		RequestNowMs:     now,
+		HostNowMs:        now,
+		CollectedAtMs:    now,
+		CoverageSinceMs:  since,
+		Host:             remoteviewv1.Host{OS: "linux", Arch: "amd64"},
+		Sessions: []remoteviewv1.Session{{
+			Agent:              remoteviewv1.AgentCodex,
+			SourceSessionID:    "9c73be46-52af-4b1d-9ee7-123456789abc",
+			Status:             &status,
+			SessionStartedAtMs: now - 1000,
+			LastActivityAtMs:   now,
+			Counts:             remoteviewv1.Counts{Turns: 1},
+			Usage:              remoteviewv1.Usage{Models: []remoteviewv1.ModelUsage{}, UnpricedModels: []string{}},
+			Digest:             []remoteviewv1.Digest{},
+			Todos:              []remoteviewv1.Todo{},
+			FileEdits:          []remoteviewv1.FileEdit{},
+			Commits:            []string{},
+			Subagents:          []remoteviewv1.Subagent{},
+		}},
+	}
+	payload, err := remoteviewv1.Marshal(view)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return payload
+}
+
+func mustFrame(t *testing.T, payload []byte) []byte {
+	t.Helper()
+	frame, err := remoteviewv1.EncodeFrame(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return frame
+}
+
+func parseSnapshotArgs(t *testing.T, command string) (since, requestNow int64) {
+	t.Helper()
+	var gotSince, gotNow int64
+	_, err := fmt.Sscanf(
+		command,
+		`exec "$HOME/.local/bin/coslash" snapshot --since %d --request-now %d --agents claude,codex`,
+		&gotSince,
+		&gotNow,
+	)
+	if err != nil {
+		t.Fatalf("parse %q: %v", command, err)
+	}
+	return gotSince, gotNow
+}
+
+func TestAPIRoutesRejectUnsupportedRemoteMethods(t *testing.T) {
+	t.Setenv("COSLASH_HOME", t.TempDir())
+	handler := routes(synthesis.NewManager(nil), settings.Open(), remote.NewManager(remote.Options{}), nil)
+	for _, test := range []struct {
+		method string
+		path   string
+	}{
+		{method: http.MethodGet, path: "/api/remote/test"},
+		{method: http.MethodGet, path: "/api/remote/retry"},
+		{method: http.MethodPut, path: "/api/remote/retry"},
+	} {
+		request := httptest.NewRequest(test.method, "http://127.0.0.1"+test.path, bytes.NewReader(nil))
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, request)
+		if response.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("%s %s status=%d", test.method, test.path, response.Code)
+		}
+	}
+}

--- a/collector/cmd/coslash/api_source.go
+++ b/collector/cmd/coslash/api_source.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/centauri-ai/coslash/collector/internal/remote"
+	"github.com/centauri-ai/coslash/collector/internal/session"
+	remoteviewv1 "github.com/centauri-ai/coslash/collector/remoteview/v1"
+)
+
+const (
+	localSourceID    = "local"
+	localSourceLabel = "This Mac"
+
+	remoteInstallationGuidePath = "docs/remote-host-installation.md"
+
+	errCodeRemoteUnsupported      = "remote_action_unsupported"
+	errCodeRemoteNotConfigured    = "remote_not_configured"
+	errCodeRemoteDisabled         = "remote_disabled"
+	errCodeRemoteUpgradeRequired  = "remote_upgrade_required"
+	errCodeRemoteAgentUnavailable = "remote_agent_unavailable"
+)
+
+type apiErrorBody struct {
+	Code  string `json:"code"`
+	Error string `json:"error"`
+}
+
+type sessionsResponse struct {
+	Sessions []boardSession `json:"sessions"`
+	Machines []machineFact  `json:"machines"`
+}
+
+type boardSession struct {
+	SourceID              string  `json:"sourceId"`
+	SourceLabel           string  `json:"sourceLabel"`
+	EligibleForAggregates bool    `json:"eligibleForAggregates"`
+	DisplayStale          bool    `json:"displayStale"`
+	LastSeenStatus        *string `json:"lastSeenStatus,omitempty"`
+	session.Session
+}
+
+type machineFact struct {
+	SourceID         string         `json:"sourceId"`
+	Label            string         `json:"label"`
+	State            remote.State   `json:"state"`
+	Complete         bool           `json:"complete"`
+	Reason           *remote.Reason `json:"reason,omitempty"`
+	CollectorVersion string         `json:"collectorVersion,omitempty"`
+	SchemaVersion    string         `json:"schemaVersion,omitempty"`
+	Capabilities     []string       `json:"capabilities,omitempty"`
+	LaunchableAgents []string       `json:"launchableAgents,omitempty"`
+	HostOS           string         `json:"hostOs,omitempty"`
+	HostArch         string         `json:"hostArch,omitempty"`
+	LastSuccessAtMs  *int64         `json:"lastSuccessAtMs,omitempty"`
+	CoverageSinceMs  *int64         `json:"coverageSinceMs,omitempty"`
+	ClockOffsetMs    *int64         `json:"clockOffsetMs,omitempty"`
+	RoundTripMs      *int64         `json:"roundTripMs,omitempty"`
+	Error            string         `json:"error,omitempty"`
+}
+
+func localMachineFact() machineFact {
+	return machineFact{
+		SourceID: localSourceID,
+		Label:    localSourceLabel,
+		State:    remote.StateOK,
+		Complete: true,
+	}
+}
+
+func machineFromHealth(health remote.Health) machineFact {
+	return machineFact{
+		SourceID:         health.SourceID,
+		Label:            health.Label,
+		State:            health.State,
+		Complete:         health.Complete,
+		Reason:           health.Reason,
+		CollectorVersion: health.CollectorVersion,
+		SchemaVersion:    health.SchemaVersion,
+		Capabilities:     health.Capabilities,
+		LaunchableAgents: health.LaunchableAgents,
+		HostOS:           health.HostOS,
+		HostArch:         health.HostArch,
+		LastSuccessAtMs:  health.LastSuccessAtMs,
+		CoverageSinceMs:  health.CoverageSinceMs,
+		ClockOffsetMs:    health.ClockOffsetMs,
+		RoundTripMs:      health.RoundTripMs,
+		Error:            health.Error,
+	}
+}
+
+func boardLocalSession(s *session.Session) boardSession {
+	return boardSession{
+		SourceID:              localSourceID,
+		SourceLabel:           localSourceLabel,
+		EligibleForAggregates: true,
+		DisplayStale:          false,
+		Session:               *s,
+	}
+}
+
+func boardRemoteSession(item remote.IndexedSession) boardSession {
+	mapped := mapRemoteViewSession(item.Session)
+	return boardSession{
+		SourceID:              item.Key.SourceID,
+		SourceLabel:           item.SourceLabel,
+		EligibleForAggregates: item.EligibleForAggregates,
+		DisplayStale:          item.DisplayStale,
+		LastSeenStatus:        item.LastSeenStatus,
+		Session:               mapped,
+	}
+}
+
+func mapRemoteViewSession(in remoteviewv1.Session) session.Session {
+	out := session.Session{
+		Agent:               in.Agent,
+		ID:                  in.SourceSessionID,
+		Name:                in.Name,
+		Summary:             in.Summary,
+		Status:              in.Status,
+		RepositoryLocalOnly: in.RepositoryLocalOnly,
+		EditedFileCount:     in.Counts.EditedFiles,
+		DurationMs:          in.DurationMs,
+		Cost:                float64(in.Usage.EstimatedCostMicroUSD) / 1_000_000,
+		UnpricedModels:      append([]string(nil), in.Usage.UnpricedModels...),
+		StartedAt:           in.SessionStartedAtMs,
+		LastActivityTime:    in.LastActivityAtMs,
+		Entrypoint:          in.Entrypoint,
+		SessionDetails: session.SessionDetails{
+			Model:         in.Model,
+			ContextTokens: in.ContextTokens,
+			ContextWindow: in.ContextWindow,
+			Turns:         in.Counts.Turns,
+			ToolUses:      in.Counts.ToolUses,
+			Errors:        in.Counts.Errors,
+			Compactions:   in.Counts.Compactions,
+			FirstPrompt:   in.FirstPrompt,
+			Commands:      []string{},
+			Commits:       append([]string(nil), in.Commits...),
+			PullRequests:  in.Counts.PullRequests,
+			DeclaredGoal:  in.DeclaredGoal,
+			LastEditAt:    in.LastEditAtMs,
+			Synthesis:     nil,
+		},
+	}
+	if in.WorkingDirectory != nil {
+		out.WorkingDirectory = *in.WorkingDirectory
+	}
+	if in.Repository != nil {
+		out.Repository = in.Repository
+	}
+	if in.Branch != nil {
+		out.Branch = in.Branch
+	}
+	out.Tokens = map[string]session.ModelTokens{}
+	for _, usage := range in.Usage.Models {
+		out.Tokens[usage.Model] = session.ModelTokens{
+			InputTokens:                usage.InputTokens,
+			OutputTokens:               usage.OutputTokens,
+			CacheCreationInputTokens:   usage.CacheCreationInputTokens,
+			CacheCreation1hInputTokens: usage.CacheCreation1hInputTokens,
+			CacheReadInputTokens:       usage.CacheReadInputTokens,
+			Cost:                       float64(usage.EstimatedCostMicroUSD) / 1_000_000,
+		}
+	}
+	out.Todos = make([]session.Todo, 0, len(in.Todos))
+	for _, todo := range in.Todos {
+		out.Todos = append(out.Todos, session.Todo{Text: todo.Text, Done: todo.Done})
+	}
+	out.Digest = make([]session.DigestEntry, 0, len(in.Digest))
+	for _, entry := range in.Digest {
+		mapped := session.DigestEntry{
+			Turn:        entry.Turn,
+			Category:    entry.Category,
+			Description: entry.Description,
+		}
+		if entry.Answer != nil {
+			mapped.Answer = *entry.Answer
+		}
+		if entry.SubagentID != nil {
+			mapped.SubagentID = *entry.SubagentID
+		}
+		out.Digest = append(out.Digest, mapped)
+	}
+	out.FileEdits = make([]session.FileEdit, 0, len(in.FileEdits))
+	for _, edit := range in.FileEdits {
+		out.FileEdits = append(out.FileEdits, session.FileEdit{
+			Path:      edit.Path,
+			Additions: edit.Additions,
+			Deletions: edit.Deletions,
+			Edits:     edit.Edits,
+			IsNew:     edit.IsNew,
+		})
+	}
+	if in.Git != nil {
+		out.Git = &session.GitDrift{
+			BaseBranch: in.Git.BaseBranch,
+			Ahead:      in.Git.Ahead,
+			Behind:     in.Git.Behind,
+		}
+	}
+	out.Subagents = make([]session.Subagent, 0, len(in.Subagents))
+	for _, sub := range in.Subagents {
+		mapped := session.Subagent{
+			ID:            sub.ID,
+			Name:          sub.Name,
+			Model:         sub.Model,
+			Status:        sub.Status,
+			Task:          sub.Task,
+			Result:        sub.Result,
+			DurationMs:    sub.DurationMs,
+			SpawnedAtTurn: sub.SpawnedAtTurn,
+			ToolUses:      sub.ToolUses,
+			Cost:          float64(sub.EstimatedCostMicroUSD) / 1_000_000,
+			Tokens:        map[string]session.ModelTokens{},
+		}
+		for _, label := range sub.CommandLabels {
+			mapped.Commands = append(mapped.Commands, session.SubagentCommand{Label: label})
+		}
+		for _, usage := range sub.Usage {
+			mapped.Tokens[usage.Model] = session.ModelTokens{
+				InputTokens:                usage.InputTokens,
+				OutputTokens:               usage.OutputTokens,
+				CacheCreationInputTokens:   usage.CacheCreationInputTokens,
+				CacheCreation1hInputTokens: usage.CacheCreation1hInputTokens,
+				CacheReadInputTokens:       usage.CacheReadInputTokens,
+				Cost:                       float64(usage.EstimatedCostMicroUSD) / 1_000_000,
+			}
+		}
+		out.Subagents = append(out.Subagents, mapped)
+	}
+	return out
+}
+
+func parseSourceID(value string) (string, error) {
+	if value == "" {
+		return localSourceID, nil
+	}
+	if value == localSourceID {
+		return localSourceID, nil
+	}
+	if !strings.HasPrefix(value, "r_") {
+		return "", fmt.Errorf("invalid source")
+	}
+	return value, nil
+}
+
+func rejectRemoteSource(w http.ResponseWriter, r *http.Request) bool {
+	source, err := parseSourceID(r.URL.Query().Get("source"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return true
+	}
+	if source != localSourceID {
+		writeAPIError(w, http.StatusConflict, errCodeRemoteUnsupported, "remote action unsupported")
+		return true
+	}
+	return false
+}
+
+func writeAPIError(w http.ResponseWriter, status int, code, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(apiErrorBody{Code: code, Error: message})
+}

--- a/collector/cmd/coslash/hub_api.go
+++ b/collector/cmd/coslash/hub_api.go
@@ -90,6 +90,9 @@ func registerHubRoutes(api *http.ServeMux, client *hubclient.Client) {
 		writeJSON(w, result)
 	})
 	api.HandleFunc("POST /api/hub/shares", func(w http.ResponseWriter, request *http.Request) {
+		if rejectRemoteSource(w, request) {
+			return
+		}
 		if client == nil {
 			http.Error(w, "Hub server is not configured", http.StatusConflict)
 			return

--- a/collector/cmd/coslash/main.go
+++ b/collector/cmd/coslash/main.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"syscall"
 	"time"
@@ -20,6 +21,7 @@ import (
 	"github.com/centauri-ai/coslash/collector/internal/diagnostics"
 	"github.com/centauri-ai/coslash/collector/internal/httpsec"
 	"github.com/centauri-ai/coslash/collector/internal/hubclient"
+	"github.com/centauri-ai/coslash/collector/internal/remote"
 	"github.com/centauri-ai/coslash/collector/internal/session"
 	"github.com/centauri-ai/coslash/collector/internal/settings"
 	"github.com/centauri-ai/coslash/collector/internal/synthesis"
@@ -114,6 +116,13 @@ func main() {
 	})
 	go cleanupHandoffs()
 
+	remoteMgr := remote.NewManager(remote.Options{})
+	if settingsState.Valid {
+		if err := remoteMgr.ApplySettings(settingsState.Config.Remote); err != nil {
+			log.Printf("remote settings: %v", err)
+		}
+	}
+
 	// Bind before opening the browser, so a port conflict is an error the user
 	// reads rather than a browser tab pointed at nothing.
 	listener, err := listen(opts.port)
@@ -141,8 +150,16 @@ func main() {
 	if err != nil {
 		log.Printf("Hub integration disabled: %v", err)
 	}
-	server := newServer(guard, mgr, settingsStore, hub)
-	if err := server.Serve(listener); err != nil {
+	server := newServer(guard, mgr, settingsStore, remoteMgr, hub)
+	go func() {
+		signals := make(chan os.Signal, 1)
+		signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+		<-signals
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.Shutdown(ctx)
+	}()
+	if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		log.Fatalf("coslash: %v", err)
 	}
 }
@@ -151,26 +168,34 @@ func newServer(
 	guard httpsec.Guard,
 	mgr *synthesis.Manager,
 	settingsStore *settings.Store,
+	remoteMgr *remote.Manager,
 	hub *hubclient.Client,
 ) *http.Server {
-	return &http.Server{
-		Handler:           guard.Wrap(routes(mgr, settingsStore, hub)),
+	server := &http.Server{
+		Handler:           guard.Wrap(routes(mgr, settingsStore, remoteMgr, hub)),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		WriteTimeout:      3 * time.Minute,
 		IdleTimeout:       60 * time.Second,
 		MaxHeaderBytes:    1 << 16,
 	}
+	server.RegisterOnShutdown(remoteMgr.Shutdown)
+	return server
 }
 
-func routes(mgr *synthesis.Manager, settingsStore *settings.Store, hub *hubclient.Client) *http.ServeMux {
+func routes(
+	mgr *synthesis.Manager,
+	settingsStore *settings.Store,
+	remoteMgr *remote.Manager,
+	hub *hubclient.Client,
+) *http.ServeMux {
 	mux := http.NewServeMux()
 	api := http.NewServeMux()
 	api.HandleFunc("GET /api/sessions", func(w http.ResponseWriter, r *http.Request) {
-		handleList(w, r, mgr)
+		handleList(w, r, mgr, remoteMgr)
 	})
 	api.HandleFunc("GET /api/synthesis", func(w http.ResponseWriter, r *http.Request) {
-		handleSynthesis(w, r.URL.Query().Get("id"), mgr)
+		handleSynthesis(w, r, mgr)
 	})
 	api.HandleFunc("GET /api/diff", func(w http.ResponseWriter, r *http.Request) {
 		handleDiff(w, r, collector.GetSessionFacts)
@@ -182,13 +207,19 @@ func routes(mgr *synthesis.Manager, settingsStore *settings.Store, hub *hubclien
 		writeSettings(w, settingsStore.State())
 	})
 	api.HandleFunc("PUT /api/settings", func(w http.ResponseWriter, r *http.Request) {
-		handleSaveSettings(w, r, settingsStore, mgr)
+		handleSaveSettings(w, r, settingsStore, mgr, remoteMgr)
 	})
 	api.HandleFunc("POST /api/launch", func(w http.ResponseWriter, r *http.Request) {
-		handleLaunch(w, r, settingsStore)
+		handleLaunchSourceAware(w, r, settingsStore, remoteMgr)
+	})
+	api.HandleFunc("POST /api/remote/test", func(w http.ResponseWriter, r *http.Request) {
+		handleRemoteTest(w, r, remoteMgr)
+	})
+	api.HandleFunc("POST /api/remote/retry", func(w http.ResponseWriter, r *http.Request) {
+		handleRemoteRetry(w, r, remoteMgr)
 	})
 	api.HandleFunc("GET /api/diagnostics", func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, diagnostics.Collect(r.Context(), version, false))
+		writeJSON(w, diagnostics.CollectWithRemote(r.Context(), version, false, remoteHealthFact(remoteMgr)))
 	})
 	registerHubRoutes(api, hub)
 	mux.Handle("/api", api)
@@ -224,6 +255,34 @@ func unavailable() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "frontend unavailable", http.StatusServiceUnavailable)
 	})
+}
+
+func remoteHealthFact(mgr *remote.Manager) *diagnostics.RemoteHealth {
+	health := mgr.DiagnosticsHealth()
+	if health.SourceID == "" {
+		return nil
+	}
+	var reason *string
+	if health.Reason != nil {
+		value := string(*health.Reason)
+		reason = &value
+	}
+	return &diagnostics.RemoteHealth{
+		SourceID:         health.SourceID,
+		Label:            health.Label,
+		State:            string(health.State),
+		Complete:         health.Complete,
+		Reason:           reason,
+		CollectorVersion: health.CollectorVersion,
+		SchemaVersion:    health.SchemaVersion,
+		Capabilities:     append([]string(nil), health.Capabilities...),
+		LaunchableAgents: append([]string(nil), health.LaunchableAgents...),
+		HostOS:           health.HostOS,
+		HostArch:         health.HostArch,
+		LastSuccessAtMs:  health.LastSuccessAtMs,
+		Error:            health.Error,
+		DiagnosticStderr: health.DiagnosticStderr,
+	}
 }
 
 func newToken() (string, error) {

--- a/collector/cmd/coslash/main_test.go
+++ b/collector/cmd/coslash/main_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/centauri-ai/coslash/collector/internal/httpsec"
+	"github.com/centauri-ai/coslash/collector/internal/remote"
 	"github.com/centauri-ai/coslash/collector/internal/session"
 	"github.com/centauri-ai/coslash/collector/internal/settings"
 	"github.com/centauri-ai/coslash/collector/internal/synthesis"
@@ -40,7 +41,7 @@ func TestListenBindsIPv4Loopback(t *testing.T) {
 
 func TestAPIRoutesRejectUnsupportedMethods(t *testing.T) {
 	t.Setenv("COSLASH_HOME", t.TempDir())
-	handler := routes(synthesis.NewManager(nil), settings.Open(), nil)
+	handler := routes(synthesis.NewManager(nil), settings.Open(), remote.NewManager(remote.Options{}), nil)
 	for _, test := range []struct {
 		method string
 		path   string
@@ -68,6 +69,7 @@ func TestServerWrapsRoutesWithGuard(t *testing.T) {
 		httpsec.Guard{Addr: "127.0.0.1:8787", Token: "secret"},
 		synthesis.NewManager(nil),
 		settings.Open(),
+		remote.NewManager(remote.Options{}),
 		nil,
 	)
 	request := httptest.NewRequest(http.MethodGet, "http://evil.example:8787/", nil)

--- a/collector/internal/diagnostics/checks.go
+++ b/collector/internal/diagnostics/checks.go
@@ -145,3 +145,33 @@ func sourceCheck(source Source) Check {
 	}
 	return check
 }
+
+func remoteCheck(remote *Remote) Check {
+	check := Check{ID: "remote", Title: "Remote SSH host", Status: StatusOK}
+	switch remote.State {
+	case "ok":
+		check.Detail = remote.Label + " is connected."
+	case "connecting":
+		check.Status = StatusWarn
+		check.Detail = "Connecting to " + remote.Label + "."
+	case "limited", "stale":
+		check.Status = StatusWarn
+		check.Detail = remote.Label + " is " + remote.State + "."
+		if remote.Error != "" {
+			check.Detail += " " + remote.Error
+		}
+	case "setup_required", "upgrade_required", "error":
+		check.Status = StatusFail
+		check.Detail = remote.Label + " needs attention."
+		if remote.Error != "" {
+			check.Detail += " " + remote.Error
+		}
+		check.Fix = "Open Machines in Settings and use Test connection or Retry."
+	case "disabled":
+		check.Detail = remote.Label + " is disabled."
+	default:
+		check.Status = StatusWarn
+		check.Detail = remote.Label + " state is " + remote.State + "."
+	}
+	return check
+}

--- a/collector/internal/diagnostics/snapshot.go
+++ b/collector/internal/diagnostics/snapshot.go
@@ -39,10 +39,29 @@ type Snapshot struct {
 	Storage             Storage   `json:"storage"`
 	Synthesis           Synthesis `json:"synthesis"`
 	Sources             []Source  `json:"sources"`
+	Remote              *Remote   `json:"remote,omitempty"`
 	Checks              []Check   `json:"checks"`
 	openCodePlugin      opencode.WaitingPluginHealth
 	openCodePluginError string
 	homeError           string
+}
+
+// Remote is the optional SSH host health block for diagnostics.
+type Remote struct {
+	SourceID         string   `json:"sourceId,omitempty"`
+	Label            string   `json:"label,omitempty"`
+	State            string   `json:"state"`
+	Complete         bool     `json:"complete"`
+	Reason           *string  `json:"reason,omitempty"`
+	CollectorVersion string   `json:"collectorVersion,omitempty"`
+	SchemaVersion    string   `json:"schemaVersion,omitempty"`
+	Capabilities     []string `json:"capabilities,omitempty"`
+	LaunchableAgents []string `json:"launchableAgents,omitempty"`
+	HostOS           string   `json:"hostOs,omitempty"`
+	HostArch         string   `json:"hostArch,omitempty"`
+	LastSuccessAtMs  *int64   `json:"lastSuccessAtMs,omitempty"`
+	Error            string   `json:"error,omitempty"`
+	DiagnosticStderr string   `json:"diagnosticStderr,omitempty"`
 }
 
 type Platform struct {
@@ -100,6 +119,53 @@ type Check struct {
 
 // Collect turns every probe failure into data so the diagnostic surface itself remains available.
 func Collect(ctx context.Context, version string, includeVersions bool) *Snapshot {
+	return CollectWithRemote(ctx, version, includeVersions, nil)
+}
+
+// RemoteHealth is the minimal remote manager fact block accepted by diagnostics.
+type RemoteHealth struct {
+	SourceID         string
+	Label            string
+	State            string
+	Complete         bool
+	Reason           *string
+	CollectorVersion string
+	SchemaVersion    string
+	Capabilities     []string
+	LaunchableAgents []string
+	HostOS           string
+	HostArch         string
+	LastSuccessAtMs  *int64
+	Error            string
+	DiagnosticStderr string
+}
+
+// CollectWithRemote includes the optional remote machine health fact block.
+func CollectWithRemote(ctx context.Context, version string, includeVersions bool, remoteHealth *RemoteHealth) *Snapshot {
+	snapshot := collectLocal(ctx, version, includeVersions)
+	if remoteHealth != nil && remoteHealth.SourceID != "" {
+		snapshot.Remote = &Remote{
+			SourceID:         remoteHealth.SourceID,
+			Label:            remoteHealth.Label,
+			State:            remoteHealth.State,
+			Complete:         remoteHealth.Complete,
+			Reason:           remoteHealth.Reason,
+			CollectorVersion: remoteHealth.CollectorVersion,
+			SchemaVersion:    remoteHealth.SchemaVersion,
+			Capabilities:     append([]string(nil), remoteHealth.Capabilities...),
+			LaunchableAgents: append([]string(nil), remoteHealth.LaunchableAgents...),
+			HostOS:           remoteHealth.HostOS,
+			HostArch:         remoteHealth.HostArch,
+			LastSuccessAtMs:  remoteHealth.LastSuccessAtMs,
+			Error:            remoteHealth.Error,
+			DiagnosticStderr: remoteHealth.DiagnosticStderr,
+		}
+		snapshot.Checks = append(snapshot.Checks, remoteCheck(snapshot.Remote))
+	}
+	return snapshot
+}
+
+func collectLocal(ctx context.Context, version string, includeVersions bool) *Snapshot {
 	userHome, userHomeErr := os.UserHomeDir()
 	state := settings.Open().State()
 	config := state.Config.Synthesis

--- a/collector/internal/remote/manager.go
+++ b/collector/internal/remote/manager.go
@@ -112,9 +112,9 @@ func (m *Manager) ApplySettings(remote *settings.RemoteSettings) error {
 	copyCfg := *remote
 	same := m.cfg != nil && m.cfg.ID == remote.ID
 	wasEnabled := same && m.cfg.Enabled
-	m.cfg = &copyCfg
 
 	if !remote.Enabled {
+		m.cfg = &copyCfg
 		m.cancelLifeLocked()
 		m.refreshing = false
 		m.probe = nil
@@ -126,7 +126,14 @@ func (m *Manager) ApplySettings(remote *settings.RemoteSettings) error {
 	}
 
 	if !same || !wasEnabled {
+		previousCfg := m.cfg
+		previousCached := m.cached
+		previousLastSuccess := m.lastSuccessAt
+		m.cfg = &copyCfg
 		if err := m.loadCacheLocked(); err != nil {
+			m.cfg = previousCfg
+			m.cached = previousCached
+			m.lastSuccessAt = previousLastSuccess
 			return err
 		}
 		m.probe = nil
@@ -138,7 +145,10 @@ func (m *Manager) ApplySettings(remote *settings.RemoteSettings) error {
 		m.nextRetryAt = time.Time{}
 		cutoff := m.lastRequestedMs
 		m.kickRefreshLocked(cutoff, true)
+		return nil
 	}
+
+	m.cfg = &copyCfg
 	return nil
 }
 

--- a/collector/internal/remote/manager_test.go
+++ b/collector/internal/remote/manager_test.go
@@ -2,6 +2,8 @@ package remote
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -401,4 +403,56 @@ func TestTestAlias(t *testing.T) {
 	if health.State != StateOK || health.CollectorVersion != "dev" {
 		t.Fatalf("%+v", health)
 	}
+}
+
+func TestApplySettingsRollsBackWhenCacheLoadFails(t *testing.T) {
+	root := t.TempDir()
+	id := "r_0123456789abcdef"
+	if err := os.MkdirAll(filepath.Join(root, "remotes"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// A file where the source directory should be makes snapshot reads fail.
+	if err := os.WriteFile(filepath.Join(root, "remotes", id), []byte("not-a-directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var calls atomic.Int32
+	fake := &FakeRunner{Hook: func(call FakeCall) (RunResult, error) {
+		calls.Add(1)
+		t.Fatal("refresh must not start after failed ApplySettings")
+		return RunResult{}, nil
+	}}
+	mgr := NewManager(Options{Runner: fake, Cache: NewCache(root)})
+	cfg := &settings.RemoteSettings{ID: id, SSHAlias: "gpu-server", Enabled: true}
+	if err := mgr.ApplySettings(cfg); err == nil {
+		t.Fatal("expected cache load error")
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("unexpected refresh calls: %d", calls.Load())
+	}
+	if health := mgr.DiagnosticsHealth(); health.SourceID != "" {
+		t.Fatalf("expected rolled-back manager, got %+v", health)
+	}
+
+	// A later save with the same settings must still be able to start cleanly.
+	cleanRoot := t.TempDir()
+	mgr = NewManager(Options{
+		Runner: &FakeRunner{Hook: func(call FakeCall) (RunResult, error) {
+			now := time.Now()
+			result := RunResult{ExitCode: 0, StartedAt: now, FinishedAt: now}
+			if call.RemoteCommand == ProbeCommand() {
+				result.Stdout = framedProbe(t)
+				return result, nil
+			}
+			result.Stdout = framedView(t, 0, now.UnixMilli())
+			return result, nil
+		}},
+		Cache: NewCache(cleanRoot),
+	})
+	if err := mgr.ApplySettings(cfg); err != nil {
+		t.Fatal(err)
+	}
+	waitUntil(t, 2*time.Second, func() bool {
+		h := mgr.DiagnosticsHealth()
+		return h.State == StateOK && !h.Refreshing
+	})
 }

--- a/collector/internal/settings/settings.go
+++ b/collector/internal/settings/settings.go
@@ -246,7 +246,7 @@ func validateRemote(remote *RemoteSettings) error {
 	if remote == nil {
 		return nil
 	}
-	if !ValidRemoteID(remote.ID) {
+	if remote.ID != "" && !ValidRemoteID(remote.ID) {
 		return fmt.Errorf("remote id %q is not a valid source id", remote.ID)
 	}
 	if !ValidSSHAlias(remote.SSHAlias) {
@@ -313,13 +313,15 @@ func Decode(data []byte) (Config, error) {
 		config.Appearance.Theme = *document.Appearance.Theme
 	}
 	if document.Remote != nil {
-		if document.Remote.ID == nil || document.Remote.SSHAlias == nil || document.Remote.Enabled == nil {
-			return Config{}, errors.New("remote must include id, sshAlias, and enabled")
+		if document.Remote.SSHAlias == nil || document.Remote.Enabled == nil {
+			return Config{}, errors.New("remote must include sshAlias and enabled")
 		}
 		config.Remote = &RemoteSettings{
-			ID:       *document.Remote.ID,
 			SSHAlias: *document.Remote.SSHAlias,
 			Enabled:  *document.Remote.Enabled,
+		}
+		if document.Remote.ID != nil {
+			config.Remote.ID = *document.Remote.ID
 		}
 	}
 	if err := Validate(config); err != nil {
@@ -380,6 +382,9 @@ func (store *Store) State() State {
 func (store *Store) Save(config Config) error {
 	if err := Validate(config); err != nil {
 		return err
+	}
+	if config.Remote != nil && !ValidRemoteID(config.Remote.ID) {
+		return fmt.Errorf("remote id %q is not a valid source id", config.Remote.ID)
 	}
 	data, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {

--- a/collector/internal/settings/settings_test.go
+++ b/collector/internal/settings/settings_test.go
@@ -63,6 +63,19 @@ func TestDecodeRemoteRejectsUnknownAndInvalid(t *testing.T) {
 	}
 }
 
+func TestDecodeRemoteAllowsOmittedID(t *testing.T) {
+	raw := strings.TrimSuffix(validBase(), "}") + `,
+  "remote": {"sshAlias": "gpu-server", "enabled": true}
+}`
+	config, err := Decode([]byte(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Remote == nil || config.Remote.ID != "" || config.Remote.SSHAlias != "gpu-server" {
+		t.Fatalf("unexpected remote: %+v", config.Remote)
+	}
+}
+
 func TestNewRemoteIDIsValidAndDistinct(t *testing.T) {
 	a, err := NewRemoteID()
 	if err != nil {

--- a/frontend/src/pages/coslash/hooks/use-sessions.test.ts
+++ b/frontend/src/pages/coslash/hooks/use-sessions.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { decodeSessionsResponse } from '@/pages/coslash/hooks/use-sessions';
+import type { Session } from '@/pages/coslash/lib/session';
+
+function sampleSession(id: string): Session {
+  return {
+    agent: 'codex',
+    id,
+    name: null,
+    summary: null,
+    status: null,
+    cwd: '/tmp',
+    branch: null,
+    repo: null,
+    repoLocalOnly: false,
+    files: 0,
+    durationMs: null,
+    tokens: {},
+    cost: 0,
+    unpricedModels: [],
+    subagents: [],
+    mtime: 1,
+    entrypoint: null,
+    synthesis: null,
+    synthesisPending: false,
+    declaredGoal: null,
+    model: null,
+    contextTokens: null,
+    contextWindow: null,
+    turns: 0,
+    toolUses: 0,
+    errors: 0,
+    compactions: 0,
+    firstPrompt: null,
+    commands: [],
+    commits: [],
+    prs: 0,
+    todos: [],
+    digest: [],
+    fileEdits: [],
+    git: null,
+    lastEditAt: null,
+  };
+}
+
+describe('decodeSessionsResponse', () => {
+  it('accepts the legacy bare array', () => {
+    const sessions = [sampleSession('a')];
+    expect(decodeSessionsResponse(sessions)).toEqual(sessions);
+  });
+
+  it('accepts the source-aware envelope', () => {
+    const sessions = [sampleSession('a'), sampleSession('b')];
+    expect(
+      decodeSessionsResponse({
+        sessions,
+        machines: [{ sourceId: 'local', label: 'This Mac', state: 'ok', complete: true }],
+      }),
+    ).toEqual(sessions);
+  });
+
+  it('rejects invalid bodies', () => {
+    expect(() => decodeSessionsResponse({ machines: [] })).toThrow('Invalid sessions response');
+    expect(() => decodeSessionsResponse(null)).toThrow('Invalid sessions response');
+  });
+});

--- a/frontend/src/pages/coslash/hooks/use-sessions.ts
+++ b/frontend/src/pages/coslash/hooks/use-sessions.ts
@@ -16,6 +16,20 @@ export type FileChange = {
   deletions: number;
 };
 
+export function decodeSessionsResponse(body: unknown): Session[] {
+  if (Array.isArray(body)) {
+    return body as Session[];
+  }
+  if (
+    body != null &&
+    typeof body === 'object' &&
+    Array.isArray((body as { sessions?: unknown }).sessions)
+  ) {
+    return (body as { sessions: Session[] }).sessions;
+  }
+  throw new Error('Invalid sessions response');
+}
+
 export function diffRequestPath(selection: FileSelection) {
   return `/api/diff?${new URLSearchParams({ id: selection.sessionId, path: selection.path })}`;
 }
@@ -75,17 +89,19 @@ export function useSessions(timeWindow: TimeWindow) {
         setLoadError(null);
       }
       const since = timeWindowStart(timeWindow);
-      const path = since == null ? '/api/sessions' : `/api/sessions?since=${since}`;
+      const path = since == null
+        ? '/api/sessions'
+        : `/api/sessions?since=${since}&remoteSince=${since}`;
       apiFetch(path, { signal: controller.signal })
         .then((response) => {
           if (!response.ok) {
             throw new Error(`Sessions request failed (${response.status})`);
           }
-          return response.json() as Promise<Session[]>;
+          return response.json() as Promise<unknown>;
         })
-        .then((loadedSessions) => {
+        .then((body) => {
           if (controller.signal.aborted) return;
-          setSessions(loadedSessions);
+          setSessions(decodeSessionsResponse(body));
           setSessionsVersion((version) => version + 1);
           setIsLoading(false);
           setLoadError(null);

--- a/frontend/src/pages/coslash/hooks/use-sessions.ts
+++ b/frontend/src/pages/coslash/hooks/use-sessions.ts
@@ -20,11 +20,7 @@ export function decodeSessionsResponse(body: unknown): Session[] {
   if (Array.isArray(body)) {
     return body as Session[];
   }
-  if (
-    body != null &&
-    typeof body === 'object' &&
-    Array.isArray((body as { sessions?: unknown }).sessions)
-  ) {
+  if (body != null && typeof body === 'object' && Array.isArray((body as { sessions?: unknown }).sessions)) {
     return (body as { sessions: Session[] }).sessions;
   }
   throw new Error('Invalid sessions response');
@@ -89,9 +85,7 @@ export function useSessions(timeWindow: TimeWindow) {
         setLoadError(null);
       }
       const since = timeWindowStart(timeWindow);
-      const path = since == null
-        ? '/api/sessions'
-        : `/api/sessions?since=${since}&remoteSince=${since}`;
+      const path = since == null ? '/api/sessions' : `/api/sessions?since=${since}&remoteSince=${since}`;
       apiFetch(path, { signal: controller.signal })
         .then((response) => {
           if (!response.ok) {


### PR DESCRIPTION
## Context

The remote collection foundation needs a stable API so the application can combine local and remote sessions without confusing their identities or routing remote actions through local-only code.

## Changes

- Return source-aware sessions and machine health while keeping local and remote time windows independent.
- Add remote connection testing, retry, and source-aware launch routing.
- Reject unsupported remote diff, synthesis, preview, and Hub-sharing actions with stable errors.

## Test

- `go vet ./...` — passed
- `go test ./...` — passed
- Manual: Live SSH host validation not run

## Stack

Review slice 2 of 4. Previous: https://github.com/centauri-ai/coslash/pull/110. Next: https://github.com/centauri-ai/coslash/pull/112. Umbrella: https://github.com/centauri-ai/coslash/pull/114.
