### PR TITLE
Show remote sessions and ship Linux collector installs

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -83,3 +83,5 @@ template: |
 
   Substitute the release version and architecture. The binaries are unsigned and unnotarized, so macOS may warn about an archive downloaded through a browser; the Homebrew install above is not affected.
 
+  Linux remote-host archives are also published as `coslash_<tag>_linux_amd64.tar.gz` and `coslash_<tag>_linux_arm64.tar.gz`. Install those with the steps in `docs/remote-host-installation.md`; Homebrew remains macOS-only.
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,8 +317,80 @@ jobs:
           fi
           collector/scripts/smoke.sh "$binary" embedded
 
+  # Cross-built Linux archives: execute the runner-native arch fully, and only
+  # verify integrity/ELF class for the other arch on this Ubuntu host.
+  smoke-linux:
+    needs: [plan, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out coSlash
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.plan.outputs.source_sha }}
+      - name: Download release artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-artifacts
+          path: dist
+      - name: Verify checksums and Linux packages
+        env:
+          VERSION: ${{ needs.plan.outputs.version }}
+        run: |
+          set -euo pipefail
+          (cd dist && sha256sum -c checksums.txt)
+
+          runner_arch="$(uname -m)"
+          case "$runner_arch" in
+            x86_64) native=amd64; other_marker='ARM aarch64' ;;
+            aarch64|arm64) native=arm64; other_marker='x86-64' ;;
+            *)
+              echo "error: unsupported runner arch $runner_arch" >&2
+              exit 1
+              ;;
+          esac
+
+          for arch in amd64 arm64; do
+            stem="coslash_${VERSION}_linux_${arch}"
+            [[ -f "dist/${stem}.tar.gz" ]] || {
+              echo "error: missing dist/${stem}.tar.gz" >&2
+              exit 1
+            }
+            unpacked="$(mktemp -d)"
+            tar -xzf "dist/${stem}.tar.gz" -C "$unpacked"
+            binary="$unpacked/$stem/coslash"
+            [[ -x "$binary" ]] || {
+              echo "error: packaged binary is not executable: $binary" >&2
+              exit 1
+            }
+            file_out="$(file -b "$binary")"
+            echo "$stem -> $file_out"
+            if [[ "$arch" == "$native" ]]; then
+              version="$("$binary" --version)"
+              if [[ "$version" != "$VERSION" ]]; then
+                echo "error: packaged binary reports $version, expected $VERSION" >&2
+                exit 1
+              fi
+              collector/scripts/smoke-linux-remote.sh "$binary"
+            else
+              if ! grep -Fq "$other_marker" <<<"$file_out"; then
+                echo "error: expected $other_marker binary for $stem, got: $file_out" >&2
+                exit 1
+              fi
+              echo "skipped execution for non-native $stem on $runner_arch"
+            fi
+            rm -rf "$unpacked"
+          done
+
+          for arch in arm64 amd64; do
+            stem="coslash_${VERSION}_darwin_${arch}"
+            [[ -f "dist/${stem}.tar.gz" ]] || {
+              echo "error: missing dist/${stem}.tar.gz" >&2
+              exit 1
+            }
+          done
+
   publish:
-    needs: [plan, build, smoke]
+    needs: [plan, build, smoke, smoke-linux]
     if: needs.plan.outputs.should_publish == 'true'
     runs-on: macos-15
     # Manual releases use the protected environment. The fallback tag path

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ coSlash serves <http://127.0.0.1:8787> and opens your browser with a fresh acces
 
 `brew upgrade coslash` updates it and `brew uninstall coslash` removes the binary. Uninstalling leaves your data in `~/.coslash`; delete that directory separately if you no longer want it.
 
+To monitor Claude Code and Codex on one Linux host over SSH, install the Linux collector manually with [`docs/remote-host-installation.md`](docs/remote-host-installation.md). Homebrew packages remain macOS-only.
+
 <details>
 <summary>Install a release archive manually</summary>
 
@@ -194,13 +196,13 @@ It is **off until you explicitly enable and save it**.
 
 ## Settings and data
 
-Settings live behind the top-right button and are stored machine-wide in `~/.coslash/settings.json` — synthesis backend and model, light or dark theme, and the terminal used for launches (Apple Terminal or iTerm2). See [`settings.schema.json`](settings.schema.json) for the file format.
+Settings live behind the top-right button and are stored machine-wide in `~/.coslash/settings.json` — synthesis backend and model, light or dark theme, the terminal used for launches (Apple Terminal or iTerm2), and an optional SSH host. See [`settings.schema.json`](settings.schema.json) for the file format.
 
 The dialog offers a short model list per backend, but the model is not restricted to it. Editing `settings.json` directly accepts any model the selected CLI can actually reach — including one served through an API proxy such as `ANTHROPIC_BASE_URL`, or a third-party provider — so long as that CLI is set up to resolve it.
 
-Transcripts are read-only; coSlash never modifies them. Cached summaries and temporary handoffs live under `~/.coslash`. The server is loopback-only and protects every API request with an access token minted at start.
+Transcripts are read-only; coSlash never modifies them. Cached summaries and temporary handoffs live under `~/.coslash`. An optional remote host keeps its last good snapshot under `~/.coslash/remotes/<sourceId>/`. The server is loopback-only and protects every API request with an access token minted at start.
 
-Read [Data and privacy](docs/data-and-privacy.md) before pointing coSlash at sensitive transcripts.
+Read [Data and privacy](docs/data-and-privacy.md) before pointing coSlash at sensitive transcripts. For Linux collector setup, see [Remote host installation](docs/remote-host-installation.md). For common remote failures, see [Troubleshooting](docs/troubleshooting.md).
 
 ## Command reference
 

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -4,7 +4,7 @@ FRONTEND := ../frontend
 STAGED := internal/web/dist
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 DIST := dist
-PLATFORMS := darwin/arm64 darwin/amd64
+PLATFORMS := darwin/arm64 darwin/amd64 linux/amd64 linux/arm64
 ARGS :=
 LDFLAGS := -X main.version=$(VERSION)
 MODELS := internal/session/models.json

--- a/collector/cmd/coslash/api_source.go
+++ b/collector/cmd/coslash/api_source.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/centauri-ai/coslash/collector/internal/diagnostics"
 	"github.com/centauri-ai/coslash/collector/internal/remote"
 	"github.com/centauri-ai/coslash/collector/internal/session"
 	remoteviewv1 "github.com/centauri-ai/coslash/collector/remoteview/v1"
@@ -15,14 +16,15 @@ const (
 	localSourceID    = "local"
 	localSourceLabel = "This Mac"
 
-	remoteInstallationGuidePath = "docs/remote-host-installation.md"
-
 	errCodeRemoteUnsupported      = "remote_action_unsupported"
 	errCodeRemoteNotConfigured    = "remote_not_configured"
 	errCodeRemoteDisabled         = "remote_disabled"
 	errCodeRemoteUpgradeRequired  = "remote_upgrade_required"
 	errCodeRemoteAgentUnavailable = "remote_agent_unavailable"
 )
+
+// Keep settings options aligned with the diagnostics/setup guide constant.
+var remoteInstallationGuidePath = diagnostics.RemoteInstallationGuidePath
 
 type apiErrorBody struct {
 	Code  string `json:"code"`

--- a/collector/cmd/coslash/doctor.go
+++ b/collector/cmd/coslash/doctor.go
@@ -10,6 +10,8 @@ import (
 	"log"
 
 	"github.com/centauri-ai/coslash/collector/internal/diagnostics"
+	"github.com/centauri-ai/coslash/collector/internal/remote"
+	"github.com/centauri-ai/coslash/collector/internal/settings"
 )
 
 func runDoctor(stdout, stderr io.Writer, args []string) int {
@@ -28,7 +30,7 @@ func runDoctor(stdout, stderr io.Writer, args []string) int {
 	}
 	logOutput := log.Writer()
 	log.SetOutput(io.Discard)
-	snapshot := diagnostics.Collect(context.Background(), version, true)
+	snapshot := collectDoctorSnapshot(context.Background())
 	log.SetOutput(logOutput)
 	if *jsonOutput {
 		if err := json.NewEncoder(stdout).Encode(snapshot); err != nil {
@@ -36,35 +38,22 @@ func runDoctor(stdout, stderr io.Writer, args []string) int {
 			return 2
 		}
 	} else {
-		renderDoctor(stdout, snapshot)
+		fmt.Fprintln(stdout, diagnostics.FormatForCopy(snapshot))
 	}
 	return doctorExitCode(snapshot)
 }
 
-func renderDoctor(w io.Writer, snapshot *diagnostics.Snapshot) {
-	fmt.Fprintf(w, "coSlash %s diagnostics\n\nChecks\n", snapshot.Version)
-	for _, check := range snapshot.Checks {
-		marker := string(check.Status)
-		if check.Status == diagnostics.StatusFail {
-			marker = "FAIL"
-		}
-		fmt.Fprintf(w, "[%s] %s: %s\n", marker, check.Title, check.Detail)
-		if check.Fix != "" {
-			fmt.Fprintf(w, "       Fix: %s\n", check.Fix)
+func collectDoctorSnapshot(ctx context.Context) *diagnostics.Snapshot {
+	mgr := remote.NewManager(remote.Options{})
+	defer mgr.Shutdown()
+
+	state := settings.Open().State()
+	if state.Valid {
+		if err := mgr.LoadSettingsSnapshot(state.Config.Remote); err != nil {
+			log.Printf("remote diagnostics: %v", err)
 		}
 	}
-	fmt.Fprintln(w, "\nFacts")
-	for _, source := range snapshot.Sources {
-		cli := "not found"
-		if source.CLI.Found {
-			cli = source.CLI.Path
-			if source.CLI.Version != "" {
-				cli += " (" + source.CLI.Version + ")"
-			}
-		}
-		fmt.Fprintf(w, "%s: %s, %d source entries, %d sessions; CLI %s\n", source.Label, source.Root, source.Entries, source.Sessions, cli)
-	}
-	fmt.Fprintf(w, "Storage: %s, writable=%t\n", snapshot.Storage.Home, snapshot.Storage.Writable)
+	return diagnostics.CollectWithRemote(ctx, version, true, remoteHealthFact(mgr))
 }
 
 func doctorExitCode(snapshot *diagnostics.Snapshot) int {

--- a/collector/cmd/coslash/doctor_test.go
+++ b/collector/cmd/coslash/doctor_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/centauri-ai/coslash/collector/internal/remote"
+	"github.com/centauri-ai/coslash/collector/internal/settings"
+	remoteviewv1 "github.com/centauri-ai/coslash/collector/remoteview/v1"
+)
+
+func TestRunDoctorIncludesConfiguredRemote(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("COSLASH_HOME", home)
+	t.Setenv("HOME", home)
+
+	id := "r_0123456789abcdef"
+	store := settings.Open()
+	config := store.State().Config
+	config.Remote = &settings.RemoteSettings{ID: id, SSHAlias: "gpu-server", Enabled: true}
+	if err := store.Save(config); err != nil {
+		t.Fatal(err)
+	}
+	if err := remote.NewCache(home).Store(id, remote.CachedSnapshot{
+		View: remoteviewv1.View{
+			SchemaVersion:    remoteviewv1.SchemaVersion,
+			CollectorVersion: "dev",
+			Capabilities:     []string{remoteviewv1.CapabilityRemoteView},
+			LaunchableAgents: []string{remoteviewv1.AgentClaude},
+			RequestNowMs:     1000,
+			HostNowMs:        1200,
+			CollectedAtMs:    1100,
+			Host:             remoteviewv1.Host{OS: "linux", Arch: "arm64"},
+			Sessions:         []remoteviewv1.Session{},
+		},
+		FetchedAtMs:      1000,
+		ClockOffsetMs:    50,
+		RoundTripMs:      20,
+		CollectorVersion: "dev",
+		SchemaVersion:    remoteviewv1.SchemaVersion,
+		Capabilities:     []string{remoteviewv1.CapabilityRemoteView},
+		LaunchableAgents: []string{remoteviewv1.AgentClaude},
+		HostOS:           "linux",
+		HostArch:         "arm64",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runDoctor(&stdout, &stderr, []string{"--json"})
+	if code != 0 && code != 1 {
+		t.Fatalf("exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v body=%s", err, stdout.String())
+	}
+	remoteBlock, ok := body["remote"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing remote block: %s", stdout.String())
+	}
+	if remoteBlock["label"] != "gpu-server" || remoteBlock["state"] != "ok" {
+		t.Fatalf("remote=%v", remoteBlock)
+	}
+	checks, _ := body["checks"].([]any)
+	found := false
+	for _, raw := range checks {
+		check, _ := raw.(map[string]any)
+		if check["id"] == "remote" {
+			found = true
+			if !strings.Contains(check["detail"].(string), "gpu-server") {
+				t.Fatalf("remote check=%v", check)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("missing remote check in %v", checks)
+	}
+	if _, err := os.Stat(filepath.Join(home, "remotes", id, "snapshot.json")); err != nil {
+		t.Fatalf("doctor must not delete cache: %v", err)
+	}
+}

--- a/collector/cmd/coslash/main.go
+++ b/collector/cmd/coslash/main.go
@@ -280,6 +280,10 @@ func remoteHealthFact(mgr *remote.Manager) *diagnostics.RemoteHealth {
 		HostOS:           health.HostOS,
 		HostArch:         health.HostArch,
 		LastSuccessAtMs:  health.LastSuccessAtMs,
+		CoverageSinceMs:  health.CoverageSinceMs,
+		ClockOffsetMs:    health.ClockOffsetMs,
+		RoundTripMs:      health.RoundTripMs,
+		NextRetryAtMs:    health.NextRetryAtMs,
 		Error:            health.Error,
 		DiagnosticStderr: health.DiagnosticStderr,
 	}

--- a/collector/internal/diagnostics/checks.go
+++ b/collector/internal/diagnostics/checks.go
@@ -147,31 +147,71 @@ func sourceCheck(source Source) Check {
 }
 
 func remoteCheck(remote *Remote) Check {
+	label := remote.Label
+	if label == "" {
+		label = "Remote host"
+	}
 	check := Check{ID: "remote", Title: "Remote SSH host", Status: StatusOK}
+	reason := ""
+	if remote.Reason != nil && *remote.Reason != "" {
+		reason = *remote.Reason
+	}
 	switch remote.State {
 	case "ok":
-		check.Detail = remote.Label + " is connected."
+		check.Detail = label + " is connected."
+		if !remote.Complete {
+			check.Status = StatusWarn
+			check.Detail = label + " is connected but coverage is incomplete."
+		}
 	case "connecting":
 		check.Status = StatusWarn
-		check.Detail = "Connecting to " + remote.Label + "."
-	case "limited", "stale":
+		check.Detail = "Connecting to " + label + "."
+		if reason == "broader_history" {
+			check.Detail = label + " is refreshing a broader history window while showing the previous snapshot."
+		} else if reason == "initial_refresh" {
+			check.Detail = label + " is running its first refresh."
+		}
+	case "limited":
 		check.Status = StatusWarn
-		check.Detail = remote.Label + " is " + remote.State + "."
+		check.Detail = label + " returned a limited history window."
+		if reason != "" {
+			check.Detail += " Reason: " + reason + "."
+		}
 		if remote.Error != "" {
 			check.Detail += " " + remote.Error
 		}
-	case "setup_required", "upgrade_required", "error":
+	case "stale":
+		check.Status = StatusWarn
+		check.Detail = label + " is showing the last good snapshot after a refresh failure."
+		if remote.Error != "" {
+			check.Detail += " " + remote.Error
+		}
+	case "setup_required":
 		check.Status = StatusFail
-		check.Detail = remote.Label + " needs attention."
+		check.Detail = label + " needs the Linux collector installed at ~/.local/bin/coslash."
 		if remote.Error != "" {
 			check.Detail += " " + remote.Error
 		}
-		check.Fix = "Open Machines in Settings and use Test connection or Retry."
+		check.Fix = "Follow " + RemoteInstallationGuidePath + ", then use Test connection in Machines."
+	case "upgrade_required":
+		check.Status = StatusFail
+		check.Detail = label + " needs a newer Linux collector."
+		if remote.Error != "" {
+			check.Detail += " " + remote.Error
+		}
+		check.Fix = "Follow " + RemoteInstallationGuidePath + ", then Retry or Test connection."
+	case "error":
+		check.Status = StatusFail
+		check.Detail = label + " refresh failed."
+		if remote.Error != "" {
+			check.Detail += " " + remote.Error
+		}
+		check.Fix = "Confirm BatchMode SSH for the alias, then Retry from the host strip or Machines."
 	case "disabled":
-		check.Detail = remote.Label + " is disabled."
+		check.Detail = label + " is disabled; its sessions are hidden and its secured cache is retained."
 	default:
 		check.Status = StatusWarn
-		check.Detail = remote.Label + " state is " + remote.State + "."
+		check.Detail = label + " state is " + remote.State + "."
 	}
 	return check
 }

--- a/collector/internal/diagnostics/format.go
+++ b/collector/internal/diagnostics/format.go
@@ -1,0 +1,121 @@
+package diagnostics
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// FormatForCopy renders a shareable diagnostics report without sensitive remote details.
+func FormatForCopy(snapshot *Snapshot) string {
+	if snapshot == nil {
+		return ""
+	}
+	lines := []string{
+		fmt.Sprintf("coSlash %s diagnostics", snapshot.Version),
+		fmt.Sprintf("Generated: %s", time.UnixMilli(snapshot.GeneratedAt).UTC().Format(time.RFC3339)),
+		fmt.Sprintf(
+			"Platform: %s/%s; terminal launch=%t",
+			snapshot.Platform.OS,
+			snapshot.Platform.Arch,
+			snapshot.Platform.TerminalLaunchSupported,
+		),
+		fmt.Sprintf("Storage: %s; writable=%t", snapshot.Storage.Home, snapshot.Storage.Writable),
+		fmt.Sprintf(
+			"Synthesis: enabled=%t; model=%s; CLI found=%t",
+			snapshot.Synthesis.Enabled,
+			orUnknown(snapshot.Synthesis.Model),
+			snapshot.Synthesis.CLIFound,
+		),
+		"",
+		"Sources:",
+	}
+	for _, source := range snapshot.Sources {
+		lines = append(lines,
+			fmt.Sprintf(
+				"- %s: %s; root=%s; entries=%d; sessions=%d; skipped=%d",
+				source.Label,
+				source.State,
+				source.Root,
+				source.Entries,
+				source.Sessions,
+				source.SkippedTotal,
+			),
+			fmt.Sprintf(
+				"  CLI: found=%t; path=%s; version=%s",
+				source.CLI.Found,
+				orUnknown(source.CLI.Path),
+				orUnknown(source.CLI.Version),
+			),
+		)
+		for _, skipped := range source.Skipped {
+			lines = append(lines, "  Skipped: "+skipped.Error)
+		}
+	}
+	if snapshot.Remote != nil {
+		lines = append(lines, "", "Remote host:")
+		lines = append(lines, formatRemoteFactLines(snapshot.Remote)...)
+	}
+	lines = append(lines, "", "Checks:")
+	for _, check := range snapshot.Checks {
+		lines = append(lines, fmt.Sprintf("- [%s] %s: %s", check.Status, check.Title, check.Detail))
+		if check.Fix != "" {
+			lines = append(lines, "  Fix: "+check.Fix)
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func formatRemoteFactLines(remote *Remote) []string {
+	lines := []string{
+		fmt.Sprintf("- alias=%s; state=%s; complete=%t", remote.Label, remote.State, remote.Complete),
+	}
+	if remote.Reason != nil && *remote.Reason != "" {
+		lines = append(lines, "  reason="+*remote.Reason)
+	}
+	if remote.CollectorVersion != "" || remote.SchemaVersion != "" {
+		lines = append(lines, fmt.Sprintf(
+			"  collector=%s; schema=%s",
+			orUnknown(remote.CollectorVersion),
+			orUnknown(remote.SchemaVersion),
+		))
+	}
+	if len(remote.Capabilities) > 0 {
+		lines = append(lines, "  capabilities="+strings.Join(remote.Capabilities, ","))
+	}
+	if len(remote.LaunchableAgents) > 0 {
+		lines = append(lines, "  launchableAgents="+strings.Join(remote.LaunchableAgents, ","))
+	}
+	if remote.HostOS != "" || remote.HostArch != "" {
+		lines = append(lines, fmt.Sprintf("  platform=%s/%s", orUnknown(remote.HostOS), orUnknown(remote.HostArch)))
+	}
+	if remote.LastSuccessAtMs != nil {
+		lines = append(lines, "  lastSuccessAtMs="+fmt.Sprintf("%d", *remote.LastSuccessAtMs))
+	}
+	if remote.CoverageSinceMs != nil {
+		lines = append(lines, "  coverageSinceMs="+fmt.Sprintf("%d", *remote.CoverageSinceMs))
+	}
+	if remote.ClockOffsetMs != nil {
+		lines = append(lines, "  clockOffsetMs="+fmt.Sprintf("%d", *remote.ClockOffsetMs))
+	}
+	if remote.RoundTripMs != nil {
+		lines = append(lines, "  roundTripMs="+fmt.Sprintf("%d", *remote.RoundTripMs))
+	}
+	if remote.NextRetryAtMs != nil {
+		lines = append(lines, "  nextRetryAtMs="+fmt.Sprintf("%d", *remote.NextRetryAtMs))
+	}
+	if remote.Error != "" {
+		lines = append(lines, "  error="+remote.Error)
+	}
+	if remote.DiagnosticStderr != "" {
+		lines = append(lines, "  diagnosticStderr="+remote.DiagnosticStderr)
+	}
+	return lines
+}
+
+func orUnknown(value string) string {
+	if value == "" {
+		return "unknown"
+	}
+	return value
+}

--- a/collector/internal/diagnostics/remote_test.go
+++ b/collector/internal/diagnostics/remote_test.go
@@ -1,0 +1,157 @@
+package diagnostics
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRemoteCheckStates(t *testing.T) {
+	t.Parallel()
+	reason := "collector_missing"
+	cases := []struct {
+		name   string
+		remote Remote
+		status Status
+		want   string
+		fix    string
+	}{
+		{
+			name:   "ok",
+			remote: Remote{Label: "gpu-server", State: "ok", Complete: true},
+			status: StatusOK,
+			want:   "gpu-server is connected.",
+		},
+		{
+			name:   "connecting incomplete",
+			remote: Remote{Label: "gpu-server", State: "connecting", Reason: strPtr("broader_history")},
+			status: StatusWarn,
+			want:   "broader history",
+		},
+		{
+			name:   "limited",
+			remote: Remote{Label: "gpu-server", State: "limited", Reason: strPtr("history_truncated"), Error: "history truncated"},
+			status: StatusWarn,
+			want:   "limited history",
+		},
+		{
+			name:   "setup",
+			remote: Remote{Label: "gpu-server", State: "setup_required", Reason: &reason, Error: "collector missing"},
+			status: StatusFail,
+			want:   "~/.local/bin/coslash",
+			fix:    RemoteInstallationGuidePath,
+		},
+		{
+			name:   "upgrade",
+			remote: Remote{Label: "gpu-server", State: "upgrade_required", Error: "collector upgrade required"},
+			status: StatusFail,
+			want:   "newer Linux collector",
+			fix:    RemoteInstallationGuidePath,
+		},
+		{
+			name:   "stale",
+			remote: Remote{Label: "gpu-server", State: "stale", Error: "connection failed"},
+			status: StatusWarn,
+			want:   "last good snapshot",
+		},
+		{
+			name:   "error",
+			remote: Remote{Label: "gpu-server", State: "error", Error: "invalid remote transport"},
+			status: StatusFail,
+			want:   "refresh failed",
+		},
+		{
+			name:   "disabled",
+			remote: Remote{Label: "gpu-server", State: "disabled"},
+			status: StatusOK,
+			want:   "disabled",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			check := remoteCheck(&tc.remote)
+			if check.Status != tc.status {
+				t.Fatalf("status=%s want %s", check.Status, tc.status)
+			}
+			if !strings.Contains(check.Detail, tc.want) {
+				t.Fatalf("detail=%q want substring %q", check.Detail, tc.want)
+			}
+			if tc.fix != "" && !strings.Contains(check.Fix, tc.fix) {
+				t.Fatalf("fix=%q want substring %q", check.Fix, tc.fix)
+			}
+		})
+	}
+}
+
+func TestFormatForCopyOmitsSensitiveRemoteValues(t *testing.T) {
+	t.Parallel()
+	reason := "connection_failed"
+	lastSuccess := int64(1_700_000_000_000)
+	coverage := int64(1_699_000_000_000)
+	offset := int64(1200)
+	roundTrip := int64(420)
+	nextRetry := int64(1_700_000_180_000)
+	snapshot := &Snapshot{
+		Version:     "v0.0.0-test",
+		GeneratedAt: lastSuccess,
+		Platform:    Platform{OS: "darwin", Arch: "arm64", TerminalLaunchSupported: true},
+		Storage:     Storage{Home: "~/.coslash", Writable: true},
+		Sources: []Source{{
+			Agent: "codex", Label: "Codex", Root: "~/.codex", State: SourceOK,
+		}},
+		Remote: &Remote{
+			SourceID:         "r_0123456789abcdef",
+			Label:            "gpu-server",
+			State:            "stale",
+			Complete:         false,
+			Reason:           &reason,
+			CollectorVersion: "v0.0.0-test",
+			SchemaVersion:    "remote-session-view/v1",
+			Capabilities:     []string{"remote-session-view/v1", "remote-launch/v1"},
+			LaunchableAgents: []string{"claude", "codex"},
+			HostOS:           "linux",
+			HostArch:         "arm64",
+			LastSuccessAtMs:  &lastSuccess,
+			CoverageSinceMs:  &coverage,
+			ClockOffsetMs:    &offset,
+			RoundTripMs:      &roundTrip,
+			NextRetryAtMs:    &nextRetry,
+			Error:            "connection failed",
+			DiagnosticStderr: "Permission denied [redacted]",
+		},
+		Checks: []Check{remoteCheck(&Remote{Label: "gpu-server", State: "stale", Error: "connection failed"})},
+	}
+	text := FormatForCopy(snapshot)
+	for _, required := range []string{
+		"alias=gpu-server",
+		"state=stale",
+		"capabilities=remote-session-view/v1,remote-launch/v1",
+		"launchableAgents=claude,codex",
+		"platform=linux/arm64",
+		"clockOffsetMs=1200",
+		"roundTripMs=420",
+		"nextRetryAtMs=1700000180000",
+		"error=connection failed",
+	} {
+		if !strings.Contains(text, required) {
+			t.Fatalf("missing %q in:\n%s", required, text)
+		}
+	}
+	for _, forbidden := range []string{
+		"ubuntu@",
+		"example.com",
+		"/home/",
+		"/.ssh/",
+		"PRIVATE KEY",
+		"id_ed25519",
+		"/Users/",
+		"transcript",
+		"handoff body",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("sensitive value %q leaked in:\n%s", forbidden, text)
+		}
+	}
+}
+
+func strPtr(value string) *string { return &value }

--- a/collector/internal/diagnostics/snapshot.go
+++ b/collector/internal/diagnostics/snapshot.go
@@ -46,6 +46,9 @@ type Snapshot struct {
 	homeError           string
 }
 
+// RemoteInstallationGuidePath is the fixed product path linked for setup/upgrade.
+const RemoteInstallationGuidePath = "docs/remote-host-installation.md"
+
 // Remote is the optional SSH host health block for diagnostics.
 type Remote struct {
 	SourceID         string   `json:"sourceId,omitempty"`
@@ -60,6 +63,10 @@ type Remote struct {
 	HostOS           string   `json:"hostOs,omitempty"`
 	HostArch         string   `json:"hostArch,omitempty"`
 	LastSuccessAtMs  *int64   `json:"lastSuccessAtMs,omitempty"`
+	CoverageSinceMs  *int64   `json:"coverageSinceMs,omitempty"`
+	ClockOffsetMs    *int64   `json:"clockOffsetMs,omitempty"`
+	RoundTripMs      *int64   `json:"roundTripMs,omitempty"`
+	NextRetryAtMs    *int64   `json:"nextRetryAtMs,omitempty"`
 	Error            string   `json:"error,omitempty"`
 	DiagnosticStderr string   `json:"diagnosticStderr,omitempty"`
 }
@@ -136,6 +143,10 @@ type RemoteHealth struct {
 	HostOS           string
 	HostArch         string
 	LastSuccessAtMs  *int64
+	CoverageSinceMs  *int64
+	ClockOffsetMs    *int64
+	RoundTripMs      *int64
+	NextRetryAtMs    *int64
 	Error            string
 	DiagnosticStderr string
 }
@@ -157,6 +168,10 @@ func CollectWithRemote(ctx context.Context, version string, includeVersions bool
 			HostOS:           remoteHealth.HostOS,
 			HostArch:         remoteHealth.HostArch,
 			LastSuccessAtMs:  remoteHealth.LastSuccessAtMs,
+			CoverageSinceMs:  remoteHealth.CoverageSinceMs,
+			ClockOffsetMs:    remoteHealth.ClockOffsetMs,
+			RoundTripMs:      remoteHealth.RoundTripMs,
+			NextRetryAtMs:    remoteHealth.NextRetryAtMs,
 			Error:            remoteHealth.Error,
 			DiagnosticStderr: remoteHealth.DiagnosticStderr,
 		}

--- a/collector/internal/remote/health.go
+++ b/collector/internal/remote/health.go
@@ -55,6 +55,7 @@ type Health struct {
 	Error            string   `json:"error,omitempty"`
 	DiagnosticStderr string   `json:"-"`
 	Refreshing       bool     `json:"-"`
+	NextRetryAtMs    *int64   `json:"-"`
 }
 
 func reasonPtr(r Reason) *Reason { return &r }

--- a/collector/internal/remote/manager.go
+++ b/collector/internal/remote/manager.go
@@ -284,6 +284,65 @@ func (m *Manager) DiagnosticsHealth() Health {
 	return m.healthLocked(m.lastRequestedMs)
 }
 
+// LoadSettingsSnapshot applies configured remote settings and cache for diagnostics
+// without starting SSH refresh work or deleting on-disk cache.
+func (m *Manager) LoadSettingsSnapshot(remote *settings.RemoteSettings) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.cancelLifeLocked()
+	m.refreshing = false
+	m.failures = 0
+	m.nextRetryAt = time.Time{}
+	m.errorCopy = ""
+	m.diagnostic = ""
+	m.probe = nil
+
+	if remote == nil {
+		m.cfg = nil
+		m.cached = nil
+		m.lastSuccessAt = nil
+		m.state = StateDisabled
+		m.reason = reasonPtr(ReasonDisabled)
+		m.complete = true
+		return nil
+	}
+	if !settings.ValidRemoteID(remote.ID) || !settings.ValidSSHAlias(remote.SSHAlias) {
+		return ErrInvalidRemoteSettings
+	}
+
+	copyCfg := *remote
+	m.cfg = &copyCfg
+	if err := m.loadCacheLocked(); err != nil {
+		m.cfg = nil
+		m.cached = nil
+		m.lastSuccessAt = nil
+		return err
+	}
+	if !remote.Enabled {
+		m.state = StateDisabled
+		m.reason = reasonPtr(ReasonDisabled)
+		m.complete = true
+		return nil
+	}
+	if m.cached == nil {
+		m.state = StateConnecting
+		m.reason = reasonPtr(ReasonInitialRefresh)
+		m.complete = false
+		return nil
+	}
+	if m.cached.View.Truncated {
+		m.state = StateLimited
+		m.reason = reasonPtr(ReasonHistoryTruncated)
+		m.complete = false
+		return nil
+	}
+	m.state = StateOK
+	m.reason = nil
+	m.complete = true
+	return nil
+}
+
 // Shutdown cancels in-flight remote work.
 func (m *Manager) Shutdown() {
 	m.mu.Lock()
@@ -614,6 +673,9 @@ func (m *Manager) healthLocked(remoteSinceMs int64) Health {
 	if m.state == StateConnecting && m.cached != nil && m.cached.View.CoverageSinceMs > remoteSinceMs {
 		health.Complete = false
 		health.Reason = reasonPtr(ReasonBroaderHistory)
+	}
+	if !m.nextRetryAt.IsZero() {
+		health.NextRetryAtMs = int64Ptr(m.nextRetryAt.UnixMilli())
 	}
 	return health
 }

--- a/collector/internal/remote/manager_test.go
+++ b/collector/internal/remote/manager_test.go
@@ -456,3 +456,60 @@ func TestApplySettingsRollsBackWhenCacheLoadFails(t *testing.T) {
 		return h.State == StateOK && !h.Refreshing
 	})
 }
+
+func TestLoadSettingsSnapshotDoesNotStartRefresh(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("COSLASH_HOME", root)
+	id := "r_0123456789abcdef"
+	cache := NewCache(root)
+	if err := cache.Store(id, CachedSnapshot{
+		View:             sampleView(0, 1000),
+		FetchedAtMs:      1000,
+		ClockOffsetMs:    50,
+		RoundTripMs:      20,
+		CollectorVersion: "dev",
+		SchemaVersion:    remoteviewv1.SchemaVersion,
+		Capabilities:     []string{remoteviewv1.CapabilityRemoteView},
+		LaunchableAgents: []string{remoteviewv1.AgentClaude},
+		HostOS:           "linux",
+		HostArch:         "arm64",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls atomic.Int32
+	mgr := NewManager(Options{
+		Runner: &FakeRunner{Hook: func(FakeCall) (RunResult, error) {
+			calls.Add(1)
+			t.Fatal("LoadSettingsSnapshot must not start SSH")
+			return RunResult{}, nil
+		}},
+		Cache: cache,
+	})
+	cfg := &settings.RemoteSettings{ID: id, SSHAlias: "gpu-server", Enabled: true}
+	if err := mgr.LoadSettingsSnapshot(cfg); err != nil {
+		t.Fatal(err)
+	}
+	health := mgr.DiagnosticsHealth()
+	if health.SourceID != id || health.Label != "gpu-server" || health.State != StateOK {
+		t.Fatalf("health=%+v", health)
+	}
+	if health.CollectorVersion != "dev" || health.RoundTripMs == nil || *health.RoundTripMs != 20 {
+		t.Fatalf("cache facts missing: %+v", health)
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("unexpected refresh calls: %d", calls.Load())
+	}
+
+	disabled := *cfg
+	disabled.Enabled = false
+	if err := mgr.LoadSettingsSnapshot(&disabled); err != nil {
+		t.Fatal(err)
+	}
+	if health := mgr.DiagnosticsHealth(); health.State != StateDisabled {
+		t.Fatalf("disabled health=%+v", health)
+	}
+	if _, err := os.Stat(filepath.Join(root, "remotes", id, "snapshot.json")); err != nil {
+		t.Fatalf("cache should remain on disk: %v", err)
+	}
+}

--- a/collector/scripts/smoke-linux-remote.sh
+++ b/collector/scripts/smoke-linux-remote.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Behavioral smoke for a packaged Linux coslash binary used as a remote collector.
+# Runs as the invoking user; do not escalate to root.
+
+set -euo pipefail
+
+usage() {
+  echo "usage: scripts/smoke-linux-remote.sh <binary>" >&2
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 2
+fi
+
+binary=$1
+if [[ ! -x "$binary" ]]; then
+  echo "error: binary is not executable: $binary" >&2
+  exit 1
+fi
+
+if [[ "$(id -u)" -eq 0 ]]; then
+  echo "error: refuse to run Linux remote smoke as root" >&2
+  exit 1
+fi
+
+smoke_home=$(mktemp -d)
+trap 'rm -rf -- "$smoke_home"' EXIT
+
+export HOME="$smoke_home"
+export COSLASH_HOME="$smoke_home/.coslash"
+
+version=$("$binary" --version)
+echo "version -> $version"
+if [[ -z "$version" || "$version" == "dev" ]]; then
+  echo "error: release binary has an invalid version: ${version:-<empty>}" >&2
+  exit 1
+fi
+
+decode_frame_to() {
+  local input=$1
+  local output=$2
+  python3 - "$input" "$output" <<'PY'
+import json, pathlib, sys
+data = pathlib.Path(sys.argv[1]).read_bytes()
+magic = b"COSLASH-REMOTE/1 "
+if not data.startswith(magic):
+    raise SystemExit(f"missing frame magic: {data[:40]!r}")
+newline = data.find(b"\n")
+if newline < 0:
+    raise SystemExit("missing frame header newline")
+length = int(data[len(magic):newline])
+payload = data[newline + 1 : newline + 1 + length]
+if len(payload) != length:
+    raise SystemExit("truncated frame payload")
+pathlib.Path(sys.argv[2]).write_text(json.dumps(json.loads(payload)))
+PY
+}
+
+probe_out="$smoke_home/probe.out"
+probe_json="$smoke_home/probe.json"
+"$binary" snapshot --probe >"$probe_out"
+decode_frame_to "$probe_out" "$probe_json"
+python3 - "$probe_json" <<'PY'
+import json, pathlib, sys
+probe = json.loads(pathlib.Path(sys.argv[1]).read_text())
+caps = set(probe.get("capabilities") or [])
+required = {"remote-session-view/v1", "remote-launch/v1"}
+missing = required - caps
+if missing:
+    raise SystemExit(f"probe missing capabilities: {sorted(missing)}")
+if probe.get("schemaVersion") != "remote-session-view/v1":
+    raise SystemExit(f"unexpected schemaVersion: {probe.get('schemaVersion')!r}")
+host = probe.get("host") or {}
+if host.get("os") != "linux":
+    raise SystemExit(f"expected linux host.os, got {host!r}")
+for agent in probe.get("launchableAgents") or []:
+    if agent not in ("claude", "codex"):
+        raise SystemExit(f"unexpected launchable agent: {agent!r}")
+    if "/" in agent or agent.startswith("."):
+        raise SystemExit(f"launchable agent looks like a path: {agent!r}")
+print("probe ok")
+PY
+
+now_ms=$(python3 -c 'import time; print(int(time.time() * 1000))')
+snap_out="$smoke_home/snapshot.out"
+snap_json="$smoke_home/snapshot.json"
+"$binary" snapshot --since 0 --request-now "$now_ms" --agents claude,codex >"$snap_out"
+decode_frame_to "$snap_out" "$snap_json"
+python3 - "$snap_json" <<'PY'
+import json, pathlib, sys
+view = json.loads(pathlib.Path(sys.argv[1]).read_text())
+if view.get("schemaVersion") != "remote-session-view/v1":
+    raise SystemExit(f"unexpected schemaVersion: {view.get('schemaVersion')!r}")
+if "sessions" not in view or not isinstance(view["sessions"], list):
+    raise SystemExit("snapshot missing sessions list")
+if view.get("requestedSinceMs") != 0:
+    raise SystemExit(f"requestedSinceMs={view.get('requestedSinceMs')!r}")
+print(f"snapshot ok ({len(view['sessions'])} sessions)")
+PY
+
+session="9c73be46-52af-4b1d-9ee7-123456789abc"
+handoff_out="$smoke_home/handoff.out"
+handoff_json="$smoke_home/handoff.json"
+printf 'smoke handoff brief' | "$binary" handoff put --agent claude --session "$session" >"$handoff_out"
+decode_frame_to "$handoff_out" "$handoff_json"
+handoff_id=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["id"])' "$handoff_json")
+if [[ ! "$handoff_id" =~ ^h_[0-9a-f]{32}$ ]]; then
+  echo "error: unexpected handoff id: $handoff_id" >&2
+  exit 1
+fi
+
+sys_prompts="$COSLASH_HOME/sys-prompts"
+handoff_file="$sys_prompts/$handoff_id"
+dir_mode=$(stat -c '%a' "$sys_prompts")
+file_mode=$(stat -c '%a' "$handoff_file")
+if [[ "$dir_mode" != "700" ]]; then
+  echo "error: sys-prompts mode is $dir_mode, expected 700" >&2
+  exit 1
+fi
+if [[ "$file_mode" != "600" ]]; then
+  echo "error: handoff file mode is $file_mode, expected 600" >&2
+  exit 1
+fi
+echo "handoff put ok (id=$handoff_id, modes 0700/0600)"
+
+set +e
+"$binary" launch --agent claude --session 'not-a-uuid' --mode resume >/dev/null 2>"$smoke_home/launch-bad.err"
+bad_code=$?
+"$binary" launch --agent claude --session "$session" --mode resume >/dev/null 2>"$smoke_home/launch-missing.err"
+missing_code=$?
+set -e
+if [[ "$bad_code" -ne 2 ]]; then
+  echo "error: invalid launch args exited $bad_code, expected 2" >&2
+  cat "$smoke_home/launch-bad.err" >&2
+  exit 1
+fi
+if [[ "$missing_code" -ne 1 ]]; then
+  echo "error: missing-session launch exited $missing_code, expected 1" >&2
+  cat "$smoke_home/launch-missing.err" >&2
+  exit 1
+fi
+if ! grep -Fq 'session not found' "$smoke_home/launch-missing.err"; then
+  echo "error: missing-session launch did not report session not found" >&2
+  cat "$smoke_home/launch-missing.err" >&2
+  exit 1
+fi
+echo "launch validation ok"
+
+echo "linux remote smoke passed"

--- a/docs/data-and-privacy.md
+++ b/docs/data-and-privacy.md
@@ -14,13 +14,27 @@ coSlash reads, but does not modify:
 
 | Path | Contents |
 | --- | --- |
-| `settings.json` | Synthesis, appearance, and terminal preferences. |
+| `settings.json` | Synthesis, appearance, terminal, and optional remote-host preferences. |
 | `token` | Access token for the current server process. |
 | `summaries/` | Cached synthesis results. |
 | `synthesis/` | Temporary synthesis files and the OpenCode scratch database. |
-| `sys-prompts/` | Temporary handoffs for fresh sessions. |
+| `sys-prompts/` | Temporary local handoffs for fresh sessions. |
+| `remotes/<sourceId>/snapshot.json` | Last validated remote session snapshot cached on the Mac. |
 
 coSlash creates the storage directory with mode `0700` and persistent files with mode `0600`. Programs running as your macOS user can still read them.
+
+## Remote host cache and Linux handoffs
+
+When you enable one SSH host, the Mac stores a secured last-good snapshot under `~/.coslash/remotes/<sourceId>/snapshot.json` (`0700` source directory, `0600` file). The cache holds bounded remote-view facts used by the board and inspector. It does not store transcript text, handoff text, credentials, SSH config, private keys, or resolved remote usernames/hostnames.
+
+| Action | Cache behavior |
+| --- | --- |
+| Disable the host | Stops refresh work and removes its sessions from the current board; retains the secured cache so re-enabling can recover quickly. |
+| Remove the host or change the SSH alias | Deletes that source cache. An alias change is treated as remove-plus-add with a new source ID. |
+
+On the Linux host, Start Fresh stages a short-lived handoff under `~/.coslash/sys-prompts` (`0700` directory, `0600` files). Each record is bound to an agent and session, expires after one hour, and can be claimed once. An abandoned handoff becomes unusable after one hour, but physical deletion happens on the next `handoff` or `launch` invocation on that host.
+
+Diagnostics and **Copy diagnostics** may include the user-entered SSH alias, collector/schema versions, capabilities, launchable agents, platform, coverage and retry timing, round-trip timing, and bounded redacted stderr. They never include resolved host/user, key paths, SSH config contents, private keys, credentials, transcript text, handoff text, or private remote working paths.
 
 ## Outbound data
 
@@ -28,7 +42,7 @@ The collector does not upload data itself. If you enable synthesis, it passes a 
 
 OpenCode has no ephemeral mode, so coSlash points each run at its own scratch database under `~/.coslash/synthesis`, discarded once the run ends. Synthesis runs never enter your own OpenCode history.
 
-Resume and Start fresh launch your installed agent CLI. Its later network and data behavior is governed by that tool.
+Resume and Start fresh launch your installed agent CLI. Its later network and data behavior is governed by that tool. Remote Resume and Start Fresh open an SSH terminal to the configured alias and run only fixed collector launch commands; they do not place remote paths or free-form handoff text in a shell string.
 
 ## Snapshot preview
 
@@ -74,4 +88,6 @@ coSlash listens on IPv4 loopback and protects API requests with a new access tok
 
 Synthesis is off until you enable and save it in Settings. Disable it there to stop new requests, then delete `~/.coslash/summaries` to remove cached results.
 
-To remove all coSlash data, quit coSlash and delete `~/.coslash` (or your `COSLASH_HOME`). `coslash doctor --json` and **Copy diagnostics** exclude transcript contents, prompts, and session names.
+Disable or remove a remote host from Settings → Machines. Disabling retains `~/.coslash/remotes/<sourceId>/`; removing the host deletes it. To remove all coSlash data, quit coSlash and delete `~/.coslash` (or your `COSLASH_HOME`). On a Linux host used only as a remote collector, also delete `~/.coslash` there if you no longer want staged handoffs.
+
+`coslash doctor --json` and **Copy diagnostics** exclude transcript contents, prompts, and session names.

--- a/docs/remote-host-installation.md
+++ b/docs/remote-host-installation.md
@@ -1,0 +1,75 @@
+# Install the Linux remote collector
+
+coSlash on macOS can monitor Claude Code and Codex sessions on one Linux host over SSH. The Mac app never downloads or upgrades the remote binary; install it manually once on the Linux host.
+
+The Mac looks for the collector at the fixed path `~/.local/bin/coslash`. Settings and probe output never supply an executable path.
+
+## Choose the release asset
+
+Published asset names match the packaging matrix exactly:
+
+| Platform | Archive |
+| --- | --- |
+| macOS Apple Silicon | `coslash_<VERSION>_darwin_arm64.tar.gz` |
+| macOS Intel | `coslash_<VERSION>_darwin_amd64.tar.gz` |
+| Linux x86_64 | `coslash_<VERSION>_linux_amd64.tar.gz` |
+| Linux ARM64 | `coslash_<VERSION>_linux_arm64.tar.gz` |
+| Checksums | `checksums.txt` |
+
+`<VERSION>` is the GitHub release tag, for example `v0.0.2` or `v0.0.2-rc.1`.
+
+On the Linux host:
+
+```sh
+uname -m
+```
+
+Use `amd64` when the output is `x86_64`, and `arm64` when the output is `aarch64` or `arm64`.
+
+## Download, verify, and install
+
+Run these commands on the Linux host as your normal user. Do not use root.
+
+```sh
+VERSION="v0.0.2" # or the desired release tag
+ARCH="arm64"     # or amd64
+ASSET="coslash_${VERSION}_linux_${ARCH}.tar.gz"
+BASE_URL="https://github.com/centauri-ai/coslash/releases/download/${VERSION}"
+
+curl -fLO "${BASE_URL}/${ASSET}"
+curl -fLO "${BASE_URL}/checksums.txt"
+grep -F "  ${ASSET}" checksums.txt | sha256sum -c -
+
+mkdir -p ~/.local/bin
+tar -xzf "${ASSET}"
+install -m 0755 "${ASSET%.tar.gz}/coslash" ~/.local/bin/coslash
+```
+
+Confirm the install:
+
+```sh
+~/.local/bin/coslash --version
+~/.local/bin/coslash snapshot --probe
+```
+
+`snapshot --probe` prints one `COSLASH-REMOTE/1` framed JSON document on stdout. It must advertise `remote-session-view/v1`. When launch support is present it also advertises `remote-launch/v1` and lists currently available agents in `launchableAgents` without executable paths.
+
+The Linux archive embeds the same UI binary used on macOS. On a remote host, invoke only the `snapshot`, `handoff`, and `launch` subcommands. There is no supported Linux desktop UI in this feature.
+
+## SSH prerequisites
+
+On the Mac, configure an SSH alias for the Linux host in `~/.ssh/config`, then run interactive SSH once so host keys and authentication work before coSlash uses `BatchMode=yes`:
+
+```sh
+ssh <alias>
+```
+
+Background probe, snapshot, and handoff staging use non-interactive SSH. Interactive Resume and Start Fresh open a normal SSH session that may prompt.
+
+Ensure the remote login environment can find `claude` and/or `codex` on `PATH` for launches. Non-login shells often miss CLI installs that only appear in interactive shell startup files.
+
+## After installation
+
+In coSlash on the Mac, open Settings → Machines, enter the SSH alias, enable the host, and use Test connection. When probe reports setup required or upgrade required, return to this guide, install or replace `~/.local/bin/coslash`, then test again.
+
+coSlash does not chmod, upload, download, or upgrade the remote collector for you.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting
 
-Start with `coslash doctor`. It checks session sources, agent CLIs, and storage. Use `coslash doctor --json` for a shareable report, and check the terminal where coSlash started for logs.
+Start with `coslash doctor`. It checks session sources, agent CLIs, storage, and an optional remote SSH host. Use `coslash doctor --json` for a shareable report, and check the terminal where coSlash started for logs.
 
 ## Sessions are missing
 
@@ -23,6 +23,44 @@ Confirm that synthesis is enabled in Settings and that the selected CLI is insta
 Launching requires macOS, a recorded working directory, the agent CLI, and the terminal selected in Settings. Confirm Apple Terminal or iTerm2 is installed and allow automation under **System Settings → Privacy & Security → Automation**.
 
 A fresh agent waiting silently is expected: handoff context is marked as background, and the agent waits for your next message.
+
+## Remote SSH host
+
+### Collector missing or outdated
+
+Probe states `setup_required` or `upgrade_required` mean the Mac cannot find a compatible collector at `~/.local/bin/coslash` on the Linux host. Install or replace it using [`docs/remote-host-installation.md`](remote-host-installation.md), then use **Test connection** or **Retry**. The app does not download or upgrade the remote binary.
+
+### Noisy shell startup output
+
+Background SSH commands tolerate bounded shell startup noise before one `COSLASH-REMOTE/1` frame. If login scripts print large or malformed output, probe and snapshot fail with an invalid-transport style error. Keep machine-readable stdout clean for non-interactive SSH, or move interactive-only printing behind an interactive-shell guard.
+
+### Agent CLI missing on the remote PATH
+
+Monitoring can succeed while Resume or Start Fresh is unavailable when `launchableAgents` omits an agent. Non-login SSH sessions often miss PATH entries that only interactive shells load. Confirm `ssh <alias> 'command -v claude'` and `command -v codex` in the same non-interactive environment coSlash uses, then adjust the remote shell profile accordingly.
+
+### BatchMode authentication or host-key failures
+
+Probe, snapshot, and handoff staging use `BatchMode=yes` and must not prompt. Run `ssh <alias>` once interactively so host keys and authentication succeed, then retry from coSlash. Diagnostics may show a bounded redacted error such as `connection failed`; they do not expose credentials, key paths, or SSH config contents, and they do not guess from locale-specific stderr phrases.
+
+### Retry backoff
+
+Automatic refresh failures back off from three minutes exponentially to a 30-minute cap. Manual **Retry** bypasses the delay but does not start a second refresh while one is already running. Diagnostics can include `nextRetryAtMs` when a backoff is active.
+
+### Limited history
+
+A `limited` host means discovery or payload limits kept the newest whole sessions and declared truncation. Widen the displayed time window only if you need older remote cards; Hub's local all-history setting does not widen remote collection.
+
+### Clock skew
+
+Diagnostics may include `clockOffsetMs` and `roundTripMs`. Coverage comparisons stay in the Mac request clock. Large skew can move edge-of-window sessions; use the reported offset as a diagnostic, not as sub-second truth.
+
+### Stale cache behavior
+
+When a refresh fails after a previous success, the board keeps the last good remote snapshot and marks the host stale or upgrade-required. Disable removes cards but retains the secured Mac cache; remove deletes `~/.coslash/remotes/<sourceId>/`.
+
+### Interactive resume errors
+
+Remote Resume and Start Fresh open an interactive SSH terminal. Authentication prompts, missing agent CLIs, or a missing session can fail inside that terminal without a precise Mac-side translation of remote stderr. Prefer the installation guide, PATH checks, and `snapshot --probe` over interpreting locale-specific error text.
 
 ## Report a bug
 

--- a/frontend/src/pages/coslash/CoslashPage.tsx
+++ b/frontend/src/pages/coslash/CoslashPage.tsx
@@ -6,6 +6,7 @@ import { setTheme } from '@/lib/theme';
 import { DiagnosticsDialog } from '@/pages/coslash/components/DiagnosticsDialog';
 import { FirstRunOnboarding } from '@/pages/coslash/components/FirstRunOnboarding';
 import { LoadingSpinner } from '@/pages/coslash/components/LoadingSpinner';
+import { RemoteHostStrip } from '@/pages/coslash/components/RemoteHostStrip';
 import { SessionBoard } from '@/pages/coslash/components/SessionBoard';
 import { SessionCard } from '@/pages/coslash/components/SessionCard';
 import { SessionInspector } from '@/pages/coslash/components/SessionInspector';
@@ -40,12 +41,20 @@ import { useSessions } from '@/pages/coslash/hooks/use-sessions';
 import { useSettings } from '@/pages/coslash/hooks/use-settings';
 import type { Diagnostics } from '@/pages/coslash/lib/diagnostics';
 import { formatEstimatedCost } from '@/pages/coslash/lib/format';
+import {
+  hostStripModel,
+  hostStripVisible,
+  remoteConfigured,
+  remoteMachine,
+} from '@/pages/coslash/lib/host-strip';
 import { sessionsEmptyStateCopy } from '@/pages/coslash/lib/page-copy';
+import { retryRemoteRefresh } from '@/pages/coslash/lib/remote-api';
 import { sessionMatchesSearchTerm } from '@/pages/coslash/lib/search';
 import {
   getSessionVendors,
   getStatus,
   isLocalSession,
+  LOCAL_SOURCE_ID,
   sessionKey,
   sessionsForAggregates,
   type Session,
@@ -204,6 +213,7 @@ function CoslashContent({
   searchTerm,
   timeWindow,
   view,
+  showMachineBadge,
   onSelectSession,
   diagnostics,
   diagnosticsLoading,
@@ -217,6 +227,7 @@ function CoslashContent({
   searchTerm: string;
   timeWindow: TimeWindow;
   view: ViewMode;
+  showMachineBadge: boolean;
   onSelectSession: (session: Session) => void;
   diagnostics: Diagnostics | null;
   diagnosticsLoading: boolean;
@@ -263,7 +274,11 @@ function CoslashContent({
   return (
     <div className="h-full overflow-y-auto">
       {view === 'board' ? (
-        <SessionBoard sessions={visibleSessions} onSelectSession={onSelectSession} />
+        <SessionBoard
+          sessions={visibleSessions}
+          onSelectSession={onSelectSession}
+          showMachineBadge={showMachineBadge}
+        />
       ) : (
         <div className="bg-background flex flex-col gap-4 px-4 py-2">
           {visibleSessions.map((session) => (
@@ -271,6 +286,7 @@ function CoslashContent({
               key={sessionKey(session)}
               session={session}
               onClick={() => onSelectSession(session)}
+              showMachineBadge={showMachineBadge}
             />
           ))}
         </div>
@@ -286,7 +302,7 @@ export function CoslashPage() {
   const shareFixtureEnabled = shareParams.get('team-share') === '1';
   const [hubDestination, setHubDestination] = useState<DestinationResult | null>(null);
   const shareEnabled = shareFixtureEnabled || hubDestination?.configured === true;
-  const { sessions, isLoading, loadError, sessionsVersion, retrySessions } = useSessions({
+  const { sessions, machines, isLoading, loadError, sessionsVersion, retrySessions } = useSessions({
     localWindow: shareEnabled ? 'all' : timeWindow,
     remoteWindow: timeWindow,
   });
@@ -305,6 +321,7 @@ export function CoslashPage() {
   const [searchTerm, setSearchTerm] = useState('');
   const [settingsDialogMode, setSettingsDialogMode] = useState<SettingsDialogMode | null>(null);
   const [shareDialogOpen, setShareDialogOpen] = useState(false);
+  const [remoteRetryInFlight, setRemoteRetryInFlight] = useState(false);
   const settingsState = useSettings();
   const settingsHaveError = settingsState.loadError != null || settingsState.response?.valid === false;
   const shareDestination = shareFixtureEnabled ? fixtureDestination(window.location.search) : hubDestination;
@@ -320,6 +337,16 @@ export function CoslashPage() {
     [sessions, shareFixtureEnabled],
   );
   const sessionVendors = getSessionVendors(sessions);
+  const configuredRemote = remoteConfigured(machines);
+  const remoteHost = remoteMachine(machines);
+  const showHostStrip = hostStripVisible(remoteHost);
+  const stripModel =
+    remoteHost != null && showHostStrip
+      ? hostStripModel(remoteHost, { retryInFlight: remoteRetryInFlight })
+      : null;
+  const installationGuidePath =
+    settingsState.response?.options.remoteInstallationGuidePath ?? 'docs/remote-host-installation.md';
+  const remoteSessionCount = sessions.filter((session) => session.sourceId !== LOCAL_SOURCE_ID).length;
 
   const refreshHubDestination = useCallback(async () => {
     const destination = await loadHubDestination();
@@ -360,6 +387,13 @@ export function CoslashPage() {
       setSettingsDialogMode((current) => current ?? 'synthesis-consent');
     }
   }, [selectedSession, settingsState.response]);
+
+  useEffect(() => {
+    if (selectedSessionKey != null && selectedSession == null) {
+      setSelectedSessionKey(null);
+    }
+  }, [selectedSession, selectedSessionKey]);
+
   // Keep live sessions visible even when their logs predate the window.
   const windowStart = timeWindowStart(timeWindow);
   const sessionsInWindow =
@@ -377,6 +411,24 @@ export function CoslashPage() {
   const refreshFirstRun = () => {
     retrySessions();
     refreshDiagnostics();
+  };
+
+  const handleRemoteRetry = () => {
+    if (remoteRetryInFlight) return;
+    setRemoteRetryInFlight(true);
+    void retryRemoteRefresh()
+      .catch(() => undefined)
+      .finally(() => {
+        setRemoteRetryInFlight(false);
+        retrySessions();
+        if (diagnosticsOpen) refreshDiagnostics();
+      });
+  };
+
+  const saveSettings = async (settings: Parameters<typeof settingsState.save>[0]) => {
+    const ok = await settingsState.save(settings);
+    if (ok) retrySessions();
+    return ok;
   };
 
   return (
@@ -426,6 +478,7 @@ export function CoslashPage() {
               isLoading={diagnosticsLoading}
               loadFailed={diagnosticsLoadFailed}
               onRefresh={refreshDiagnostics}
+              remoteSessionCount={remoteSessionCount}
             />
             {shareEnabled && (
               <Button variant="outline" size="sm" onClick={() => setShareDialogOpen(true)}>
@@ -435,6 +488,14 @@ export function CoslashPage() {
           </div>
         </div>
       </div>
+      {stripModel && (
+        <RemoteHostStrip
+          model={stripModel}
+          installationGuidePath={installationGuidePath}
+          onRetry={handleRemoteRetry}
+          onOpenDiagnostics={() => setDiagnosticsOpen(true)}
+        />
+      )}
       <div className="flex flex-1 flex-col overflow-hidden">
         <div className="min-h-0 flex-1 overflow-hidden">
           <LoadingSpinner isLoading={isLoading && sessions.length === 0}>
@@ -446,6 +507,7 @@ export function CoslashPage() {
               searchTerm={searchTerm}
               timeWindow={timeWindow}
               view={view}
+              showMachineBadge={configuredRemote}
               onSelectSession={(session) => setSelectedSessionKey(sessionKey(session))}
               diagnostics={diagnostics}
               diagnosticsLoading={diagnosticsLoading}
@@ -459,6 +521,8 @@ export function CoslashPage() {
         session={selectedSession}
         sessionsVersion={sessionsVersion}
         synthesisSettingsKey={synthesisSettingsKey}
+        showMachineBadge={configuredRemote}
+        remoteMachineFact={remoteHost}
         onClose={() => setSelectedSessionKey(null)}
       />
       {shareEnabled && shareDestination && (
@@ -487,7 +551,7 @@ export function CoslashPage() {
         loadError={settingsState.loadError}
         saveError={settingsState.saveError}
         isSaving={settingsState.isSaving}
-        onSave={settingsState.save}
+        onSave={saveSettings}
       />
     </div>
   );

--- a/frontend/src/pages/coslash/CoslashPage.tsx
+++ b/frontend/src/pages/coslash/CoslashPage.tsx
@@ -29,7 +29,11 @@ import {
   type ViewMode,
 } from '@/pages/coslash/CoslashTabMenus';
 import { loadHubDestination } from '@/pages/coslash/features/sharing/api';
-import { HUB_SHARE_VERSION, type DestinationResult } from '@/pages/coslash/features/sharing/model';
+import {
+  HUB_SHARE_VERSION,
+  localShareCandidates,
+  type DestinationResult,
+} from '@/pages/coslash/features/sharing/model';
 import { ShareToHubDialog } from '@/pages/coslash/features/sharing/ShareToHubDialog';
 import { useDiagnostics } from '@/pages/coslash/hooks/use-diagnostics';
 import { useSessions } from '@/pages/coslash/hooks/use-sessions';
@@ -38,7 +42,14 @@ import type { Diagnostics } from '@/pages/coslash/lib/diagnostics';
 import { formatEstimatedCost } from '@/pages/coslash/lib/format';
 import { sessionsEmptyStateCopy } from '@/pages/coslash/lib/page-copy';
 import { sessionMatchesSearchTerm } from '@/pages/coslash/lib/search';
-import { getSessionVendors, getStatus, type Session } from '@/pages/coslash/lib/session';
+import {
+  getSessionVendors,
+  getStatus,
+  isLocalSession,
+  sessionKey,
+  sessionsForAggregates,
+  type Session,
+} from '@/pages/coslash/lib/session';
 import { shouldPromptForSynthesisConsent } from '@/pages/coslash/lib/settings';
 import { timeWindowStart, type TimeWindow } from '@/pages/coslash/lib/time-window';
 
@@ -143,23 +154,26 @@ function SessionsStats({
 }) {
   if (loadFailed) return null;
 
-  const activeSessions = sessions.filter((session) => getStatus(session.status) === 'busy').length;
-  const waitingSessions = sessions.filter((session) => getStatus(session.status) === 'waiting').length;
+  const aggregateSessions = sessionsForAggregates(sessions);
+  const activeSessions = aggregateSessions.filter((session) => getStatus(session.status) === 'busy').length;
+  const waitingSessions = aggregateSessions.filter(
+    (session) => getStatus(session.status) === 'waiting',
+  ).length;
 
   return (
     <div className="flex w-full min-w-0 items-center justify-between gap-3">
       <div className="text-muted-foreground flex min-w-0 items-center gap-2 text-sm">
         <span className="truncate">
           <span className="text-foreground font-semibold">
-            {sessions.length} {sessions.length === 1 ? 'session' : 'sessions'}
+            {aggregateSessions.length} {aggregateSessions.length === 1 ? 'session' : 'sessions'}
           </span>{' '}
           {WINDOW_ACTIVITY_LABELS[timeWindow]} ·{' '}
-          {sessions.filter((session) => session.agent === 'claude').length} Claude Code,{' '}
-          {sessions.filter((session) => session.agent === 'codex').length} Codex,{' '}
-          {sessions.filter((session) => session.agent === 'opencode').length} OpenCode ·
+          {aggregateSessions.filter((session) => session.agent === 'claude').length} Claude Code,{' '}
+          {aggregateSessions.filter((session) => session.agent === 'codex').length} Codex,{' '}
+          {aggregateSessions.filter((session) => session.agent === 'opencode').length} OpenCode ·
         </span>
-        <UnpricedModelWarning unpriced={sessions.flatMap((session) => session.unpricedModels)}>
-          {formatEstimatedCost(sessions.reduce((sum, session) => sum + session.cost, 0))}
+        <UnpricedModelWarning unpriced={aggregateSessions.flatMap((session) => session.unpricedModels)}>
+          {formatEstimatedCost(aggregateSessions.reduce((sum, session) => sum + session.cost, 0))}
         </UnpricedModelWarning>
         <span
           className="shrink-0 cursor-help underline decoration-dotted underline-offset-2"
@@ -254,7 +268,7 @@ function CoslashContent({
         <div className="bg-background flex flex-col gap-4 px-4 py-2">
           {visibleSessions.map((session) => (
             <SessionCard
-              key={`${session.agent}:${session.id}`}
+              key={sessionKey(session)}
               session={session}
               onClick={() => onSelectSession(session)}
             />
@@ -272,9 +286,10 @@ export function CoslashPage() {
   const shareFixtureEnabled = shareParams.get('team-share') === '1';
   const [hubDestination, setHubDestination] = useState<DestinationResult | null>(null);
   const shareEnabled = shareFixtureEnabled || hubDestination?.configured === true;
-  const { sessions, isLoading, loadError, sessionsVersion, retrySessions } = useSessions(
-    shareEnabled ? 'all' : timeWindow,
-  );
+  const { sessions, isLoading, loadError, sessionsVersion, retrySessions } = useSessions({
+    localWindow: shareEnabled ? 'all' : timeWindow,
+    remoteWindow: timeWindow,
+  });
   const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
   const diagnosticsEnabled = diagnosticsOpen || (!isLoading && loadError == null && sessions.length === 0);
   const {
@@ -286,7 +301,7 @@ export function CoslashPage() {
   const [view, setView] = useState<ViewMode>('list');
   const [sortKey, setSortKey] = useState<SortKey>(SortKey.Recency);
   const [sortDir, setSortDir] = useState<SortDir>('desc');
-  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
+  const [selectedSessionKey, setSelectedSessionKey] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
   const [settingsDialogMode, setSettingsDialogMode] = useState<SettingsDialogMode | null>(null);
   const [shareDialogOpen, setShareDialogOpen] = useState(false);
@@ -296,10 +311,12 @@ export function CoslashPage() {
   const shareFixtureOutcome = shareParams.get('share-result') === 'partial' ? 'partial' : 'success';
   const shareCandidates = useMemo(
     () =>
-      sessions.map((session, index) => ({
-        session,
-        previouslyShared: shareFixtureEnabled && index === 0,
-      })),
+      localShareCandidates(
+        sessions.map((session, index) => ({
+          session,
+          previouslyShared: shareFixtureEnabled && index === 0,
+        })),
+      ),
     [sessions, shareFixtureEnabled],
   );
   const sessionVendors = getSessionVendors(sessions);
@@ -321,10 +338,10 @@ export function CoslashPage() {
   useEffect(() => {
     if (vendor !== 'all' && !sessions.some((session) => session.agent === vendor)) setVendor('all');
   }, [sessions, vendor]);
-  // Held by id, not by value: the inspector must render the freshest record
-  // each refresh, and a stored object would freeze at click time. Looked up
+  // Held by source-aware key, not by value: the inspector must render the freshest
+  // record each refresh, and a stored object would freeze at click time. Looked up
   // from the unfiltered list so filters never close an open inspector.
-  const selectedSession = sessions.find((session) => session.id === selectedSessionId) ?? null;
+  const selectedSession = sessions.find((session) => sessionKey(session) === selectedSessionKey) ?? null;
   const synthesisSettingsKey = settingsState.response
     ? [
         settingsState.response.persisted,
@@ -335,7 +352,11 @@ export function CoslashPage() {
     : 'loading';
 
   useEffect(() => {
-    if (shouldPromptForSynthesisConsent(selectedSession, settingsState.response)) {
+    if (
+      selectedSession != null &&
+      isLocalSession(selectedSession) &&
+      shouldPromptForSynthesisConsent(selectedSession, settingsState.response)
+    ) {
       setSettingsDialogMode((current) => current ?? 'synthesis-consent');
     }
   }, [selectedSession, settingsState.response]);
@@ -425,7 +446,7 @@ export function CoslashPage() {
               searchTerm={searchTerm}
               timeWindow={timeWindow}
               view={view}
-              onSelectSession={(session) => setSelectedSessionId(session.id)}
+              onSelectSession={(session) => setSelectedSessionKey(sessionKey(session))}
               diagnostics={diagnostics}
               diagnosticsLoading={diagnosticsLoading}
               diagnosticsLoadFailed={diagnosticsLoadFailed}
@@ -438,7 +459,7 @@ export function CoslashPage() {
         session={selectedSession}
         sessionsVersion={sessionsVersion}
         synthesisSettingsKey={synthesisSettingsKey}
-        onClose={() => setSelectedSessionId(null)}
+        onClose={() => setSelectedSessionKey(null)}
       />
       {shareEnabled && shareDestination && (
         <ShareToHubDialog

--- a/frontend/src/pages/coslash/components/DiagnosticsDialog.tsx
+++ b/frontend/src/pages/coslash/components/DiagnosticsDialog.tsx
@@ -14,6 +14,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { DiagnosticsButton } from '@/pages/coslash/components/DiagnosticsButton';
 import { DiagnosticsChecklist } from '@/pages/coslash/components/DiagnosticsChecklist';
 import { formatDiagnosticsForCopy, worstStatus, type Diagnostics } from '@/pages/coslash/lib/diagnostics';
+import { formatRemoteDiagnosticsFacts } from '@/pages/coslash/lib/remote-diagnostics';
 
 export function DiagnosticsDialog({
   open,
@@ -22,6 +23,7 @@ export function DiagnosticsDialog({
   isLoading,
   loadFailed,
   onRefresh,
+  remoteSessionCount,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -29,6 +31,7 @@ export function DiagnosticsDialog({
   isLoading: boolean;
   loadFailed: boolean;
   onRefresh: () => void;
+  remoteSessionCount?: number;
 }) {
   const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
   const copyDiagnostics = () => {
@@ -45,6 +48,11 @@ export function DiagnosticsDialog({
     if (!nextOpen) setCopyState('idle');
     onOpenChange(nextOpen);
   };
+
+  const remoteFacts =
+    diagnostics?.remote && diagnostics.remote.state
+      ? formatRemoteDiagnosticsFacts(diagnostics.remote, { sessionCount: remoteSessionCount })
+      : null;
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -78,6 +86,14 @@ export function DiagnosticsDialog({
                     CLI: {source.cli.found ? source.cli.version || source.cli.path : 'not found'}
                   </div>
                 ))}
+                {remoteFacts && (
+                  <div>
+                    <div className="text-foreground pb-1 font-semibold">Remote host</div>
+                    {remoteFacts.map((line) => (
+                      <div key={line}>{line}</div>
+                    ))}
+                  </div>
+                )}
                 <div>
                   Storage: <code>{diagnostics.storage.home}</code>
                 </div>

--- a/frontend/src/pages/coslash/components/MachineBadge.tsx
+++ b/frontend/src/pages/coslash/components/MachineBadge.tsx
@@ -1,0 +1,9 @@
+import { Badge } from '@/components/ui/badge';
+
+export function MachineBadge({ label }: { label: string }) {
+  return (
+    <Badge variant="secondary" className="text-muted-foreground shrink-0 text-xs font-semibold">
+      {label}
+    </Badge>
+  );
+}

--- a/frontend/src/pages/coslash/components/MachinesSettingsSection.tsx
+++ b/frontend/src/pages/coslash/components/MachinesSettingsSection.tsx
@@ -1,0 +1,169 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { firstTimeSshHint, formatTestConnectionResult } from '@/pages/coslash/lib/host-strip';
+import type { MachineFact } from '@/pages/coslash/lib/machines';
+import { testRemoteAlias } from '@/pages/coslash/lib/remote-api';
+import type { RemoteHostSettings } from '@/pages/coslash/lib/settings';
+
+export function MachinesSettingsSection({
+  remote,
+  installationGuidePath,
+  onChange,
+}: {
+  remote: RemoteHostSettings | null | undefined;
+  installationGuidePath: string;
+  onChange: (remote: RemoteHostSettings | null) => void;
+}) {
+  const draft = remote ?? { sshAlias: '', enabled: true };
+  const hasHost = remote != null;
+  const [testResult, setTestResult] = useState<MachineFact | null>(null);
+  const [testError, setTestError] = useState<string | null>(null);
+  const [testing, setTesting] = useState(false);
+  const [confirmRemove, setConfirmRemove] = useState(false);
+
+  const setAlias = (sshAlias: string) => {
+    setTestResult(null);
+    setTestError(null);
+    setConfirmRemove(false);
+    onChange({ ...draft, sshAlias });
+  };
+
+  const setEnabled = (enabled: boolean) => {
+    setConfirmRemove(false);
+    onChange({ ...draft, enabled });
+  };
+
+  const runTest = async () => {
+    const alias = draft.sshAlias.trim();
+    if (!alias) {
+      setTestError('Enter an SSH alias first');
+      return;
+    }
+    setTesting(true);
+    setTestError(null);
+    setTestResult(null);
+    try {
+      setTestResult(await testRemoteAlias(alias));
+    } catch (error: unknown) {
+      setTestError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const removeHost = () => {
+    if (!confirmRemove) {
+      setConfirmRemove(true);
+      return;
+    }
+    setConfirmRemove(false);
+    setTestResult(null);
+    setTestError(null);
+    onChange(null);
+  };
+
+  const showSetupLink = testResult?.state === 'setup_required' || testResult?.state === 'upgrade_required';
+  const showFirstTimeHint = testResult?.state === 'error' && testResult.reason === 'connection_failed';
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-2 px-0.5">
+        <span className="text-muted-foreground text-[11px] font-semibold tracking-widest uppercase">
+          Machines
+        </span>
+        <span className="bg-border h-px flex-1" />
+      </div>
+      <div className="border-border bg-card overflow-hidden rounded-xl border">
+        <div className="flex flex-col gap-1 p-4">
+          <div className="text-sm font-semibold">Remote host</div>
+          <div className="text-muted-foreground text-xs text-pretty">
+            Monitor Claude Code and Codex through your existing SSH config.
+          </div>
+        </div>
+
+        <div className="border-border flex flex-col gap-3 border-t p-4 sm:flex-row sm:items-center sm:justify-between">
+          <label htmlFor="remote-ssh-alias" className="text-[13px] font-semibold">
+            SSH alias
+          </label>
+          <input
+            id="remote-ssh-alias"
+            aria-label="SSH alias"
+            value={draft.sshAlias}
+            onChange={(event) => setAlias(event.target.value)}
+            placeholder="gpu-server"
+            className="border-border bg-background text-foreground focus-visible:border-ring focus-visible:ring-ring h-8 w-full rounded-lg border px-2.5 font-mono text-xs outline-none focus-visible:ring-3 sm:max-w-72"
+          />
+        </div>
+
+        <div className="border-border flex items-center justify-between gap-4 border-t p-4">
+          <div className="flex min-w-0 flex-col gap-1">
+            <div className="text-[13px] font-semibold">Enabled</div>
+            <div className="text-muted-foreground text-[11px]">
+              {draft.enabled
+                ? 'Monitor this host on the board'
+                : 'Disabled — no remote cards or strip; cache retained'}
+            </div>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-label="Remote host enabled"
+            aria-checked={draft.enabled}
+            disabled={!draft.sshAlias.trim()}
+            onClick={() => setEnabled(!draft.enabled)}
+            className="bg-input focus-visible:border-ring focus-visible:ring-ring aria-checked:bg-primary relative inline-flex h-6 w-10 shrink-0 cursor-pointer items-center rounded-full p-0.5 transition-colors outline-none focus-visible:ring-3 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <span
+              className={cn(
+                'bg-background pointer-events-none size-5 rounded-full shadow-sm transition-transform',
+                {
+                  'translate-x-4': draft.enabled,
+                  'translate-x-0': !draft.enabled,
+                },
+              )}
+            />
+          </button>
+        </div>
+
+        <div className="border-border flex flex-wrap items-center justify-between gap-3 border-t p-4">
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={testing || !draft.sshAlias.trim()}
+              onClick={() => void runTest()}
+            >
+              {testing ? 'Testing…' : 'Test connection'}
+            </Button>
+            {hasHost && (
+              <Button type="button" variant="outline" size="sm" onClick={removeHost}>
+                {confirmRemove ? 'Confirm remove' : 'Remove host'}
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {(testResult != null || testError != null) && (
+          <div
+            role={testResult?.state === 'ok' ? 'status' : 'alert'}
+            className={cn('border-t px-4 py-3 text-xs', {
+              'bg-success-bg text-success-fg': testResult?.state === 'ok',
+              'bg-warning-bg text-warning-fg': testResult != null && testResult.state !== 'ok',
+              'bg-destructive/10 text-destructive': testError != null,
+            })}
+          >
+            {testError ?? (testResult ? formatTestConnectionResult(testResult) : null)}
+            {showFirstTimeHint && <div className="pt-1">{firstTimeSshHint(draft.sshAlias.trim())}</div>}
+            {showSetupLink && (
+              <div className="pt-1">
+                Installation guide · <code className="font-mono">{installationGuidePath}</code>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/coslash/components/RemoteHostStrip.tsx
+++ b/frontend/src/pages/coslash/components/RemoteHostStrip.tsx
@@ -1,0 +1,57 @@
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { type HostStripModel } from '@/pages/coslash/lib/host-strip';
+
+export function RemoteHostStrip({
+  model,
+  installationGuidePath,
+  onRetry,
+  onOpenDiagnostics,
+}: {
+  model: HostStripModel;
+  installationGuidePath: string;
+  onRetry: () => void;
+  onOpenDiagnostics: () => void;
+}) {
+  return (
+    <div
+      role={model.role}
+      className={cn(
+        'flex items-center justify-between gap-3 border-b px-4 py-2 text-xs',
+        model.tone === 'danger' ? 'bg-destructive/10 text-destructive' : 'bg-warning-bg text-warning-fg',
+      )}
+    >
+      <span className="min-w-0 font-medium">{model.message}</span>
+      <div className="flex shrink-0 items-center gap-2">
+        {model.actions.includes('installation') && (
+          <span className="text-[11px]">
+            Installation guide · <code className="font-mono">{installationGuidePath}</code>
+          </span>
+        )}
+        {model.actions.includes('diagnostics') && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs"
+            onClick={onOpenDiagnostics}
+          >
+            Diagnostics
+          </Button>
+        )}
+        {model.actions.includes('retry') && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs"
+            disabled={model.retryDisabled}
+            onClick={onRetry}
+          >
+            Retry
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/coslash/components/SessionBoard.tsx
+++ b/frontend/src/pages/coslash/components/SessionBoard.tsx
@@ -6,6 +6,8 @@ import { formatEstimatedCost, formatTokens } from '@/pages/coslash/lib/format';
 import {
   getStatus,
   getTotalTokens,
+  sessionKey,
+  sessionsForAggregates,
   STATUS_ORDER,
   STATUSES,
   type Session,
@@ -28,23 +30,25 @@ function groupBy(sessions: Session[], keyOf: (session: Session) => string): [str
 }
 
 function StatusColumnHeader({ status, sessions }: { status: Status; sessions: Session[] }) {
+  const count = sessionsForAggregates(sessions).length;
   return (
     <div className="bg-background sticky top-0 z-10 flex items-center gap-2 border-b border-l px-3 py-2">
       <span className={cn('size-2 rounded-full', status.dot)} />
       <span className={cn('text-xs font-semibold', status.fg)}>{status.label}</span>
-      <span className="text-muted-foreground font-mono text-xs">{sessions.length}</span>
+      <span className="text-muted-foreground font-mono text-xs">{count}</span>
     </div>
   );
 }
 
 function GroupTotals({ sessions }: { sessions: Session[] }) {
-  const tokens = sessions.reduce((sum, session) => sum + getTotalTokens(session.tokens), 0);
-  const cost = sessions.reduce((sum, session) => sum + session.cost, 0);
+  const aggregate = sessionsForAggregates(sessions);
+  const tokens = aggregate.reduce((sum, session) => sum + getTotalTokens(session.tokens), 0);
+  const cost = aggregate.reduce((sum, session) => sum + session.cost, 0);
 
   return (
     <span className="text-muted-foreground text-xs">
-      {sessions.length} {sessions.length === 1 ? 'session' : 'sessions'} · {formatTokens(tokens)} tok ·{' '}
-      <UnpricedModelWarning unpriced={sessions.flatMap((session) => session.unpricedModels)}>
+      {aggregate.length} {aggregate.length === 1 ? 'session' : 'sessions'} · {formatTokens(tokens)} tok ·{' '}
+      <UnpricedModelWarning unpriced={aggregate.flatMap((session) => session.unpricedModels)}>
         {formatEstimatedCost(cost)}
       </UnpricedModelWarning>
     </span>
@@ -75,7 +79,7 @@ function SessionCardColumn({
         .filter((session) => getStatus(session.status) === status)
         .map((session) => (
           <SessionCard
-            key={`${session.agent}:${session.id}`}
+            key={sessionKey(session)}
             session={session}
             onClick={() => onSelectSession(session)}
             variant="compact"

--- a/frontend/src/pages/coslash/components/SessionBoard.tsx
+++ b/frontend/src/pages/coslash/components/SessionBoard.tsx
@@ -4,7 +4,7 @@ import { SessionCard } from '@/pages/coslash/components/SessionCard';
 import { UnpricedModelWarning } from '@/pages/coslash/components/UnpricedModelWarning';
 import { formatEstimatedCost, formatTokens } from '@/pages/coslash/lib/format';
 import {
-  getStatus,
+  boardStatusKey,
   getTotalTokens,
   sessionKey,
   sessionsForAggregates,
@@ -67,22 +67,25 @@ function RepoGroupHeader({ repo, sessions }: { repo: string; sessions: Session[]
 function SessionCardColumn({
   status,
   sessions,
+  showMachineBadge,
   onSelectSession,
 }: {
   status: string;
   sessions: Session[];
+  showMachineBadge: boolean;
   onSelectSession: (session: Session) => void;
 }) {
   return (
     <>
       {sessions
-        .filter((session) => getStatus(session.status) === status)
+        .filter((session) => boardStatusKey(session) === status)
         .map((session) => (
           <SessionCard
             key={sessionKey(session)}
             session={session}
             onClick={() => onSelectSession(session)}
             variant="compact"
+            showMachineBadge={showMachineBadge}
           />
         ))}
     </>
@@ -93,11 +96,13 @@ function BranchRow({
   branch,
   sessions,
   visibleStatuses,
+  showMachineBadge,
   onSelectSession,
 }: {
   branch: string;
   sessions: Session[];
   visibleStatuses: [string, Status][];
+  showMachineBadge: boolean;
   onSelectSession: (session: Session) => void;
 }) {
   return (
@@ -108,7 +113,12 @@ function BranchRow({
       </div>
       {visibleStatuses.map(([status]) => (
         <div key={status} data-status={status} className="flex flex-col gap-2 border-b border-l p-2">
-          <SessionCardColumn status={status} sessions={sessions} onSelectSession={onSelectSession} />
+          <SessionCardColumn
+            status={status}
+            sessions={sessions}
+            showMachineBadge={showMachineBadge}
+            onSelectSession={onSelectSession}
+          />
         </div>
       ))}
     </>
@@ -118,12 +128,14 @@ function BranchRow({
 export function SessionBoard({
   sessions,
   onSelectSession,
+  showMachineBadge = false,
 }: {
   sessions: Session[];
   onSelectSession: (session: Session) => void;
+  showMachineBadge?: boolean;
 }) {
   const visibleStatuses = STATUS_ORDER.filter((status) =>
-    sessions.some((session) => getStatus(session.status) === status),
+    sessions.some((session) => boardStatusKey(session) === status),
   ).map((status): [string, Status] => [status, STATUSES[status]]);
 
   return (
@@ -136,7 +148,7 @@ export function SessionBoard({
         <StatusColumnHeader
           key={key}
           status={status}
-          sessions={sessions.filter((session) => getStatus(session.status) === key)}
+          sessions={sessions.filter((session) => boardStatusKey(session) === key)}
         />
       ))}
       {groupBy(sessions, (session) => session.repo ?? '(no repo)').map(([repo, repoSessions]) => (
@@ -148,6 +160,7 @@ export function SessionBoard({
               branch={branch}
               sessions={branchSessions}
               visibleStatuses={visibleStatuses}
+              showMachineBadge={showMachineBadge}
               onSelectSession={onSelectSession}
             />
           ))}

--- a/frontend/src/pages/coslash/components/SessionCard.tsx
+++ b/frontend/src/pages/coslash/components/SessionCard.tsx
@@ -12,9 +12,11 @@ import {
 } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
 import { CopyableBadge } from '@/pages/coslash/components/CopyableBadge';
+import { MachineBadge } from '@/pages/coslash/components/MachineBadge';
 import { UnpricedModelWarning } from '@/pages/coslash/components/UnpricedModelWarning';
 import { formatDuration, formatEstimatedCost, formatTimeAgo, formatTokens } from '@/pages/coslash/lib/format';
 import {
+  displayStatusLabel,
   environmentFact,
   getModality,
   getSessionCardSummary,
@@ -25,7 +27,6 @@ import {
   SUBAGENT_STATUSES,
   sumTokens,
   type Session,
-  type Status,
   type Subagent,
   type SubagentCommand,
 } from '@/pages/coslash/lib/session';
@@ -38,6 +39,7 @@ export type SessionCardProps = {
   session: Session;
   onClick?: () => void;
   variant?: SessionCardVariant;
+  showMachineBadge?: boolean;
 };
 
 function shortenSessionId(id: string): string {
@@ -94,11 +96,12 @@ export function SessionId({ id, shortened = false }: { id: string; shortened?: b
   );
 }
 
-function StatusBadge({ status }: { status: Status }) {
+function StatusBadge({ session }: { session: Session }) {
+  const status = STATUSES[getStatus(session.displayStale ? null : session.status)];
   return (
     <Badge className={cn('gap-1 text-xs font-semibold', status.fg, status.bg)}>
-      <span className={cn('size-1 rounded-full', status.dot)} />
-      {status.label}
+      {!session.displayStale && <span className={cn('size-1 rounded-full', status.dot)} />}
+      {displayStatusLabel(session)}
     </Badge>
   );
 }
@@ -140,13 +143,14 @@ function Summary({ session }: { session: Session }) {
   return <div className="text-muted-foreground pt-2 text-xs">{getSessionCardSummary(session)}</div>;
 }
 
-function CompactSessionCard({ session }: { session: Session }) {
+function CompactSessionCard({ session, showMachineBadge }: { session: Session; showMachineBadge: boolean }) {
   return (
     <>
       <div className="flex items-center justify-between gap-2">
         <div className="flex min-w-0 items-center gap-2">
           <SessionVendorBadge agent={session.agent} abbreviated />
           <SessionName name={session.name} variant="compact" />
+          {showMachineBadge && <MachineBadge label={session.sourceLabel} />}
         </div>
         <span className="text-xs font-semibold whitespace-nowrap">
           <UnpricedModelWarning unpriced={session.unpricedModels}>
@@ -165,17 +169,16 @@ function CompactSessionCard({ session }: { session: Session }) {
   );
 }
 
-function DetailedSessionCard({ session }: { session: Session }) {
-  const status = STATUSES[getStatus(session.status)];
-
+function DetailedSessionCard({ session, showMachineBadge }: { session: Session; showMachineBadge: boolean }) {
   return (
-    <div className="flex items-start gap-4">
+    <div className={cn('flex items-start gap-4', { 'opacity-75': session.displayStale })}>
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
           <SessionVendorBadge agent={session.agent} />
           <SessionName name={session.name} />
           <SessionId id={session.id} />
-          <StatusBadge status={status} />
+          <StatusBadge session={session} />
+          {showMachineBadge && <MachineBadge label={session.sourceLabel} />}
           <Modality session={session} />
         </div>
         <Summary session={session} />
@@ -432,14 +435,19 @@ function SessionSubagentRail({
   );
 }
 
-export function SessionCard({ session, onClick, variant = 'detailed' }: SessionCardProps) {
+export function SessionCard({
+  session,
+  onClick,
+  variant = 'detailed',
+  showMachineBadge = false,
+}: SessionCardProps) {
   return (
     <div className="flex flex-col gap-2">
       <Card className={cn('cursor-pointer', variant === 'compact' ? 'gap-1 p-3' : 'p-4')} onClick={onClick}>
         {variant === 'compact' ? (
-          <CompactSessionCard session={session} />
+          <CompactSessionCard session={session} showMachineBadge={showMachineBadge} />
         ) : (
-          <DetailedSessionCard session={session} />
+          <DetailedSessionCard session={session} showMachineBadge={showMachineBadge} />
         )}
       </Card>
       <SessionSubagentRail subagents={session.subagents} parentName={session.name} variant={variant} />

--- a/frontend/src/pages/coslash/components/SessionCard.tsx
+++ b/frontend/src/pages/coslash/components/SessionCard.tsx
@@ -15,6 +15,7 @@ import { CopyableBadge } from '@/pages/coslash/components/CopyableBadge';
 import { UnpricedModelWarning } from '@/pages/coslash/components/UnpricedModelWarning';
 import { formatDuration, formatEstimatedCost, formatTimeAgo, formatTokens } from '@/pages/coslash/lib/format';
 import {
+  environmentFact,
   getModality,
   getSessionCardSummary,
   getStatus,
@@ -113,8 +114,8 @@ function Modality({ session }: { session: Session }) {
 
 function Metadata({ session }: { session: Session }) {
   return (
-    <div className="text-muted-foreground pt-2 font-mono text-xs" title={session.cwd}>
-      {session.repo ?? '—'} · {session.branch ?? '—'} · {formatTimeAgo(session.mtime)} ·{' '}
+    <div className="text-muted-foreground pt-2 font-mono text-xs" title={environmentFact(session.cwd)}>
+      {environmentFact(session.repo)} · {environmentFact(session.branch)} · {formatTimeAgo(session.mtime)} ·{' '}
       {formatDuration(session.durationMs)} · {session.files} files
     </div>
   );

--- a/frontend/src/pages/coslash/components/SessionInspector.tsx
+++ b/frontend/src/pages/coslash/components/SessionInspector.tsx
@@ -19,6 +19,7 @@ import { Sheet, SheetContent, SheetFooter, SheetHeader, SheetTitle } from '@/com
 import { cn } from '@/lib/utils';
 import { CopyableBadge } from '@/pages/coslash/components/CopyableBadge';
 import { DiffList } from '@/pages/coslash/components/DiffList';
+import { MachineBadge } from '@/pages/coslash/components/MachineBadge';
 import {
   SessionId,
   SessionName,
@@ -43,8 +44,11 @@ import {
   formatTokens,
 } from '@/pages/coslash/lib/format';
 import { handoffBrief } from '@/pages/coslash/lib/handoff';
+import { remoteLaunchGate } from '@/pages/coslash/lib/host-strip';
+import type { MachineFact } from '@/pages/coslash/lib/machines';
 import { teamPreviewEnabled } from '@/pages/coslash/lib/preview';
 import {
+  displayStatusLabel,
   environmentFact,
   getModality,
   getSessionOutcome,
@@ -243,8 +247,8 @@ export function SessionModelUsage({
   );
 }
 
-function HeaderMeta({ detail }: { detail: SessionDetail }) {
-  const status = STATUSES[getStatus(detail.status)];
+function HeaderMeta({ detail, showMachineBadge }: { detail: SessionDetail; showMachineBadge: boolean }) {
+  const status = STATUSES[getStatus(detail.displayStale ? null : detail.status)];
 
   return (
     <div className="flex flex-col gap-2 pt-2">
@@ -264,6 +268,7 @@ function HeaderMeta({ detail }: { detail: SessionDetail }) {
               <span className="truncate">{detail.branch}</span>
             </CopyableBadge>
           )}
+          {showMachineBadge && <MachineBadge label={detail.sourceLabel} />}
         </div>
         <span
           className={cn(
@@ -271,8 +276,8 @@ function HeaderMeta({ detail }: { detail: SessionDetail }) {
             status.fg,
           )}
         >
-          <span className={cn('size-2 rounded-full', status.dot)} />
-          {status.label} · {getModality(detail.entrypoint)}
+          {!detail.displayStale && <span className={cn('size-2 rounded-full', status.dot)} />}
+          {displayStatusLabel(detail)} · {getModality(detail.entrypoint)}
         </span>
       </div>
       <div className="bg-muted rounded-lg border p-2 font-mono text-xs">
@@ -343,8 +348,19 @@ function LaunchError({ message }: { message: string | null }) {
   return <span className="text-destructive text-xs">{message}</span>;
 }
 
-function ResumeSessionButton({ detail }: { detail: SessionDetail }) {
+function ResumeSessionButton({
+  detail,
+  launchGate,
+}: {
+  detail: SessionDetail;
+  launchGate: ReturnType<typeof remoteLaunchGate> | null;
+}) {
   const { launch, launchError } = useLaunchTerminal(detail);
+  const blocked = launchGate != null && !launchGate.allowed;
+
+  if (blocked) {
+    return <span className="text-muted-foreground text-xs">{launchGate.reason}</span>;
+  }
 
   return (
     <div className="flex flex-col gap-1">
@@ -361,12 +377,17 @@ function StartNewSessionButton({
   detail,
   brief,
   onCopy,
+  launchGate,
 }: {
   detail: SessionDetail;
   brief: string;
   onCopy: () => void;
+  launchGate: ReturnType<typeof remoteLaunchGate> | null;
 }) {
   const { launch, launchError } = useLaunchTerminal(detail);
+  const blocked = launchGate != null && !launchGate.allowed;
+
+  if (blocked) return null;
 
   const startNewSession = () => {
     onCopy();
@@ -384,7 +405,13 @@ function StartNewSessionButton({
   );
 }
 
-function HandoffSection({ detail }: { detail: SessionDetail }) {
+function HandoffSection({
+  detail,
+  launchGate,
+}: {
+  detail: SessionDetail;
+  launchGate: ReturnType<typeof remoteLaunchGate> | null;
+}) {
   const [copied, setCopied] = useState(false);
   const contextFill = contextFillReadiness(detail);
   const branchDrift = branchDriftReadiness(detail.git);
@@ -409,13 +436,22 @@ function HandoffSection({ detail }: { detail: SessionDetail }) {
         <PromptCacheCell lastAccessAt={detail.mtime} />
       </div>
 
-      <div className="flex items-center gap-2">
-        <StartNewSessionButton detail={detail} brief={brief} onCopy={copyBrief} />
+      <div className="flex flex-wrap items-center gap-2">
+        <StartNewSessionButton detail={detail} brief={brief} onCopy={copyBrief} launchGate={launchGate} />
         <Button variant="outline" className="w-fit p-2 text-xs" onClick={copyBrief}>
           <span>Copy handoff</span>
         </Button>
         {copied && <span className="text-xs text-neutral-300">copied to clipboard</span>}
       </div>
+      {launchGate != null && !launchGate.allowed && (
+        <div className="text-muted-foreground text-xs">{launchGate.reason}</div>
+      )}
+      {!isLocalSession(detail) && (
+        <div className="text-muted-foreground text-xs">
+          Remote session · Copy handoff uses available remote facts. File diffs, synthesis, Hub sharing, and
+          command history are unavailable.
+        </div>
+      )}
     </div>
   );
 }
@@ -813,7 +849,7 @@ function CommitsAndTodos({ detail }: { detail: SessionDetail }) {
 
 function CommandsSection({ detail }: { detail: SessionDetail }) {
   const [open, setOpen] = useState(false);
-  if (detail.commands.length === 0) return null;
+  if (!isLocalSession(detail) || detail.commands.length === 0) return null;
 
   return (
     <div className="pt-4">
@@ -839,9 +875,11 @@ function CommandsSection({ detail }: { detail: SessionDetail }) {
 
 function InspectorBody({
   detail,
+  launchGate,
   onSelectFile,
 }: {
   detail: SessionDetail;
+  launchGate: ReturnType<typeof remoteLaunchGate> | null;
   onSelectFile: ((path: string) => void) | null;
 }) {
   // scroll on the outer div, layout on the inner one — flex children of a
@@ -850,7 +888,7 @@ function InspectorBody({
   return (
     <div className="flex-1 overflow-y-auto pb-2">
       <div className="flex flex-col gap-2 px-4">
-        <HandoffSection detail={detail} />
+        <HandoffSection detail={detail} launchGate={launchGate} />
         <RecapSection detail={detail} />
         <DigestSection detail={detail} />
         <ArtifactStats detail={detail} />
@@ -862,7 +900,13 @@ function InspectorBody({
   );
 }
 
-function InspectorFooter({ detail }: { detail: SessionDetail }) {
+function InspectorFooter({
+  detail,
+  launchGate,
+}: {
+  detail: SessionDetail;
+  launchGate: ReturnType<typeof remoteLaunchGate> | null;
+}) {
   const [previewOpen, setPreviewOpen] = useState(false);
   const showTeamPreview =
     isLocalSession(detail) && teamPreviewEnabled(window.location.search) && !detail.repoLocalOnly;
@@ -889,7 +933,7 @@ function InspectorFooter({ detail }: { detail: SessionDetail }) {
             />
           </>
         )}
-        <ResumeSessionButton detail={detail} />
+        <ResumeSessionButton detail={detail} launchGate={launchGate} />
       </div>
     </SheetFooter>
   );
@@ -899,11 +943,15 @@ export function SessionInspector({
   session,
   sessionsVersion,
   synthesisSettingsKey,
+  showMachineBadge = false,
+  remoteMachineFact = null,
   onClose,
 }: {
   session: Session | null;
   sessionsVersion: number;
   synthesisSettingsKey: string;
+  showMachineBadge?: boolean;
+  remoteMachineFact?: MachineFact | null;
   onClose: () => void;
 }) {
   const { detail, loadError } = useSessionDetail(session, sessionsVersion, synthesisSettingsKey);
@@ -916,6 +964,8 @@ export function SessionInspector({
   } = useFileDiff(selectedDiff);
   const isOpen = session != null;
   const openSessionKey = session == null ? null : sessionKey(session);
+  const launchGate =
+    detail != null && !isLocalSession(detail) ? remoteLaunchGate(remoteMachineFact, detail.agent) : null;
 
   useEffect(() => {
     setSelectedDiff(null);
@@ -951,8 +1001,9 @@ export function SessionInspector({
                     <SessionName name={detail.name} variant="inspector" />
                   </SheetTitle>
                   <SessionId id={detail.id} shortened />
+                  {showMachineBadge && <MachineBadge label={detail.sourceLabel} />}
                 </div>
-                <HeaderMeta detail={detail} />
+                <HeaderMeta detail={detail} showMachineBadge={false} />
                 <div className="border-b p-1" />
               </div>
             </SheetHeader>
@@ -963,6 +1014,7 @@ export function SessionInspector({
             )}
             <InspectorBody
               detail={detail}
+              launchGate={launchGate}
               onSelectFile={
                 isLocalSession(detail)
                   ? (path) =>
@@ -975,7 +1027,7 @@ export function SessionInspector({
                   : null
               }
             />
-            <InspectorFooter detail={detail} />
+            <InspectorFooter detail={detail} launchGate={launchGate} />
           </>
         )}
       </SheetContent>

--- a/frontend/src/pages/coslash/components/SessionInspector.tsx
+++ b/frontend/src/pages/coslash/components/SessionInspector.tsx
@@ -30,7 +30,7 @@ import {
 import { SnapshotPreviewDialog } from '@/pages/coslash/components/SnapshotPreviewDialog';
 import { UnpricedModelWarning } from '@/pages/coslash/components/UnpricedModelWarning';
 import { useLaunchTerminal } from '@/pages/coslash/hooks/use-launch-terminal';
-import { useFileDiff, type FileSelection } from '@/pages/coslash/hooks/use-sessions';
+import { synthesisRequestPath, useFileDiff, type FileSelection } from '@/pages/coslash/hooks/use-sessions';
 import { ApiAuthenticationError, apiFetch } from '@/pages/coslash/lib/api';
 import {
   digestDateKey,
@@ -45,17 +45,21 @@ import {
 import { handoffBrief } from '@/pages/coslash/lib/handoff';
 import { teamPreviewEnabled } from '@/pages/coslash/lib/preview';
 import {
+  environmentFact,
   getModality,
   getSessionOutcome,
   getStatus,
   getVendor,
   goalSourceLabel,
+  isLocalSession,
   resolveGoal,
+  sessionKey,
   STATUSES,
   SUBAGENT_STATUSES,
   type DigestEntry,
   type Session,
   type SessionDetail,
+  type SessionIdentity,
 } from '@/pages/coslash/lib/session';
 import { HOUR, MINUTE } from '@/pages/coslash/lib/time';
 
@@ -66,8 +70,14 @@ type SynthesisResponse = {
 };
 
 /* oxlint-disable react/only-export-components -- exported for focused rendering tests */
-export function filePanelOpen(selection: FileSelection | null, sessionId: string): boolean {
-  return selection?.sessionId === sessionId;
+export function filePanelOpen(selection: FileSelection | null, session: SessionIdentity | null): boolean {
+  return (
+    selection != null &&
+    session != null &&
+    selection.sourceId === session.sourceId &&
+    selection.agent === session.agent &&
+    selection.sessionId === session.id
+  );
 }
 /* oxlint-enable react/only-export-components */
 
@@ -76,41 +86,53 @@ function useSessionDetail(
   sessionsVersion: number,
   synthesisSettingsKey: string,
 ): { detail: SessionDetail | null; loadError: string | null } {
-  const [loaded, setLoaded] = useState<({ sessionId: string } & SynthesisResponse) | null>(null);
+  const [loaded, setLoaded] = useState<({ key: string } & SynthesisResponse) | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
-  const pollDeadline = useRef<{ sessionId: string; deadline: number } | null>(null);
-  const sessionId = session?.id ?? null;
+  const pollDeadline = useRef<{ key: string; deadline: number } | null>(null);
+  const sessionRef = useRef(session);
+  sessionRef.current = session;
+  const key = session == null ? null : sessionKey(session);
 
   useEffect(() => {
-    setLoaded((current) => (current?.sessionId === sessionId ? current : null));
+    const current = sessionRef.current;
+    setLoaded((prev) => (prev?.key === key ? prev : null));
     setLoadError(null);
-    if (sessionId == null) {
+    if (current == null || key == null) {
       pollDeadline.current = null;
       return;
     }
-    if (pollDeadline.current?.sessionId !== sessionId) {
+    if (!isLocalSession(current)) {
+      pollDeadline.current = null;
+      return;
+    }
+    if (pollDeadline.current?.key !== key) {
       pollDeadline.current = null;
     }
+    const identity = {
+      sourceId: current.sourceId,
+      agent: current.agent,
+      id: current.id,
+    };
     const controller = new AbortController();
     let timer: ReturnType<typeof setTimeout> | undefined;
     const load = async () => {
       try {
-        const res = await apiFetch(`/api/synthesis?id=${sessionId}`, {
+        const res = await apiFetch(synthesisRequestPath(identity), {
           signal: controller.signal,
         });
         if (!res.ok) return;
         const result = (await res.json()) as SynthesisResponse;
         if (result.synthesis == null && result.synthesisPending) {
-          pollDeadline.current ??= { sessionId, deadline: Date.now() + 2 * MINUTE };
+          pollDeadline.current ??= { key, deadline: Date.now() + 2 * MINUTE };
           if (Date.now() < pollDeadline.current.deadline) {
             timer = setTimeout(load, 3_000);
-            setLoaded({ sessionId, ...result });
+            setLoaded({ key, ...result });
           } else {
-            setLoaded({ sessionId, ...result, synthesisPending: false });
+            setLoaded({ key, ...result, synthesisPending: false });
           }
         } else {
           pollDeadline.current = null;
-          setLoaded({ sessionId, ...result });
+          setLoaded({ key, ...result });
         }
       } catch (error: unknown) {
         if (!controller.signal.aborted && error instanceof ApiAuthenticationError) {
@@ -123,10 +145,10 @@ function useSessionDetail(
       controller.abort();
       if (timer != null) clearTimeout(timer);
     };
-  }, [sessionId, sessionsVersion, synthesisSettingsKey]);
+  }, [key, sessionsVersion, synthesisSettingsKey]);
 
   if (session == null) return { detail: null, loadError };
-  if (loaded?.sessionId !== session.id) return { detail: session, loadError };
+  if (loaded?.key !== sessionKey(session)) return { detail: session, loadError };
   return {
     detail: {
       ...session,
@@ -228,9 +250,9 @@ function HeaderMeta({ detail }: { detail: SessionDetail }) {
     <div className="flex flex-col gap-2 pt-2">
       <div className="text-muted-foreground flex flex-wrap items-center justify-between gap-x-2 gap-y-1 font-mono text-xs">
         <div className="flex min-w-40 flex-1 items-center gap-1 overflow-hidden">
-          <Badge variant="secondary">{detail.repo ?? '—'}</Badge>
+          <Badge variant="secondary">{environmentFact(detail.repo)}</Badge>
           <span>/</span>
-          {detail.branch == null ? (
+          {detail.branch == null || detail.branch.trim() === '' ? (
             <Badge variant="secondary">—</Badge>
           ) : (
             <CopyableBadge
@@ -322,7 +344,7 @@ function LaunchError({ message }: { message: string | null }) {
 }
 
 function ResumeSessionButton({ detail }: { detail: SessionDetail }) {
-  const { launch, launchError } = useLaunchTerminal(detail.id);
+  const { launch, launchError } = useLaunchTerminal(detail);
 
   return (
     <div className="flex flex-col gap-1">
@@ -344,7 +366,7 @@ function StartNewSessionButton({
   brief: string;
   onCopy: () => void;
 }) {
-  const { launch, launchError } = useLaunchTerminal(detail.id);
+  const { launch, launchError } = useLaunchTerminal(detail);
 
   const startNewSession = () => {
     onCopy();
@@ -700,7 +722,7 @@ function FilesChangedList({
   onSelectFile,
 }: {
   detail: SessionDetail;
-  onSelectFile: (path: string) => void;
+  onSelectFile: ((path: string) => void) | null;
 }) {
   if (detail.fileEdits.length === 0) return null;
   const newFiles = detail.fileEdits.filter((fileEdit) => fileEdit.isNew).length;
@@ -710,19 +732,30 @@ function FilesChangedList({
       <div className="rounded-sm border p-2">
         {detail.fileEdits.map((fileEdit) => (
           <div key={fileEdit.path} className="flex items-center justify-between gap-2 py-1 font-mono text-xs">
-            <button
-              type="button"
-              title={fileEdit.path}
-              className={cn(
-                'text-muted-foreground min-w-0 cursor-pointer truncate text-left hover:underline',
-                {
+            {onSelectFile == null ? (
+              <span
+                title={fileEdit.path}
+                className={cn('text-muted-foreground min-w-0 truncate text-left', {
                   'text-success-fg': fileEdit.isNew,
-                },
-              )}
-              onClick={() => onSelectFile(fileEdit.path)}
-            >
-              {fileEdit.path.split('/').pop()}
-            </button>
+                })}
+              >
+                {fileEdit.path.split('/').pop()}
+              </span>
+            ) : (
+              <button
+                type="button"
+                title={fileEdit.path}
+                className={cn(
+                  'text-muted-foreground min-w-0 cursor-pointer truncate text-left hover:underline',
+                  {
+                    'text-success-fg': fileEdit.isNew,
+                  },
+                )}
+                onClick={() => onSelectFile(fileEdit.path)}
+              >
+                {fileEdit.path.split('/').pop()}
+              </button>
+            )}
             <span className="whitespace-nowrap">
               <span className="text-success-fg">+{fileEdit.adds}</span>{' '}
               <span className="text-destructive">−{fileEdit.dels}</span>{' '}
@@ -809,7 +842,7 @@ function InspectorBody({
   onSelectFile,
 }: {
   detail: SessionDetail;
-  onSelectFile: (path: string) => void;
+  onSelectFile: ((path: string) => void) | null;
 }) {
   // scroll on the outer div, layout on the inner one — flex children of a
   // scroll container shrink to fit instead of overflowing, which collapses
@@ -831,7 +864,8 @@ function InspectorBody({
 
 function InspectorFooter({ detail }: { detail: SessionDetail }) {
   const [previewOpen, setPreviewOpen] = useState(false);
-  const showTeamPreview = teamPreviewEnabled(window.location.search) && !detail.repoLocalOnly;
+  const showTeamPreview =
+    isLocalSession(detail) && teamPreviewEnabled(window.location.search) && !detail.repoLocalOnly;
 
   return (
     <SheetFooter className="bg-muted flex-row items-center justify-between gap-4 border-t">
@@ -881,6 +915,11 @@ export function SessionInspector({
     loadError: fileDiffError,
   } = useFileDiff(selectedDiff);
   const isOpen = session != null;
+  const openSessionKey = session == null ? null : sessionKey(session);
+
+  useEffect(() => {
+    setSelectedDiff(null);
+  }, [openSessionKey]);
 
   return (
     <Sheet
@@ -924,14 +963,24 @@ export function SessionInspector({
             )}
             <InspectorBody
               detail={detail}
-              onSelectFile={(path) => setSelectedDiff({ sessionId: detail.id, path })}
+              onSelectFile={
+                isLocalSession(detail)
+                  ? (path) =>
+                      setSelectedDiff({
+                        sourceId: detail.sourceId,
+                        agent: detail.agent,
+                        sessionId: detail.id,
+                        path,
+                      })
+                  : null
+              }
             />
             <InspectorFooter detail={detail} />
           </>
         )}
       </SheetContent>
       <Sheet
-        open={filePanelOpen(selectedDiff, detail?.id ?? '')}
+        open={filePanelOpen(selectedDiff, detail)}
         onOpenChange={(open) => {
           if (!open) setSelectedDiff(null);
         }}

--- a/frontend/src/pages/coslash/components/SessionSortDropdownMenu.tsx
+++ b/frontend/src/pages/coslash/components/SessionSortDropdownMenu.tsx
@@ -9,7 +9,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { assertOneOf } from '@/pages/coslash/lib/narrow';
-import { getStatus, getTotalTokens, STATUS_ORDER, type Session } from '@/pages/coslash/lib/session';
+import { boardStatusKey, getTotalTokens, STATUS_ORDER, type Session } from '@/pages/coslash/lib/session';
 
 export const SortKey = {
   Recency: 'recency',
@@ -35,7 +35,7 @@ function sortValue(session: Session, key: SortKey): number {
     case SortKey.Recency:
       return session.mtime;
     case SortKey.Status:
-      return STATUS_ORDER.length - STATUS_ORDER.indexOf(getStatus(session.status));
+      return STATUS_ORDER.length - STATUS_ORDER.indexOf(boardStatusKey(session));
     case SortKey.Value:
       return session.cost;
     case SortKey.Tokens:
@@ -47,6 +47,8 @@ function sortValue(session: Session, key: SortKey): number {
 
 export function sortSessions(sessions: Session[], key: SortKey, dir: SortDir): Session[] {
   return [...sessions].sort((a, b) => {
+    // Stale/limited/incomplete cards always sort after current cards.
+    if (a.displayStale !== b.displayStale) return a.displayStale ? 1 : -1;
     const diff = sortValue(a, key) - sortValue(b, key);
     return dir === 'desc' ? -diff : diff;
   });

--- a/frontend/src/pages/coslash/components/SettingsDialog.tsx
+++ b/frontend/src/pages/coslash/components/SettingsDialog.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { setTheme } from '@/lib/theme';
 import { cn } from '@/lib/utils';
+import { MachinesSettingsSection } from '@/pages/coslash/components/MachinesSettingsSection';
 import {
   availableSynthesisBackends,
   initialSettingsDraft,
@@ -469,6 +470,27 @@ export function SettingsDialog({
                     )}
                   </div>
                 </div>
+              )}
+
+              {showFullSettings && (
+                <MachinesSettingsSection
+                  remote={draft.remote}
+                  installationGuidePath={response.options.remoteInstallationGuidePath}
+                  onChange={(remote) => {
+                    if (remote == null) {
+                      const { remote: _removed, ...rest } = draft;
+                      setDraft({ ...rest, remote: null });
+                      return;
+                    }
+                    // Blank alias with no saved host stays omitted so local-only settings stay unchanged.
+                    if (!remote.sshAlias.trim() && draft.remote == null) {
+                      const { remote: _removed, ...rest } = draft;
+                      setDraft(rest);
+                      return;
+                    }
+                    setDraft({ ...draft, remote: { ...remote, sshAlias: remote.sshAlias.trim() } });
+                  }}
+                />
               )}
 
               {saveError && (

--- a/frontend/src/pages/coslash/components/SnapshotPreviewDialog.tsx
+++ b/frontend/src/pages/coslash/components/SnapshotPreviewDialog.tsx
@@ -144,7 +144,7 @@ export function SnapshotPreviewDialog({
     }
     const controller = new AbortController();
     setLoad({ status: 'loading' });
-    apiFetch(previewRequestPath(detail.id, detail.mtime), { signal: controller.signal })
+    apiFetch(previewRequestPath(detail, detail.mtime), { signal: controller.signal })
       .then((response) => {
         if (!response.ok) throw new Error(`Preview request failed (${response.status})`);
         return response.json() as Promise<unknown>;
@@ -159,7 +159,7 @@ export function SnapshotPreviewDialog({
         }
       });
     return () => controller.abort();
-  }, [detail.id, detail.mtime, open]);
+  }, [detail, open]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/frontend/src/pages/coslash/features/sharing/ShareToHubDialog.tsx
+++ b/frontend/src/pages/coslash/features/sharing/ShareToHubDialog.tsx
@@ -264,7 +264,7 @@ export function ShareToHubDialog({
           if (existing && consentStillCurrent(existing.item, session, existing.preview, destination)) {
             return existing;
           }
-          const response = await apiFetch(previewRequestPath(session.id, session.mtime));
+          const response = await apiFetch(previewRequestPath(session, session.mtime));
           if (!response.ok) throw new Error(`Preview request failed (${response.status}).`);
           const value: unknown = await response.json();
           if (!isSnapshotPreview(value)) throw new Error('Preview response is outside snapshot-preview/v1.');

--- a/frontend/src/pages/coslash/features/sharing/model.test.ts
+++ b/frontend/src/pages/coslash/features/sharing/model.test.ts
@@ -7,6 +7,7 @@ import {
   filterShareCandidates,
   hubRouteURL,
   localSessionId,
+  localShareCandidates,
   planShareRetry,
   primarySuccessRoute,
   reconcileVisibleSelection,
@@ -29,6 +30,10 @@ const destination: ShareDestination = {
 
 function session(id: string, repo: string, mtime: number): Session {
   return {
+    sourceId: 'local',
+    sourceLabel: 'This Mac',
+    eligibleForAggregates: true,
+    displayStale: false,
     agent: 'codex',
     id,
     name: `Session ${id}`,
@@ -84,6 +89,17 @@ function preview(sourceRevision: number, hash = `sha256:${'a'.repeat(64)}`): Sna
     snapshot,
   };
 }
+
+describe('localShareCandidates', () => {
+  it('excludes remote sessions before agent:id Hub keying', () => {
+    const local = { session: session('local-1', 'coslash', 10), previouslyShared: false };
+    const remote = {
+      session: { ...session('remote-1', 'coslash', 10), sourceId: 'r_0123456789abcdef', sourceLabel: 'gpu' },
+      previouslyShared: false,
+    };
+    expect(localShareCandidates([local, remote])).toEqual([local]);
+  });
+});
 
 describe('hub-share/v1 public consumer', () => {
   const now = Date.UTC(2026, 7, 18);

--- a/frontend/src/pages/coslash/features/sharing/model.ts
+++ b/frontend/src/pages/coslash/features/sharing/model.ts
@@ -1,5 +1,5 @@
 import { canonicalUploadBytes, type SnapshotPreview } from '@/pages/coslash/lib/preview';
-import type { Session } from '@/pages/coslash/lib/session';
+import { isLocalSession, type Session } from '@/pages/coslash/lib/session';
 
 // C4 contract; provider fixtures live in coslash-server/testdata/hub-share-v1.
 export const HUB_SHARE_VERSION = 'hub-share/v1' as const;
@@ -183,6 +183,11 @@ export const RETRY_RULES: Record<
 
 export function localSessionId(session: Pick<Session, 'agent' | 'id'>): string {
   return `${session.agent}:${session.id}`;
+}
+
+/** Hub candidates stay local-only before the existing agent:id sharing key. */
+export function localShareCandidates(candidates: ShareCandidate[]): ShareCandidate[] {
+  return candidates.filter(({ session }) => isLocalSession(session));
 }
 
 export function filterShareCandidates(

--- a/frontend/src/pages/coslash/hooks/use-launch-terminal.ts
+++ b/frontend/src/pages/coslash/hooks/use-launch-terminal.ts
@@ -1,25 +1,35 @@
 import { useState } from 'react';
-import { apiFetch } from '@/pages/coslash/lib/api';
+import { apiFetch, readApiError } from '@/pages/coslash/lib/api';
+import type { SessionIdentity } from '@/pages/coslash/lib/session';
 
 export type LaunchMode = 'resume' | 'new';
 
-async function launchTerminal(sessionId: string, mode: LaunchMode, handoff?: string): Promise<void> {
-  const response = await apiFetch(`/api/launch?id=${sessionId}&mode=${mode}`, {
+export function launchRequestPath(session: SessionIdentity, mode: LaunchMode): string {
+  return `/api/launch?${new URLSearchParams({
+    source: session.sourceId,
+    agent: session.agent,
+    id: session.id,
+    mode,
+  })}`;
+}
+
+async function launchTerminal(session: SessionIdentity, mode: LaunchMode, handoff?: string): Promise<void> {
+  const response = await apiFetch(launchRequestPath(session, mode), {
     method: 'POST',
     body: handoff,
   });
   if (!response.ok) {
-    const reason = (await response.text()).trim();
-    throw new Error(reason || `Launch failed (${response.status})`);
+    const apiError = await readApiError(response);
+    throw new Error(apiError?.error || `Launch failed (${response.status})`);
   }
 }
 
-export function useLaunchTerminal(sessionId: string) {
+export function useLaunchTerminal(session: SessionIdentity) {
   const [launchError, setLaunchError] = useState<string | null>(null);
 
   const launch = (mode: LaunchMode, handoff?: string) => {
     setLaunchError(null);
-    launchTerminal(sessionId, mode, handoff).catch((error: unknown) => {
+    launchTerminal(session, mode, handoff).catch((error: unknown) => {
       setLaunchError(error instanceof Error ? error.message : String(error));
     });
   };

--- a/frontend/src/pages/coslash/hooks/use-sessions.test.ts
+++ b/frontend/src/pages/coslash/hooks/use-sessions.test.ts
@@ -1,9 +1,18 @@
 import { describe, expect, it } from 'vitest';
-import { decodeSessionsResponse } from '@/pages/coslash/hooks/use-sessions';
-import type { Session } from '@/pages/coslash/lib/session';
+import {
+  decodeSessionsResponse,
+  diffRequestPath,
+  sessionsRequestPath,
+  synthesisRequestPath,
+} from '@/pages/coslash/hooks/use-sessions';
+import { LOCAL_SOURCE_ID, type Session } from '@/pages/coslash/lib/session';
 
-function sampleSession(id: string): Session {
+function sampleSession(id: string, sourceId = LOCAL_SOURCE_ID): Session {
   return {
+    sourceId,
+    sourceLabel: sourceId === LOCAL_SOURCE_ID ? 'This Mac' : 'gpu-server',
+    eligibleForAggregates: true,
+    displayStale: false,
     agent: 'codex',
     id,
     name: null,
@@ -44,23 +53,62 @@ function sampleSession(id: string): Session {
 }
 
 describe('decodeSessionsResponse', () => {
-  it('accepts the legacy bare array', () => {
-    const sessions = [sampleSession('a')];
-    expect(decodeSessionsResponse(sessions)).toEqual(sessions);
+  it('accepts the legacy bare array with local source defaults', () => {
+    const {
+      sourceId: _s,
+      sourceLabel: _l,
+      eligibleForAggregates: _e,
+      displayStale: _d,
+      ...legacy
+    } = sampleSession('a');
+    expect(decodeSessionsResponse([legacy])).toEqual({
+      sessions: [sampleSession('a')],
+      machines: [],
+    });
   });
 
-  it('accepts the source-aware envelope', () => {
-    const sessions = [sampleSession('a'), sampleSession('b')];
-    expect(
-      decodeSessionsResponse({
-        sessions,
-        machines: [{ sourceId: 'local', label: 'This Mac', state: 'ok', complete: true }],
-      }),
-    ).toEqual(sessions);
+  it('accepts the source-aware envelope and preserves machines', () => {
+    const sessions = [sampleSession('a'), sampleSession('b', 'r_0123456789abcdef')];
+    const machines = [{ sourceId: 'local', label: 'This Mac', state: 'ok', complete: true }];
+    expect(decodeSessionsResponse({ sessions, machines })).toEqual({ sessions, machines });
   });
 
-  it('rejects invalid bodies', () => {
+  it('rejects invalid bodies and unknown machine enums', () => {
     expect(() => decodeSessionsResponse({ machines: [] })).toThrow('Invalid sessions response');
     expect(() => decodeSessionsResponse(null)).toThrow('Invalid sessions response');
+    expect(() =>
+      decodeSessionsResponse({
+        sessions: [],
+        machines: [{ sourceId: 'local', label: 'This Mac', state: 'nope', complete: true }],
+      }),
+    ).toThrow(/Expected one of/);
+  });
+});
+
+describe('sessionsRequestPath', () => {
+  it('sends displayed remoteSince while Hub omits local since', () => {
+    expect(sessionsRequestPath({ localSince: null, remoteSince: 1_700_000_000_000 })).toBe(
+      '/api/sessions?remoteSince=1700000000000',
+    );
+  });
+
+  it('sends matching cutoffs for ordinary board refresh', () => {
+    expect(sessionsRequestPath({ localSince: 10, remoteSince: 10 })).toBe(
+      '/api/sessions?since=10&remoteSince=10',
+    );
+  });
+});
+
+describe('local-only request builders', () => {
+  it('refuses remote diff and synthesis construction', () => {
+    const remote = {
+      sourceId: 'r_0123456789abcdef',
+      agent: 'codex',
+      id: 'abc',
+      sessionId: 'abc',
+      path: 'a.ts',
+    };
+    expect(() => diffRequestPath(remote)).toThrow('remote diff unsupported');
+    expect(() => synthesisRequestPath(remote)).toThrow('remote synthesis unsupported');
   });
 });

--- a/frontend/src/pages/coslash/hooks/use-sessions.ts
+++ b/frontend/src/pages/coslash/hooks/use-sessions.ts
@@ -1,13 +1,25 @@
 import { useEffect, useState } from 'react';
 import { ApiAuthenticationError, apiFetch } from '@/pages/coslash/lib/api';
-import type { Session } from '@/pages/coslash/lib/session';
+import { decodeMachineFacts, type MachineFact } from '@/pages/coslash/lib/machines';
+import {
+  isLocalSource,
+  withLocalSourceDefaults,
+  type Session,
+  type SessionIdentity,
+} from '@/pages/coslash/lib/session';
 import { MINUTE } from '@/pages/coslash/lib/time';
 import { timeWindowStart, type TimeWindow } from '@/pages/coslash/lib/time-window';
 
 // Background refresh keeps statuses and "ago" times current.
 const REFRESH_INTERVAL_MS = MINUTE;
 
-export type FileSelection = { sessionId: string; path: string };
+export type FileSelection = {
+  sourceId: string;
+  agent: string;
+  sessionId: string;
+  path: string;
+};
+
 export type FileChange = {
   kind: 'diff' | 'content';
   text: string;
@@ -16,22 +28,68 @@ export type FileChange = {
   deletions: number;
 };
 
-export function decodeSessionsResponse(body: unknown): Session[] {
+export type SessionsPayload = {
+  sessions: Session[];
+  machines: MachineFact[];
+};
+
+export type SessionsQuery = {
+  localWindow: TimeWindow;
+  remoteWindow: TimeWindow;
+};
+
+export function decodeSessionsResponse(body: unknown): SessionsPayload {
   if (Array.isArray(body)) {
-    return body as Session[];
+    return {
+      sessions: body.map((session) => withLocalSourceDefaults(session as Session)),
+      machines: [],
+    };
   }
-  if (
-    body != null &&
-    typeof body === 'object' &&
-    Array.isArray((body as { sessions?: unknown }).sessions)
-  ) {
-    return (body as { sessions: Session[] }).sessions;
+  if (body == null || typeof body !== 'object') {
+    throw new Error('Invalid sessions response');
   }
-  throw new Error('Invalid sessions response');
+  const sessions = (body as { sessions?: unknown }).sessions;
+  if (!Array.isArray(sessions)) {
+    throw new Error('Invalid sessions response');
+  }
+  const machinesRaw = (body as { machines?: unknown }).machines;
+  return {
+    sessions: sessions.map((session) => withLocalSourceDefaults(session as Session)),
+    machines: machinesRaw === undefined ? [] : decodeMachineFacts(machinesRaw),
+  };
+}
+
+/** Independent local/remote cutoffs; omit local `since` for Hub all-history without widening remote. */
+export function sessionsRequestPath(query: {
+  localSince: number | null;
+  remoteSince: number | null;
+}): string {
+  const params = new URLSearchParams();
+  if (query.localSince != null) params.set('since', String(query.localSince));
+  if (query.remoteSince != null) params.set('remoteSince', String(query.remoteSince));
+  const encoded = params.toString();
+  return encoded === '' ? '/api/sessions' : `/api/sessions?${encoded}`;
 }
 
 export function diffRequestPath(selection: FileSelection) {
+  if (!isLocalSource(selection.sourceId)) {
+    throw new Error('remote diff unsupported');
+  }
   return `/api/diff?${new URLSearchParams({ id: selection.sessionId, path: selection.path })}`;
+}
+
+export function synthesisRequestPath(session: SessionIdentity) {
+  if (!isLocalSource(session.sourceId)) {
+    throw new Error('remote synthesis unsupported');
+  }
+  return `/api/synthesis?${new URLSearchParams({ id: session.id })}`;
+}
+
+function sameFileSelection(
+  left: Pick<FileSelection, 'sourceId' | 'sessionId' | 'path'>,
+  right: Pick<FileSelection, 'sourceId' | 'sessionId' | 'path'>,
+): boolean {
+  return left.sourceId === right.sourceId && left.sessionId === right.sessionId && left.path === right.path;
 }
 
 export function useFileDiff(selection: FileSelection | null) {
@@ -41,6 +99,14 @@ export function useFileDiff(selection: FileSelection | null) {
 
   useEffect(() => {
     if (selection == null) return;
+    if (!isLocalSource(selection.sourceId)) {
+      setLoaded({
+        ...selection,
+        changes: null,
+        loadError: 'Remote file diffs are not available.',
+      });
+      return;
+    }
     const controller = new AbortController();
 
     apiFetch(diffRequestPath(selection), { signal: controller.signal })
@@ -64,8 +130,7 @@ export function useFileDiff(selection: FileSelection | null) {
     return () => controller.abort();
   }, [selection]);
 
-  const isCurrent =
-    selection != null && loaded?.sessionId === selection.sessionId && loaded.path === selection.path;
+  const isCurrent = selection != null && loaded != null && sameFileSelection(loaded, selection);
   return {
     changes: isCurrent ? loaded.changes : null,
     isLoading: selection != null && !isCurrent,
@@ -73,8 +138,9 @@ export function useFileDiff(selection: FileSelection | null) {
   };
 }
 
-export function useSessions(timeWindow: TimeWindow) {
+export function useSessions({ localWindow, remoteWindow }: SessionsQuery) {
   const [sessions, setSessions] = useState<Session[]>([]);
+  const [machines, setMachines] = useState<MachineFact[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [retryCount, setRetryCount] = useState(0);
@@ -88,10 +154,10 @@ export function useSessions(timeWindow: TimeWindow) {
         setIsLoading(true);
         setLoadError(null);
       }
-      const since = timeWindowStart(timeWindow);
-      const path = since == null
-        ? '/api/sessions'
-        : `/api/sessions?since=${since}&remoteSince=${since}`;
+      const path = sessionsRequestPath({
+        localSince: timeWindowStart(localWindow),
+        remoteSince: timeWindowStart(remoteWindow),
+      });
       apiFetch(path, { signal: controller.signal })
         .then((response) => {
           if (!response.ok) {
@@ -101,7 +167,9 @@ export function useSessions(timeWindow: TimeWindow) {
         })
         .then((body) => {
           if (controller.signal.aborted) return;
-          setSessions(decodeSessionsResponse(body));
+          const payload = decodeSessionsResponse(body);
+          setSessions(payload.sessions);
+          setMachines(payload.machines);
           setSessionsVersion((version) => version + 1);
           setIsLoading(false);
           setLoadError(null);
@@ -113,6 +181,7 @@ export function useSessions(timeWindow: TimeWindow) {
           // refresh fails. Authentication failures invalidate that private data.
           if (!background || authenticationFailed) {
             setSessions([]);
+            setMachines([]);
             setIsLoading(false);
             setLoadError(
               authenticationFailed ? error.message : 'CoSlash couldn’t load sessions from the API.',
@@ -128,7 +197,7 @@ export function useSessions(timeWindow: TimeWindow) {
       clearInterval(refresh);
       controller.abort();
     };
-  }, [retryCount, timeWindow]);
+  }, [localWindow, remoteWindow, retryCount]);
 
   const retrySessions = () => {
     setIsLoading(true);
@@ -138,6 +207,7 @@ export function useSessions(timeWindow: TimeWindow) {
 
   return {
     sessions,
+    machines,
     isLoading,
     loadError,
     sessionsVersion,

--- a/frontend/src/pages/coslash/hooks/use-settings.ts
+++ b/frontend/src/pages/coslash/hooks/use-settings.ts
@@ -1,6 +1,10 @@
 import { useEffect, useState } from 'react';
 import { apiFetch } from '@/pages/coslash/lib/api';
-import type { CoslashSettings, SettingsResponse } from '@/pages/coslash/lib/settings';
+import {
+  decodeSettingsResponse,
+  type CoslashSettings,
+  type SettingsResponse,
+} from '@/pages/coslash/lib/settings';
 
 async function readError(response: Response): Promise<string> {
   const message = (await response.text()).trim();
@@ -19,7 +23,7 @@ export function useSettings() {
     apiFetch('/api/settings', { signal: controller.signal })
       .then(async (result) => {
         if (!result.ok) throw new Error(await readError(result));
-        return result.json() as Promise<SettingsResponse>;
+        return decodeSettingsResponse(await result.json());
       })
       .then((loaded) => {
         if (controller.signal.aborted) return;
@@ -44,7 +48,7 @@ export function useSettings() {
         body: JSON.stringify(settings),
       });
       if (!result.ok) throw new Error(await readError(result));
-      setResponse((await result.json()) as SettingsResponse);
+      setResponse(decodeSettingsResponse(await result.json()));
       setIsSaving(false);
       return true;
     } catch (error: unknown) {

--- a/frontend/src/pages/coslash/lib/api.ts
+++ b/frontend/src/pages/coslash/lib/api.ts
@@ -9,6 +9,32 @@ export class ApiAuthenticationError extends Error {
   }
 }
 
+export type ApiErrorBody = {
+  code: string;
+  error: string;
+};
+
+export function decodeApiError(value: unknown): ApiErrorBody {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Invalid API error');
+  }
+  const raw = value as Record<string, unknown>;
+  if (typeof raw.code !== 'string' || typeof raw.error !== 'string') {
+    throw new Error('Invalid API error');
+  }
+  return { code: raw.code, error: raw.error };
+}
+
+export async function readApiError(response: Response): Promise<ApiErrorBody | null> {
+  const text = (await response.text()).trim();
+  if (text === '') return null;
+  try {
+    return decodeApiError(JSON.parse(text) as unknown);
+  } catch {
+    return null;
+  }
+}
+
 function loadToken(): string | null {
   const fragment = new URLSearchParams(window.location.hash.slice(1));
   const suppliedToken = fragment.get('t');

--- a/frontend/src/pages/coslash/lib/diagnostics.test.ts
+++ b/frontend/src/pages/coslash/lib/diagnostics.test.ts
@@ -68,9 +68,19 @@ describe('diagnostics helpers', () => {
     value.sources[0].skipped = [
       { path: '~/.claude/projects/-Users-alice-private-repo/session.jsonl', error: 'permission denied' },
     ];
+    value.remote = {
+      label: 'gpu-server',
+      state: 'stale',
+      complete: false,
+      nextRetryAtMs: 1_700_000_180_000,
+      error: 'connection failed',
+    };
     const output = formatDiagnosticsForCopy(value);
     expect(output).toContain('~/.claude/projects');
     expect(output).toContain('entries=4; sessions=3');
+    expect(output).toContain('Remote host:');
+    expect(output).toContain('alias=gpu-server');
+    expect(output).toContain('nextRetryAtMs=1700000180000');
     expect(output).not.toContain('-Users-alice-private-repo');
     expect(output).not.toContain('/Users/alice');
     expect(output).not.toContain('secret session name');

--- a/frontend/src/pages/coslash/lib/diagnostics.ts
+++ b/frontend/src/pages/coslash/lib/diagnostics.ts
@@ -22,6 +22,27 @@ export type DiagnosticSource = {
   cli: { name: string; found: boolean; path: string; version: string };
 };
 
+export type RemoteDiagnostics = {
+  sourceId?: string;
+  label?: string;
+  state: string;
+  complete: boolean;
+  reason?: string;
+  collectorVersion?: string;
+  schemaVersion?: string;
+  capabilities?: string[];
+  launchableAgents?: string[];
+  hostOs?: string;
+  hostArch?: string;
+  lastSuccessAtMs?: number;
+  coverageSinceMs?: number;
+  clockOffsetMs?: number;
+  roundTripMs?: number;
+  nextRetryAtMs?: number;
+  error?: string;
+  diagnosticStderr?: string;
+};
+
 export type Diagnostics = {
   version: string;
   generatedAt: number;
@@ -29,6 +50,7 @@ export type Diagnostics = {
   storage: { home: string; writable: boolean; error: string };
   synthesis: { enabled: boolean; model: string; cliFound: boolean; reason: string; error: string };
   sources: DiagnosticSource[];
+  remote?: RemoteDiagnostics;
   checks: DiagnosticsCheck[];
 };
 
@@ -57,6 +79,21 @@ export function formatDiagnosticsForCopy(snapshot: Diagnostics): string {
       `  CLI: found=${source.cli.found}; path=${source.cli.path || 'unknown'}; version=${source.cli.version || 'unknown'}`,
     );
     for (const skipped of source.skipped) lines.push(`  Skipped: ${skipped.error}`);
+  }
+  if (snapshot.remote) {
+    lines.push('', 'Remote host:');
+    lines.push(
+      `- alias=${snapshot.remote.label ?? 'unknown'}; state=${snapshot.remote.state}; complete=${snapshot.remote.complete}`,
+    );
+    if (snapshot.remote.collectorVersion || snapshot.remote.schemaVersion) {
+      lines.push(
+        `  collector=${snapshot.remote.collectorVersion || 'unknown'}; schema=${snapshot.remote.schemaVersion || 'unknown'}`,
+      );
+    }
+    if (snapshot.remote.nextRetryAtMs != null) {
+      lines.push(`  nextRetryAtMs=${snapshot.remote.nextRetryAtMs}`);
+    }
+    if (snapshot.remote.error) lines.push(`  error=${snapshot.remote.error}`);
   }
   lines.push('', 'Checks:');
   for (const check of snapshot.checks) {

--- a/frontend/src/pages/coslash/lib/handoff.test.ts
+++ b/frontend/src/pages/coslash/lib/handoff.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { launchRequestPath } from '@/pages/coslash/hooks/use-launch-terminal';
+import { decodeApiError } from '@/pages/coslash/lib/api';
+import { handoffBrief } from '@/pages/coslash/lib/handoff';
+import { remoteTestRequestInit } from '@/pages/coslash/lib/remote-api';
+import { LOCAL_SOURCE_ID, type SessionDetail } from '@/pages/coslash/lib/session';
+import { decodeRemoteHostSettings, decodeSettingsResponse } from '@/pages/coslash/lib/settings';
+
+function remoteDetail(): SessionDetail {
+  return {
+    sourceId: 'r_0123456789abcdef',
+    sourceLabel: 'gpu-server',
+    eligibleForAggregates: true,
+    displayStale: false,
+    agent: 'codex',
+    id: 'sess-1',
+    name: 'Remote work',
+    summary: 'Did the thing',
+    status: 'idle',
+    cwd: '',
+    branch: null,
+    repo: null,
+    repoLocalOnly: false,
+    files: 0,
+    durationMs: 60_000,
+    tokens: {},
+    cost: 0,
+    unpricedModels: [],
+    subagents: [],
+    mtime: 1,
+    entrypoint: null,
+    synthesis: null,
+    synthesisPending: false,
+    declaredGoal: null,
+    model: null,
+    contextTokens: null,
+    contextWindow: null,
+    turns: 2,
+    toolUses: 0,
+    errors: 0,
+    compactions: 0,
+    firstPrompt: 'Start',
+    commands: [],
+    commits: [],
+    prs: 0,
+    todos: [],
+    digest: [],
+    fileEdits: [],
+    git: null,
+    lastEditAt: null,
+  };
+}
+
+describe('handoffBrief', () => {
+  it('formats missing remote environment facts without literal undefined', () => {
+    const brief = handoffBrief(remoteDetail());
+    expect(brief).toContain('- Repository: —');
+    expect(brief).toContain('- Branch: —');
+    expect(brief).toContain('- Working directory: —');
+    expect(brief).not.toContain('undefined');
+  });
+});
+
+describe('launchRequestPath', () => {
+  it('includes the full source-aware key', () => {
+    expect(launchRequestPath({ sourceId: LOCAL_SOURCE_ID, agent: 'codex', id: 'abc' }, 'resume')).toBe(
+      '/api/launch?source=local&agent=codex&id=abc&mode=resume',
+    );
+    expect(launchRequestPath({ sourceId: 'r_0123456789abcdef', agent: 'claude', id: 'xyz' }, 'new')).toBe(
+      '/api/launch?source=r_0123456789abcdef&agent=claude&id=xyz&mode=new',
+    );
+  });
+});
+
+describe('settings and remote API decoders', () => {
+  it('decodes optional remote settings and guide path', () => {
+    expect(decodeRemoteHostSettings(null)).toBeNull();
+    expect(
+      decodeRemoteHostSettings({ id: 'r_0123456789abcdef', sshAlias: 'gpu-server', enabled: true }),
+    ).toEqual({ id: 'r_0123456789abcdef', sshAlias: 'gpu-server', enabled: true });
+
+    const decoded = decodeSettingsResponse({
+      settings: {
+        $schema: 'x',
+        version: 1,
+        synthesis: { enabled: false, backend: '', model: '' },
+        appearance: { theme: 'light' },
+        launch: { terminal: 'Terminal' },
+        remote: { id: 'r_0123456789abcdef', sshAlias: 'gpu-server', enabled: true },
+      },
+      persisted: true,
+      valid: true,
+      options: {
+        synthesisBackends: [],
+        terminals: [],
+        remoteInstallationGuidePath: 'docs/remote-host-installation.md',
+      },
+    });
+    expect(decoded.settings.remote?.sshAlias).toBe('gpu-server');
+    expect(decoded.options.remoteInstallationGuidePath).toBe('docs/remote-host-installation.md');
+  });
+
+  it('decodes stable API errors and builds remote test requests', () => {
+    expect(decodeApiError({ code: 'remote_disabled', error: 'remote disabled' })).toEqual({
+      code: 'remote_disabled',
+      error: 'remote disabled',
+    });
+    expect(remoteTestRequestInit('gpu-server')).toEqual({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sshAlias: 'gpu-server' }),
+    });
+  });
+});

--- a/frontend/src/pages/coslash/lib/handoff.ts
+++ b/frontend/src/pages/coslash/lib/handoff.ts
@@ -1,5 +1,6 @@
 import { formatDuration, formatEstimatedCost, formatTokens } from '@/pages/coslash/lib/format';
 import {
+  environmentFact,
   getTotalTokens,
   getVendor,
   goalSourceLabel,
@@ -54,9 +55,9 @@ export function handoffBrief(detail: SessionDetail): string {
     '',
     '## Environment',
     `- Vendor: ${getVendor(detail.agent).label}`,
-    `- Repository: ${detail.repo ?? '—'}`,
-    `- Branch: ${detail.branch ?? '—'}`,
-    `- Working directory: ${detail.cwd}`,
+    `- Repository: ${environmentFact(detail.repo)}`,
+    `- Branch: ${environmentFact(detail.branch)}`,
+    `- Working directory: ${environmentFact(detail.cwd)}`,
     `- Runtime: ${formatDuration(detail.durationMs)}`,
     `- Tokens: ${formatTokens(getTotalTokens(detail.tokens))}`,
     `- ${costLabel}: ${formatEstimatedCost(detail.cost)}`,

--- a/frontend/src/pages/coslash/lib/host-strip.test.ts
+++ b/frontend/src/pages/coslash/lib/host-strip.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from 'vitest';
+import { SortKey, sortSessions } from '@/pages/coslash/components/SessionSortDropdownMenu';
+import {
+  firstTimeSshHint,
+  formatTestConnectionResult,
+  hostStripModel,
+  hostStripVisible,
+  remoteConfigured,
+  remoteLaunchGate,
+  remoteMachine,
+} from '@/pages/coslash/lib/host-strip';
+import type { MachineFact } from '@/pages/coslash/lib/machines';
+import { formatRemoteDiagnosticsFacts } from '@/pages/coslash/lib/remote-diagnostics';
+import {
+  boardStatusKey,
+  displayStatusLabel,
+  LOCAL_SOURCE_ID,
+  sessionsForAggregates,
+  type Session,
+} from '@/pages/coslash/lib/session';
+
+function machine(overrides: Partial<MachineFact> = {}): MachineFact {
+  return {
+    sourceId: 'r_0123456789abcdef',
+    label: 'gpu-server',
+    state: 'ok',
+    complete: true,
+    ...overrides,
+  };
+}
+
+function session(overrides: Partial<Session> & Pick<Session, 'id'>): Session {
+  return {
+    sourceId: LOCAL_SOURCE_ID,
+    sourceLabel: 'This Mac',
+    eligibleForAggregates: true,
+    displayStale: false,
+    agent: 'codex',
+    name: null,
+    summary: null,
+    status: 'busy',
+    cwd: '/tmp',
+    branch: null,
+    repo: null,
+    repoLocalOnly: false,
+    files: 0,
+    durationMs: 1,
+    cost: 1,
+    unpricedModels: [],
+    mtime: 200,
+    entrypoint: null,
+    model: null,
+    contextTokens: 0,
+    contextWindow: 0,
+    turns: 0,
+    toolUses: 0,
+    errors: 0,
+    tokens: {},
+    firstPrompt: null,
+    commands: [],
+    fileEdits: [],
+    commits: [],
+    todos: [],
+    prs: 0,
+    declaredGoal: null,
+    lastEditAt: 0,
+    synthesis: null,
+    synthesisPending: false,
+    subagents: [],
+    digest: [],
+    git: null,
+    compactions: 0,
+    ...overrides,
+  };
+}
+
+describe('host strip', () => {
+  it('hides for healthy and disabled monitoring', () => {
+    expect(hostStripVisible(machine({ state: 'ok' }))).toBe(false);
+    expect(hostStripVisible(machine({ state: 'disabled' }))).toBe(false);
+    expect(hostStripVisible(null)).toBe(false);
+  });
+
+  it('maps every unhealthy state to copy, role, and actions', () => {
+    const cases: Array<{
+      state: MachineFact['state'];
+      reason?: MachineFact['reason'];
+      role: 'status' | 'alert';
+      includes: string;
+      actions: string[];
+    }> = [
+      { state: 'connecting', role: 'status', includes: 'connecting…', actions: [] },
+      {
+        state: 'connecting',
+        reason: 'broader_history',
+        role: 'status',
+        includes: 'refreshing remote history',
+        actions: ['retry'],
+      },
+      {
+        state: 'limited',
+        reason: 'history_truncated',
+        role: 'alert',
+        includes: 'too large',
+        actions: ['retry', 'diagnostics'],
+      },
+      {
+        state: 'limited',
+        reason: 'refresh_timeout',
+        role: 'alert',
+        includes: 'took too long',
+        actions: ['retry', 'diagnostics'],
+      },
+      {
+        state: 'setup_required',
+        role: 'alert',
+        includes: '~/.local/bin/coslash',
+        actions: ['installation', 'retry'],
+      },
+      {
+        state: 'upgrade_required',
+        role: 'alert',
+        includes: 'needs an update',
+        actions: ['installation', 'retry'],
+      },
+      {
+        state: 'stale',
+        role: 'alert',
+        includes: 'unreachable',
+        actions: ['retry', 'diagnostics'],
+      },
+      {
+        state: 'error',
+        role: 'alert',
+        includes: 'could not load',
+        actions: ['retry', 'diagnostics'],
+      },
+    ];
+
+    for (const tc of cases) {
+      const model = hostStripModel(
+        machine({
+          state: tc.state,
+          reason: tc.reason,
+          lastSuccessAtMs: Date.now() - 6 * 60_000,
+        }),
+        { nowMs: Date.now() },
+      );
+      expect(model.role).toBe(tc.role);
+      expect(model.message).toContain(tc.includes);
+      expect(model.actions).toEqual(tc.actions);
+    }
+  });
+
+  it('disables retry while connecting or an in-flight manual retry', () => {
+    expect(hostStripModel(machine({ state: 'stale' }), { retryInFlight: true }).retryDisabled).toBe(true);
+    expect(hostStripModel(machine({ state: 'connecting' })).retryDisabled).toBe(true);
+    expect(hostStripModel(machine({ state: 'stale' })).retryDisabled).toBe(false);
+  });
+
+  it('detects configured remotes and launch gates from machine facts', () => {
+    const machines = [
+      { sourceId: LOCAL_SOURCE_ID, label: 'This Mac', state: 'ok' as const, complete: true },
+      machine({
+        capabilities: ['remote-session-view/v1', 'remote-launch/v1'],
+        launchableAgents: ['claude'],
+      }),
+    ];
+    expect(remoteConfigured(machines)).toBe(true);
+    expect(remoteMachine(machines)?.label).toBe('gpu-server');
+    expect(remoteLaunchGate(remoteMachine(machines), 'claude')).toEqual({ allowed: true });
+    expect(remoteLaunchGate(remoteMachine(machines), 'codex')).toEqual({
+      allowed: false,
+      reason: 'remote agent unavailable',
+    });
+    expect(remoteLaunchGate(machine({ capabilities: ['remote-session-view/v1'] }), 'claude')).toEqual({
+      allowed: false,
+      reason: 'remote upgrade required',
+    });
+  });
+
+  it('formats test results and first-time SSH hint without classifying stderr', () => {
+    expect(
+      formatTestConnectionResult(
+        machine({
+          state: 'ok',
+          collectorVersion: 'dev',
+          hostOs: 'linux',
+          hostArch: 'arm64',
+          launchableAgents: ['claude', 'codex'],
+        }),
+      ),
+    ).toContain('Resume and handoff ready');
+    expect(firstTimeSshHint('gpu-server')).toContain('ssh gpu-server');
+  });
+});
+
+describe('stale session display and aggregates', () => {
+  it('places stale cards inactive and labels last-seen status', () => {
+    expect(boardStatusKey({ status: 'busy', displayStale: true })).toBe('inactive');
+    expect(displayStatusLabel({ status: 'busy', displayStale: true, lastSeenStatus: 'busy' })).toBe(
+      'Last seen active',
+    );
+    expect(displayStatusLabel({ status: 'waiting', displayStale: true, lastSeenStatus: 'waiting' })).toBe(
+      'Last seen waiting',
+    );
+    expect(displayStatusLabel({ status: 'busy', displayStale: false })).toBe('Active');
+  });
+
+  it('excludes ineligible sessions from aggregates and sorts them after current cards', () => {
+    const current = session({ id: 'a', mtime: 200 });
+    const stale = session({
+      id: 'b',
+      mtime: 300,
+      displayStale: true,
+      eligibleForAggregates: false,
+      sourceId: 'r_0123456789abcdef',
+      sourceLabel: 'gpu-server',
+    });
+    expect(sessionsForAggregates([current, stale])).toEqual([current]);
+    expect(sortSessions([stale, current], SortKey.Recency, 'desc').map((s) => s.id)).toEqual(['a', 'b']);
+  });
+});
+
+describe('remote diagnostics facts', () => {
+  it('includes alias, retry timing, and bounded error without paths', () => {
+    const lines = formatRemoteDiagnosticsFacts(
+      {
+        label: 'gpu-server',
+        state: 'stale',
+        complete: false,
+        collectorVersion: 'dev',
+        hostOs: 'linux',
+        hostArch: 'arm64',
+        lastSuccessAtMs: 1_700_000_000_000,
+        coverageSinceMs: 1_699_000_000_000,
+        roundTripMs: 420,
+        nextRetryAtMs: Date.now() + 10 * 60_000,
+        error: 'connection failed',
+      },
+      { sessionCount: 3, nowMs: Date.now() },
+    );
+    expect(lines[0]).toContain('gpu-server');
+    expect(lines.some((line) => line.includes('3 sessions'))).toBe(true);
+    expect(lines.some((line) => line.includes('next automatic retry'))).toBe(true);
+    expect(lines.some((line) => line.includes('error: connection failed'))).toBe(true);
+    expect(lines.join('\n')).not.toContain('/home/');
+  });
+});

--- a/frontend/src/pages/coslash/lib/host-strip.ts
+++ b/frontend/src/pages/coslash/lib/host-strip.ts
@@ -1,0 +1,129 @@
+import type { MachineFact, MachineReason, MachineState } from '@/pages/coslash/lib/machines';
+import { LOCAL_SOURCE_ID } from '@/pages/coslash/lib/session';
+import { MINUTE } from '@/pages/coslash/lib/time';
+
+export type HostStripAction = 'retry' | 'diagnostics' | 'installation';
+
+export type HostStripModel = {
+  role: 'status' | 'alert';
+  message: string;
+  actions: HostStripAction[];
+  retryDisabled: boolean;
+  tone: 'warning' | 'danger';
+};
+
+const REMOTE_LAUNCH = 'remote-launch/v1';
+
+export function remoteMachine(machines: readonly MachineFact[]): MachineFact | null {
+  return machines.find((machine) => machine.sourceId !== LOCAL_SOURCE_ID) ?? null;
+}
+
+export function remoteConfigured(machines: readonly MachineFact[]): boolean {
+  return remoteMachine(machines) != null;
+}
+
+export function hostStripVisible(machine: MachineFact | null): boolean {
+  if (machine == null) return false;
+  return machine.state !== 'ok' && machine.state !== 'disabled';
+}
+
+function snapshotAgeLabel(lastSuccessAtMs: number | undefined, nowMs: number): string {
+  if (lastSuccessAtMs == null) return 'a previous snapshot';
+  const mins = Math.max(1, Math.floor((nowMs - lastSuccessAtMs) / MINUTE));
+  return `a snapshot from ${mins}m ago`;
+}
+
+function stripMessage(machine: MachineFact, nowMs: number): string {
+  const label = machine.label;
+  switch (machine.state) {
+    case 'connecting':
+      if (machine.reason === 'broader_history') {
+        return `${label} · refreshing remote history · showing the previous snapshot`;
+      }
+      return `${label} · connecting…`;
+    case 'limited':
+      if (machine.reason === 'refresh_timeout') {
+        return `${label} · remote history took too long to refresh`;
+      }
+      return `${label} · remote history is too large · showing the newest sessions`;
+    case 'setup_required':
+      return `${label} · collector not found at ~/.local/bin/coslash`;
+    case 'upgrade_required':
+      return `${label} · remote collector needs an update`;
+    case 'stale':
+      return `${label} · unreachable · showing ${snapshotAgeLabel(machine.lastSuccessAtMs, nowMs)}`;
+    case 'error':
+      return `${label} · could not load remote sessions`;
+    default:
+      return `${label} · remote host needs attention`;
+  }
+}
+
+function stripActions(state: MachineState, reason: MachineReason | undefined): HostStripAction[] {
+  switch (state) {
+    case 'connecting':
+      return reason === 'broader_history' ? ['retry'] : [];
+    case 'limited':
+    case 'stale':
+    case 'error':
+      return ['retry', 'diagnostics'];
+    case 'setup_required':
+    case 'upgrade_required':
+      return ['installation', 'retry'];
+    default:
+      return ['retry'];
+  }
+}
+
+export function hostStripModel(
+  machine: MachineFact,
+  options: { nowMs?: number; retryInFlight?: boolean } = {},
+): HostStripModel {
+  const nowMs = options.nowMs ?? Date.now();
+  const retryInFlight = options.retryInFlight === true || machine.state === 'connecting';
+  return {
+    role: machine.state === 'connecting' ? 'status' : 'alert',
+    message: stripMessage(machine, nowMs),
+    actions: stripActions(machine.state, machine.reason),
+    retryDisabled: retryInFlight,
+    tone: machine.state === 'error' || machine.state === 'stale' ? 'danger' : 'warning',
+  };
+}
+
+export type RemoteLaunchGate = { allowed: true } | { allowed: false; reason: string };
+
+export function remoteLaunchGate(machine: MachineFact | null, agent: string): RemoteLaunchGate {
+  if (machine == null || machine.state === 'disabled') {
+    return { allowed: false, reason: 'remote disabled' };
+  }
+  if (!(machine.capabilities ?? []).includes(REMOTE_LAUNCH)) {
+    return { allowed: false, reason: 'remote upgrade required' };
+  }
+  if (!(machine.launchableAgents ?? []).includes(agent)) {
+    return { allowed: false, reason: 'remote agent unavailable' };
+  }
+  return { allowed: true };
+}
+
+export function formatTestConnectionResult(machine: MachineFact): string {
+  const platform =
+    machine.hostOs != null && machine.hostArch != null ? `${machine.hostOs}/${machine.hostArch}` : null;
+  const collector = machine.collectorVersion ? `collector ${machine.collectorVersion}` : null;
+  if (machine.state === 'ok') {
+    const launchable = (machine.launchableAgents ?? []).length > 0;
+    const parts = ['Connected', collector, platform].filter(Boolean);
+    return `${parts.join(' · ')}${launchable ? ' · Resume and handoff ready' : ''}`;
+  }
+  if (machine.state === 'setup_required') {
+    return `${machine.label} · collector not found at ~/.local/bin/coslash`;
+  }
+  if (machine.state === 'upgrade_required') {
+    return `${machine.label} · remote collector needs an update`;
+  }
+  if (machine.error) return `${machine.label} · ${machine.error}`;
+  return `${machine.label} · ${machine.state.replaceAll('_', ' ')}`;
+}
+
+export function firstTimeSshHint(alias: string): string {
+  return `If this is the first connection, run ssh ${alias} once in a terminal to accept the host key and authenticate.`;
+}

--- a/frontend/src/pages/coslash/lib/machines.ts
+++ b/frontend/src/pages/coslash/lib/machines.ts
@@ -1,0 +1,112 @@
+import { assertOneOf } from '@/pages/coslash/lib/narrow';
+
+export const MACHINE_STATES = [
+  'ok',
+  'connecting',
+  'limited',
+  'setup_required',
+  'upgrade_required',
+  'stale',
+  'error',
+  'disabled',
+] as const;
+
+export type MachineState = (typeof MACHINE_STATES)[number];
+
+export const MACHINE_REASONS = [
+  'initial_refresh',
+  'broader_history',
+  'history_truncated',
+  'refresh_timeout',
+  'collector_missing',
+  'collector_outdated',
+  'connection_failed',
+  'collector_failed',
+  'invalid_remote_transport',
+  'disabled',
+] as const;
+
+export type MachineReason = (typeof MACHINE_REASONS)[number];
+
+export type MachineFact = {
+  sourceId: string;
+  label: string;
+  state: MachineState;
+  complete: boolean;
+  reason?: MachineReason;
+  collectorVersion?: string;
+  schemaVersion?: string;
+  capabilities?: string[];
+  launchableAgents?: string[];
+  hostOs?: string;
+  hostArch?: string;
+  lastSuccessAtMs?: number;
+  coverageSinceMs?: number;
+  clockOffsetMs?: number;
+  roundTripMs?: number;
+  error?: string;
+};
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function optionalNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function optionalStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) return undefined;
+  return value;
+}
+
+export function decodeMachineFact(value: unknown): MachineFact {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Invalid machine fact');
+  }
+  const raw = value as Record<string, unknown>;
+  if (typeof raw.sourceId !== 'string' || typeof raw.label !== 'string') {
+    throw new Error('Invalid machine fact');
+  }
+  if (typeof raw.state !== 'string' || typeof raw.complete !== 'boolean') {
+    throw new Error('Invalid machine fact');
+  }
+  const fact: MachineFact = {
+    sourceId: raw.sourceId,
+    label: raw.label,
+    state: assertOneOf(raw.state, MACHINE_STATES),
+    complete: raw.complete,
+  };
+  if (raw.reason != null) {
+    if (typeof raw.reason !== 'string') throw new Error('Invalid machine fact');
+    fact.reason = assertOneOf(raw.reason, MACHINE_REASONS);
+  }
+  const collectorVersion = optionalString(raw.collectorVersion);
+  if (collectorVersion != null) fact.collectorVersion = collectorVersion;
+  const schemaVersion = optionalString(raw.schemaVersion);
+  if (schemaVersion != null) fact.schemaVersion = schemaVersion;
+  const capabilities = optionalStringArray(raw.capabilities);
+  if (capabilities != null) fact.capabilities = capabilities;
+  const launchableAgents = optionalStringArray(raw.launchableAgents);
+  if (launchableAgents != null) fact.launchableAgents = launchableAgents;
+  const hostOs = optionalString(raw.hostOs);
+  if (hostOs != null) fact.hostOs = hostOs;
+  const hostArch = optionalString(raw.hostArch);
+  if (hostArch != null) fact.hostArch = hostArch;
+  const lastSuccessAtMs = optionalNumber(raw.lastSuccessAtMs);
+  if (lastSuccessAtMs != null) fact.lastSuccessAtMs = lastSuccessAtMs;
+  const coverageSinceMs = optionalNumber(raw.coverageSinceMs);
+  if (coverageSinceMs != null) fact.coverageSinceMs = coverageSinceMs;
+  const clockOffsetMs = optionalNumber(raw.clockOffsetMs);
+  if (clockOffsetMs != null) fact.clockOffsetMs = clockOffsetMs;
+  const roundTripMs = optionalNumber(raw.roundTripMs);
+  if (roundTripMs != null) fact.roundTripMs = roundTripMs;
+  const error = optionalString(raw.error);
+  if (error != null) fact.error = error;
+  return fact;
+}
+
+export function decodeMachineFacts(value: unknown): MachineFact[] {
+  if (!Array.isArray(value)) throw new Error('Invalid machines list');
+  return value.map(decodeMachineFact);
+}

--- a/frontend/src/pages/coslash/lib/preview.test.ts
+++ b/frontend/src/pages/coslash/lib/preview.test.ts
@@ -88,7 +88,12 @@ describe('snapshot preview adapter', () => {
       { kind: 'truncation', path: '/session/firstPrompt', reason: 'text_budget' },
     ]);
     expect(frozenCostDisclosure(preview)).toBe('$0.00 frozen priced estimate; 1 unpriced model excluded');
-    expect(previewRequestPath('session/id', 42)).toBe('/api/share-preview?id=session%2Fid&revision=42');
+    expect(previewRequestPath({ sourceId: 'local', id: 'session/id' }, 42)).toBe(
+      '/api/share-preview?id=session%2Fid&revision=42',
+    );
+    expect(() => previewRequestPath({ sourceId: 'r_0123456789abcdef', id: 'session/id' }, 42)).toThrow(
+      'remote preview unsupported',
+    );
   });
 
   it('distinguishes a true zero from unpriced models', () => {

--- a/frontend/src/pages/coslash/lib/preview.ts
+++ b/frontend/src/pages/coslash/lib/preview.ts
@@ -1,3 +1,5 @@
+import { isLocalSource } from '@/pages/coslash/lib/session';
+
 export type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
 
 export type PreviewState = 'ready' | 'invalid' | 'unsupported_version' | 'stale_source' | 'oversized';
@@ -48,8 +50,11 @@ export function isSnapshotPreview(value: unknown): value is SnapshotPreview {
   );
 }
 
-export function previewRequestPath(id: string, revision: number): string {
-  return `/api/share-preview?${new URLSearchParams({ id, revision: String(revision) })}`;
+export function previewRequestPath(session: { sourceId: string; id: string }, revision: number): string {
+  if (!isLocalSource(session.sourceId)) {
+    throw new Error('remote preview unsupported');
+  }
+  return `/api/share-preview?${new URLSearchParams({ id: session.id, revision: String(revision) })}`;
 }
 
 export function teamPreviewEnabled(search: string): boolean {

--- a/frontend/src/pages/coslash/lib/remote-api.ts
+++ b/frontend/src/pages/coslash/lib/remote-api.ts
@@ -1,0 +1,29 @@
+import { apiFetch, decodeApiError, readApiError } from '@/pages/coslash/lib/api';
+import { decodeMachineFact, type MachineFact } from '@/pages/coslash/lib/machines';
+
+export function remoteTestRequestInit(sshAlias: string): RequestInit {
+  return {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ sshAlias }),
+  };
+}
+
+export async function testRemoteAlias(sshAlias: string): Promise<MachineFact> {
+  const response = await apiFetch('/api/remote/test', remoteTestRequestInit(sshAlias));
+  if (!response.ok) {
+    const apiError = await readApiError(response);
+    throw new Error(apiError?.error || `Remote test failed (${response.status})`);
+  }
+  return decodeMachineFact(await response.json());
+}
+
+export async function retryRemoteRefresh(): Promise<{ status: number; machine: MachineFact }> {
+  const response = await apiFetch('/api/remote/retry', { method: 'POST' });
+  const body: unknown = await response.json();
+  if (!response.ok) {
+    const apiError = decodeApiError(body);
+    throw Object.assign(new Error(apiError.error), { code: apiError.code, status: response.status });
+  }
+  return { status: response.status, machine: decodeMachineFact(body) };
+}

--- a/frontend/src/pages/coslash/lib/remote-diagnostics.ts
+++ b/frontend/src/pages/coslash/lib/remote-diagnostics.ts
@@ -1,0 +1,42 @@
+import type { RemoteDiagnostics } from '@/pages/coslash/lib/diagnostics';
+import { MINUTE } from '@/pages/coslash/lib/time';
+
+function formatNextRetry(nextRetryAtMs: number, nowMs: number): string {
+  const mins = Math.ceil((nextRetryAtMs - nowMs) / MINUTE);
+  if (mins <= 0) return 'now';
+  if (mins < 60) return `in ${mins}m`;
+  return `in ${Math.ceil(mins / 60)}h`;
+}
+
+export function formatRemoteDiagnosticsFacts(
+  remote: RemoteDiagnostics,
+  options: { sessionCount?: number; nowMs?: number } = {},
+): string[] {
+  const nowMs = options.nowMs ?? Date.now();
+  const lines: string[] = [];
+  const head = [remote.label ?? 'Remote host', remote.state];
+  if (remote.collectorVersion) head.push(`collector ${remote.collectorVersion}`);
+  if (remote.hostOs && remote.hostArch) head.push(`${remote.hostOs}/${remote.hostArch}`);
+  lines.push(head.join(' · '));
+
+  const counts: string[] = [];
+  if (options.sessionCount != null) counts.push(`${options.sessionCount} sessions`);
+  if (remote.coverageSinceMs != null) {
+    counts.push(`coverage since ${new Date(remote.coverageSinceMs).toISOString()}`);
+  }
+  if (counts.length > 0) lines.push(counts.join(' · '));
+
+  const timing: string[] = [];
+  if (remote.lastSuccessAtMs != null) {
+    timing.push(`last success ${new Date(remote.lastSuccessAtMs).toISOString()}`);
+  }
+  if (remote.roundTripMs != null) timing.push(`round trip ${remote.roundTripMs}ms`);
+  if (remote.nextRetryAtMs != null) {
+    timing.push(`next automatic retry ${formatNextRetry(remote.nextRetryAtMs, nowMs)}`);
+  }
+  if (timing.length > 0) lines.push(timing.join(' · '));
+
+  if (remote.error) lines.push(`error: ${remote.error}`);
+  if (remote.diagnosticStderr) lines.push(`stderr: ${remote.diagnosticStderr}`);
+  return lines;
+}

--- a/frontend/src/pages/coslash/lib/session.test.ts
+++ b/frontend/src/pages/coslash/lib/session.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { getSessionVendors, type Session } from '@/pages/coslash/lib/session';
+import { decodeMachineFact } from '@/pages/coslash/lib/machines';
+import {
+  environmentFact,
+  getSessionVendors,
+  LOCAL_SOURCE_ID,
+  sessionKey,
+  sessionsForAggregates,
+  withLocalSourceDefaults,
+  type Session,
+} from '@/pages/coslash/lib/session';
 
 describe('getSessionVendors', () => {
   it('returns only vendors represented by loaded sessions in display order', () => {
@@ -11,5 +20,76 @@ describe('getSessionVendors', () => {
     ] satisfies Pick<Session, 'agent'>[];
 
     expect(getSessionVendors(sessions)).toEqual(['claude', 'opencode']);
+  });
+});
+
+describe('sessionKey', () => {
+  it('keeps the same agent and id distinct across sources', () => {
+    expect(sessionKey({ sourceId: LOCAL_SOURCE_ID, agent: 'codex', id: 'abc' })).toBe('local:codex:abc');
+    expect(sessionKey({ sourceId: 'r_0123456789abcdef', agent: 'codex', id: 'abc' })).toBe(
+      'r_0123456789abcdef:codex:abc',
+    );
+  });
+});
+
+describe('withLocalSourceDefaults', () => {
+  it('fills omitted legacy source fields as local', () => {
+    expect(withLocalSourceDefaults({ agent: 'codex', id: 'abc' })).toEqual({
+      agent: 'codex',
+      id: 'abc',
+      sourceId: 'local',
+      sourceLabel: 'This Mac',
+      eligibleForAggregates: true,
+      displayStale: false,
+    });
+  });
+});
+
+describe('environmentFact', () => {
+  it('renders missing and blank values as an em dash', () => {
+    expect(environmentFact(null)).toBe('—');
+    expect(environmentFact(undefined)).toBe('—');
+    expect(environmentFact('')).toBe('—');
+    expect(environmentFact('  ')).toBe('—');
+    expect(environmentFact('/home/user/proj')).toBe('/home/user/proj');
+  });
+});
+
+describe('sessionsForAggregates', () => {
+  it('omits ineligible sessions from aggregate counts', () => {
+    expect(
+      sessionsForAggregates([
+        { eligibleForAggregates: true },
+        { eligibleForAggregates: false },
+        { eligibleForAggregates: true },
+      ]),
+    ).toEqual([{ eligibleForAggregates: true }, { eligibleForAggregates: true }]);
+  });
+});
+
+describe('decodeMachineFact', () => {
+  it('accepts a healthy remote machine fact', () => {
+    expect(
+      decodeMachineFact({
+        sourceId: 'r_0123456789abcdef',
+        label: 'gpu-server',
+        state: 'ok',
+        complete: true,
+        collectorVersion: 'dev',
+        schemaVersion: 'remote-session-view/v1',
+        capabilities: ['remote-session-view/v1', 'remote-launch/v1'],
+        launchableAgents: ['claude', 'codex'],
+      }),
+    ).toMatchObject({
+      sourceId: 'r_0123456789abcdef',
+      state: 'ok',
+      launchableAgents: ['claude', 'codex'],
+    });
+  });
+
+  it('rejects unknown machine states', () => {
+    expect(() =>
+      decodeMachineFact({ sourceId: 'local', label: 'This Mac', state: 'weird', complete: true }),
+    ).toThrow(/Expected one of/);
   });
 });

--- a/frontend/src/pages/coslash/lib/session.ts
+++ b/frontend/src/pages/coslash/lib/session.ts
@@ -31,7 +31,15 @@ export type Subagent = {
   cost: number;
 };
 
+export const LOCAL_SOURCE_ID = 'local';
+export const LOCAL_SOURCE_LABEL = 'This Mac';
+
 export type Session = {
+  sourceId: string;
+  sourceLabel: string;
+  eligibleForAggregates: boolean;
+  displayStale: boolean;
+  lastSeenStatus?: string;
   agent: string;
   id: string;
   name: string | null;
@@ -70,6 +78,49 @@ export type Session = {
   git: GitDrift | null;
   lastEditAt: number | null;
 };
+
+export type SessionIdentity = Pick<Session, 'sourceId' | 'agent' | 'id'>;
+
+export function sessionKey(session: SessionIdentity): string {
+  return `${session.sourceId}:${session.agent}:${session.id}`;
+}
+
+export function sameSession(a: SessionIdentity, b: SessionIdentity): boolean {
+  return a.sourceId === b.sourceId && a.agent === b.agent && a.id === b.id;
+}
+
+export function isLocalSource(sourceId: string): boolean {
+  return sourceId === LOCAL_SOURCE_ID;
+}
+
+export function isLocalSession(session: Pick<Session, 'sourceId'>): boolean {
+  return isLocalSource(session.sourceId);
+}
+
+export function sessionsForAggregates<T extends Pick<Session, 'eligibleForAggregates'>>(
+  sessions: readonly T[],
+): T[] {
+  return sessions.filter((session) => session.eligibleForAggregates);
+}
+
+/** Missing or blank remote env facts render as an em dash, never `undefined`. */
+export function environmentFact(value: string | null | undefined): string {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : '—';
+}
+
+export function withLocalSourceDefaults<T extends { agent: string; id: string }>(
+  session: T,
+): T & Pick<Session, 'sourceId' | 'sourceLabel' | 'eligibleForAggregates' | 'displayStale'> {
+  const record = session as T & Partial<Session>;
+  return {
+    ...session,
+    sourceId: record.sourceId ?? LOCAL_SOURCE_ID,
+    sourceLabel: record.sourceLabel ?? LOCAL_SOURCE_LABEL,
+    eligibleForAggregates: record.eligibleForAggregates ?? true,
+    displayStale: record.displayStale ?? false,
+  };
+}
 
 type FileEdit = {
   path: string;

--- a/frontend/src/pages/coslash/lib/session.ts
+++ b/frontend/src/pages/coslash/lib/session.ts
@@ -286,6 +286,22 @@ export function getStatus(status: string | null): StatusKey {
   return status !== null && status in STATUSES ? (status as StatusKey) : 'inactive';
 }
 
+/** Board column and live status for a card; stale/limited/incomplete sessions are inactive. */
+export function boardStatusKey(session: Pick<Session, 'status' | 'displayStale'>): StatusKey {
+  if (session.displayStale) return 'inactive';
+  return getStatus(session.status);
+}
+
+/** Badge label: live status, or "Last seen …" when the remote snapshot is stale/incomplete. */
+export function displayStatusLabel(
+  session: Pick<Session, 'status' | 'displayStale' | 'lastSeenStatus'>,
+): string {
+  if (!session.displayStale) return STATUSES[getStatus(session.status)].label;
+  const seen = getStatus(session.lastSeenStatus ?? session.status);
+  const label = STATUSES[seen].label.toLowerCase();
+  return `Last seen ${label}`;
+}
+
 export function sumTokens(
   tokens: Session['tokens'],
   key: Exclude<keyof Session['tokens'][string], 'cost'>,

--- a/frontend/src/pages/coslash/lib/settings.ts
+++ b/frontend/src/pages/coslash/lib/settings.ts
@@ -6,12 +6,19 @@ export type SynthesisSettings = {
   model: string;
 };
 
+export type RemoteHostSettings = {
+  id?: string;
+  sshAlias: string;
+  enabled: boolean;
+};
+
 export type CoslashSettings = {
   $schema: string;
   version: number;
   synthesis: SynthesisSettings;
   appearance: { theme: 'light' | 'dark' };
   launch: { terminal: string };
+  remote?: RemoteHostSettings | null;
 };
 
 export type ModelOption = {
@@ -41,8 +48,59 @@ export type SettingsResponse = {
   options: {
     synthesisBackends: BackendOption[];
     terminals: TerminalOption[];
+    remoteInstallationGuidePath: string;
   };
 };
+
+export function decodeRemoteHostSettings(value: unknown): RemoteHostSettings | null {
+  if (value == null) return null;
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Invalid remote settings');
+  }
+  const raw = value as Record<string, unknown>;
+  if (typeof raw.sshAlias !== 'string' || typeof raw.enabled !== 'boolean') {
+    throw new Error('Invalid remote settings');
+  }
+  const remote: RemoteHostSettings = {
+    sshAlias: raw.sshAlias,
+    enabled: raw.enabled,
+  };
+  if (raw.id != null) {
+    if (typeof raw.id !== 'string') throw new Error('Invalid remote settings');
+    remote.id = raw.id;
+  }
+  return remote;
+}
+
+export function decodeSettingsResponse(value: unknown): SettingsResponse {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Invalid settings response');
+  }
+  const raw = value as Record<string, unknown>;
+  if (raw.settings == null || typeof raw.settings !== 'object' || Array.isArray(raw.settings)) {
+    throw new Error('Invalid settings response');
+  }
+  if (raw.options == null || typeof raw.options !== 'object' || Array.isArray(raw.options)) {
+    throw new Error('Invalid settings response');
+  }
+  const settingsRaw = raw.settings as Record<string, unknown>;
+  const optionsRaw = raw.options as Record<string, unknown>;
+  if (typeof optionsRaw.remoteInstallationGuidePath !== 'string') {
+    throw new Error('Invalid settings response');
+  }
+  const response = value as SettingsResponse;
+  return {
+    ...response,
+    settings: {
+      ...response.settings,
+      remote: decodeRemoteHostSettings(settingsRaw.remote),
+    },
+    options: {
+      ...response.options,
+      remoteInstallationGuidePath: optionsRaw.remoteInstallationGuidePath,
+    },
+  };
+}
 
 export function availableSynthesisBackends(options: readonly BackendOption[]): BackendOption[] {
   return options.filter((option) => option.available);
@@ -70,6 +128,7 @@ export function initialSettingsDraft(response: SettingsResponse): CoslashSetting
     synthesis,
     appearance: { ...response.settings.appearance },
     launch: { ...response.settings.launch },
+    remote: response.settings.remote ? { ...response.settings.remote } : response.settings.remote,
   };
 }
 


### PR DESCRIPTION
## Context

Users need remote sessions to appear naturally beside local sessions, with honest health states and a documented Linux installation path.

## Changes

- Add source-aware session identity, machine badges, host health states, and Machines settings.
- Keep stale or incomplete sessions visible without including them in totals, and hide unsupported local-only actions.
- Package Linux AMD64 and ARM64 collectors with checksums, diagnostics, smoke coverage, and installation guidance.

## Test

- `npm run lint` — passed with existing Fast Refresh warnings
- `npm test` — 60 passed
- `npm run format:check` — passed
- `npm run build` — passed with Node 24.4.1
- `make dist` — passed for Darwin and Linux AMD64/ARM64

### Screenshots

- [ ] Board with local and remote sessions
- [ ] Unhealthy-host status strip
- [ ] Settings → Machines
- [ ] Remote session inspector

## Stack

Review slice 3 of 4. Previous: https://github.com/centauri-ai/coslash/pull/111. Next: https://github.com/centauri-ai/coslash/pull/113. Umbrella: https://github.com/centauri-ai/coslash/pull/114.
