### PR TITLE
Document Mac-only SSH monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,11 @@ coSlash needs at least one local agent session to read. If it finds none, it say
 
 In **Settings → Machines**, add one alias from your Mac's existing OpenSSH
 configuration. coSlash runs the system `ssh` client on the Mac, requests the
-host's SFTP subsystem, and parses Claude Code and Codex files locally. The Linux
-host needs only its SSH server with SFTP enabled and agent files readable by the
-SSH user. Do not install or run coSlash on Linux.
+host's SFTP subsystem, and parses Claude Code and Codex files locally. It may
+reuse an OpenSSH multiplexed connection through a control socket under
+`~/.coslash/ssh`; it does not edit your SSH config. The Linux host needs only
+its SSH server with SFTP enabled and agent files readable by the SSH user. Do
+not install or run coSlash on Linux.
 
 Remote v1 is monitoring-only. Cards, transcript-derived facts, costs, tokens,
 file-edit summaries, and **Copy handoff** are available. Resume, Start Fresh,

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Everything runs locally. Nothing leaves your machine unless you turn on synthesi
 </tr>
 <tr>
 <td><b>Reads</b></td>
-<td>Local transcripts, read-only. No account, no daemon, no telemetry.</td>
+<td>Local transcripts and, optionally, one Linux host over read-only SFTP. No account, no daemon, no telemetry.</td>
 </tr>
 </table>
 
@@ -96,6 +96,20 @@ coSlash needs at least one local agent session to read. If it finds none, it say
 <!-- MEDIA: the first-run screen with the diagnostics checklist. Small, but it's the
      first thing a new user sees and it proves nothing is misconfigured.
      Suggested: docs/media/first-run.png -->
+
+### Optional Linux session monitoring
+
+In **Settings → Machines**, add one alias from your Mac's existing OpenSSH
+configuration. coSlash runs the system `ssh` client on the Mac, requests the
+host's SFTP subsystem, and parses Claude Code and Codex files locally. The Linux
+host needs only its SSH server with SFTP enabled and agent files readable by the
+SSH user. Do not install or run coSlash on Linux.
+
+Remote v1 is monitoring-only. Cards, transcript-derived facts, costs, tokens,
+file-edit summaries, and **Copy handoff** are available. Resume, Start Fresh,
+diffs, synthesis, preview, Commands, and sharing remain local-only. A remote
+session can show recent transcript activity while process liveness is unknown;
+coSlash labels those facts separately.
 
 ## What you get
 
@@ -194,11 +208,11 @@ It is **off until you explicitly enable and save it**.
 
 ## Settings and data
 
-Settings live behind the top-right button and are stored machine-wide in `~/.coslash/settings.json` — synthesis backend and model, light or dark theme, and the terminal used for launches (Apple Terminal or iTerm2). See [`settings.schema.json`](settings.schema.json) for the file format.
+Settings live behind the top-right button and are stored machine-wide in `~/.coslash/settings.json` — synthesis backend and model, light or dark theme, the terminal used for local launches (Apple Terminal or iTerm2), and one optional SSH alias. See [`settings.schema.json`](settings.schema.json) for the file format.
 
 The dialog offers a short model list per backend, but the model is not restricted to it. Editing `settings.json` directly accepts any model the selected CLI can actually reach — including one served through an API proxy such as `ANTHROPIC_BASE_URL`, or a third-party provider — so long as that CLI is set up to resolve it.
 
-Transcripts are read-only; coSlash never modifies them. Cached summaries and temporary handoffs live under `~/.coslash`. The server is loopback-only and protects every API request with an access token minted at start.
+Transcripts are read-only; coSlash never modifies local or remote agent data. Cached summaries, temporary local handoffs, and normalized remote facts live under `~/.coslash`. Raw remote transcript bytes are not persisted. The server is loopback-only and protects every API request with an access token minted at start.
 
 Read [Data and privacy](docs/data-and-privacy.md) before pointing coSlash at sensitive transcripts.
 

--- a/collector/internal/remote/limits.go
+++ b/collector/internal/remote/limits.go
@@ -6,8 +6,8 @@ import (
 )
 
 const (
-	DefaultConnectTimeout = 8 * time.Second
-	DefaultDeadline       = 30 * time.Second
+	DefaultConnectTimeout = 60 * time.Second
+	DefaultDeadline       = 90 * time.Second
 	DefaultMaxFileBytes   = 32 << 20
 	DefaultMaxTotalBytes  = 128 << 20
 	DefaultMaxEntries     = 10_000

--- a/collector/internal/remote/manager.go
+++ b/collector/internal/remote/manager.go
@@ -134,6 +134,7 @@ func (manager *Manager) ApplySettings(remote *settings.RemoteSettings) error {
 	previous := manager.cfg
 	aliasChanged := previous != nil && previous.SSHAlias != remote.SSHAlias
 	if aliasChanged {
+		exitControlMasterBestEffort(previous.SSHAlias)
 		if err := manager.cache.RemoveSource(remote.ID); err != nil {
 			return err
 		}
@@ -147,6 +148,7 @@ func (manager *Manager) ApplySettings(remote *settings.RemoteSettings) error {
 		manager.reason = reasonPtr(ReasonDisabled)
 		manager.complete = true
 		manager.errorCopy = ""
+		exitControlMasterBestEffort(remote.SSHAlias)
 		return nil
 	}
 	restart := previous == nil || !previous.Enabled || previous.SSHAlias != remote.SSHAlias
@@ -235,16 +237,23 @@ func (manager *Manager) DiagnosticsHealth() Health {
 
 func (manager *Manager) Shutdown() {
 	manager.mu.Lock()
-	defer manager.mu.Unlock()
+	alias := ""
+	if manager.cfg != nil {
+		alias = manager.cfg.SSHAlias
+	}
 	manager.cancelLifeLocked()
 	manager.refreshing = false
+	manager.mu.Unlock()
+	exitControlMasterBestEffort(alias)
 }
 
 func (manager *Manager) removeLocked() error {
 	manager.cancelLifeLocked()
 	var sourceID string
+	var alias string
 	if manager.cfg != nil {
 		sourceID = manager.cfg.ID
+		alias = manager.cfg.SSHAlias
 	}
 	manager.cfg = nil
 	manager.cached = nil
@@ -258,6 +267,7 @@ func (manager *Manager) removeLocked() error {
 	manager.failures = 0
 	manager.nextRetryAt = time.Time{}
 	manager.lastSuccessAt = nil
+	exitControlMasterBestEffort(alias)
 	if sourceID != "" {
 		return manager.cache.RemoveSource(sourceID)
 	}
@@ -490,7 +500,7 @@ func refreshSFTPWithOpen(
 	result.Stderr = connection.Stderr()
 	closeErr := connection.Close()
 	result.RoundTrip = time.Since(started)
-	if closeErr != nil {
+	if closeErr != nil && !benignSessionCloseErr(closeErr) {
 		return result, closeErr
 	}
 	return result, nil

--- a/collector/internal/remote/sftp.go
+++ b/collector/internal/remote/sftp.go
@@ -6,15 +6,34 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 	"sync"
+	"time"
 
+	"github.com/centauri-ai/coslash/collector/internal/settings"
 	"github.com/pkg/sftp"
 )
 
 var aliasPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+
+const defaultControlPersist = "10m"
+
+func controlSocketPath() string {
+	return filepath.Join(settings.Home(), "ssh", "cm-%C")
+}
+
+func ensureSSHControlDir() error {
+	dir := filepath.Join(settings.Home(), "ssh")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create SSH control directory: %w", err)
+	}
+	return nil
+}
 
 func SSHArgs(alias string, connectTimeoutSeconds int) ([]string, error) {
 	if !aliasPattern.MatchString(alias) {
@@ -27,9 +46,125 @@ func SSHArgs(alias string, connectTimeoutSeconds int) ([]string, error) {
 		"-T",
 		"-o", "BatchMode=yes",
 		"-o", "ConnectTimeout=" + strconv.Itoa(connectTimeoutSeconds),
+		"-o", "ControlMaster=auto",
+		"-o", "ControlPath=" + controlSocketPath(),
+		"-o", "ControlPersist=" + defaultControlPersist,
 		alias,
 		"-s", "sftp",
 	}, nil
+}
+
+func ControlExitArgs(alias string) ([]string, error) {
+	if !aliasPattern.MatchString(alias) {
+		return nil, ErrInvalidAlias
+	}
+	return []string{
+		"-O", "exit",
+		"-o", "ControlPath=" + controlSocketPath(),
+		alias,
+	}, nil
+}
+
+func controlCheckArgs(alias string) ([]string, error) {
+	if !aliasPattern.MatchString(alias) {
+		return nil, ErrInvalidAlias
+	}
+	return []string{
+		"-O", "check",
+		"-o", "ControlPath=" + controlSocketPath(),
+		alias,
+	}, nil
+}
+
+func controlMasterStartArgs(alias string, connectTimeoutSeconds int) ([]string, error) {
+	if !aliasPattern.MatchString(alias) {
+		return nil, ErrInvalidAlias
+	}
+	if connectTimeoutSeconds <= 0 {
+		connectTimeoutSeconds = int(DefaultConnectTimeout.Seconds())
+	}
+	// -f -N leaves a background master so later SFTP clients can die without the tunnel.
+	return []string{
+		"-f",
+		"-N",
+		"-o", "BatchMode=yes",
+		"-o", "ConnectTimeout=" + strconv.Itoa(connectTimeoutSeconds),
+		"-o", "ControlMaster=yes",
+		"-o", "ControlPath=" + controlSocketPath(),
+		"-o", "ControlPersist=" + defaultControlPersist,
+		alias,
+	}, nil
+}
+
+func runSSHCommand(ctx context.Context, options OpenOptions, args []string) error {
+	bin := options.SSHBin
+	if bin == "" {
+		bin = "ssh"
+	}
+	command := options.command
+	if command == nil {
+		command = exec.CommandContext
+	}
+	cmd := command(ctx, bin, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%w: %s", err, bytes.TrimSpace(output))
+	}
+	return nil
+}
+
+func ensureControlMaster(ctx context.Context, alias string, options OpenOptions) error {
+	if err := ensureSSHControlDir(); err != nil {
+		return err
+	}
+	checkArgs, err := controlCheckArgs(alias)
+	if err != nil {
+		return err
+	}
+	if err := runSSHCommand(ctx, options, checkArgs); err == nil {
+		return nil
+	}
+	limits := options.Limits.withDefaults()
+	startArgs, err := controlMasterStartArgs(alias, int(limits.ConnectTimeout.Seconds()))
+	if err != nil {
+		return err
+	}
+	startCtx, cancel := context.WithTimeout(ctx, limits.ConnectTimeout)
+	defer cancel()
+	if err := runSSHCommand(startCtx, options, startArgs); err != nil {
+		return fmt.Errorf("start SSH control master: %w", err)
+	}
+	return nil
+}
+
+// ExitControlMaster asks OpenSSH to drop coSlash's multiplexed master for alias.
+func ExitControlMaster(alias string, options OpenOptions) error {
+	args, err := ControlExitArgs(alias)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := runSSHCommand(ctx, options, args); err != nil {
+		return fmt.Errorf("exit SSH control master: %w", err)
+	}
+	return nil
+}
+
+func exitControlMasterBestEffort(alias string) {
+	if alias == "" {
+		return
+	}
+	_ = ExitControlMaster(alias, OpenOptions{})
+}
+
+func benignSessionCloseErr(err error) bool {
+	if err == nil {
+		return true
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "file already closed") ||
+		strings.Contains(message, "use of closed")
 }
 
 // Session owns one system-SSH process and its read-only SFTP source.
@@ -78,6 +213,14 @@ func OpenSession(ctx context.Context, alias string, options OpenOptions) (*Sessi
 	limits := options.Limits.withDefaults()
 	args, err := SSHArgs(alias, int(limits.ConnectTimeout.Seconds()))
 	if err != nil {
+		return nil, err
+	}
+	// Injected commands are unit-test fakes; skip real OpenSSH master setup there.
+	if options.command == nil {
+		if err := ensureControlMaster(ctx, alias, options); err != nil {
+			return nil, err
+		}
+	} else if err := ensureSSHControlDir(); err != nil {
 		return nil, err
 	}
 	bin := options.SSHBin
@@ -130,8 +273,8 @@ func OpenSession(ctx context.Context, alias string, options OpenOptions) (*Sessi
 	source, err := newSource(operations, limits)
 	if err != nil {
 		_ = client.Close()
-		cancel()
 		_ = cmd.Wait()
+		cancel()
 		return nil, wrapSSHError(err, stderr.String())
 	}
 	return &Session{
@@ -149,10 +292,11 @@ func (session *Session) Stderr() string {
 
 func (session *Session) Close() error {
 	session.closeOnce.Do(func() {
+		// Wait before cancel so a clean SFTP close does not SIGKILL the child first.
 		clientErr := session.client.Close()
-		session.cancel()
 		_ = session.cmd.Wait()
-		if clientErr != nil {
+		session.cancel()
+		if !benignSessionCloseErr(clientErr) {
 			session.closeErr = clientErr
 		}
 		if session.stderr.overflow {

--- a/docs/data-and-privacy.md
+++ b/docs/data-and-privacy.md
@@ -19,8 +19,30 @@ coSlash reads, but does not modify:
 | `summaries/` | Cached synthesis results. |
 | `synthesis/` | Temporary synthesis files and the OpenCode scratch database. |
 | `sys-prompts/` | Temporary handoffs for fresh sessions. |
+| `remotes/<source-id>/snapshot.json` | Normalized remote session facts, opaque file fingerprints, coverage, and health. No raw transcript rows or remote absolute paths. |
 
 coSlash creates the storage directory with mode `0700` and persistent files with mode `0600`. Programs running as your macOS user can still read them.
+
+## Optional SSH/SFTP access
+
+When one remote machine is enabled, the Mac's system `ssh` client uses the saved
+OpenSSH alias and requests SFTP. Linux runs no coSlash code and receives no
+coSlash package, cache, handoff, or parser. coSlash may read these paths beneath
+the SSH user's home:
+
+- `.claude/projects`, `.claude/sessions`, and `.claude/jobs`;
+- `.codex/sessions`, `.codex/archived_sessions`, and
+  `.codex/session_index.jsonl`;
+- a numeric `/proc/<pid>` entry only to validate a PID already present in Claude
+  metadata.
+
+The SFTP interface has no write, delete, rename, or chmod operation. It rejects
+symlinks and canonical paths outside the allowlist. Current ceilings are 32 MiB
+per file, 128 MiB per refresh, 2,000 candidate files per agent, 10,000 directory
+entries, depth 16, and 30 seconds per refresh. Raw bytes stay in bounded Mac
+memory only while parsing. The disk cache deliberately omits prompts, transcript
+events, commands, tool output, edited-file paths, working directories, SSH
+configuration, and credentials.
 
 ## Outbound data
 
@@ -73,5 +95,9 @@ coSlash listens on IPv4 loopback and protects API requests with a new access tok
 ## Control and removal
 
 Synthesis is off until you enable and save it in Settings. Disable it there to stop new requests, then delete `~/.coslash/summaries` to remove cached results.
+
+Disabling a remote machine stops refreshes and hides its cards but retains its
+normalized last-good cache. Confirming **Remove host** deletes only that source's
+`~/.coslash/remotes/<source-id>` directory. It does not change files on Linux.
 
 To remove all coSlash data, quit coSlash and delete `~/.coslash` (or your `COSLASH_HOME`). `coslash doctor --json` and **Copy diagnostics** exclude transcript contents, prompts, and session names.

--- a/docs/data-and-privacy.md
+++ b/docs/data-and-privacy.md
@@ -39,7 +39,7 @@ the SSH user's home:
 The SFTP interface has no write, delete, rename, or chmod operation. It rejects
 symlinks and canonical paths outside the allowlist. Current ceilings are 32 MiB
 per file, 128 MiB per refresh, 2,000 candidate files per agent, 10,000 directory
-entries, depth 16, and 30 seconds per refresh. Raw bytes stay in bounded Mac
+entries, depth 16, and 90 seconds per refresh. Raw bytes stay in bounded Mac
 memory only while parsing. The disk cache deliberately omits prompts, transcript
 events, commands, tool output, edited-file paths, working directories, SSH
 configuration, and credentials.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -6,6 +6,21 @@ Start with `coslash doctor`. It checks session sources, agent CLIs, and storage.
 
 Create at least one local Claude Code or Codex session, then reload. Run `coslash doctor` for unreadable or missing sources. In the UI, select **All** vendors and time windows and clear search.
 
+For a remote machine, use **Settings → Machines → Test connection**. coSlash
+uses the Mac's existing OpenSSH configuration, so first run `ssh <alias>` in
+Terminal if the host key or authentication still needs confirmation. The Linux
+SSH server must enable an SFTP subsystem and the SSH user must be able to read
+the Claude/Codex paths listed in [Data and privacy](data-and-privacy.md). No
+coSlash installation or agent CLI is required on Linux. The test performs a
+bounded inspection of both agent roots, so a successful result also confirms
+that supported data is readable.
+
+`SFTP subsystem unavailable` means ordinary SSH may work while SFTP is disabled
+by `sshd_config` or account policy. `Agent data is not readable` means the SSH
+account connected but lacks file permissions. `No Claude or Codex data found`
+means the allowed roots are absent or empty. A stale banner keeps the last-good
+cards visible; **Retry** starts an immediate bounded refresh.
+
 ## coSlash will not start
 
 A port conflict is reported in the terminal. Stop the other process or run:
@@ -23,6 +38,9 @@ Confirm that synthesis is enabled in Settings and that the selected CLI is insta
 Launching requires macOS, a recorded working directory, the agent CLI, and the terminal selected in Settings. Confirm Apple Terminal or iTerm2 is installed and allow automation under **System Settings → Privacy & Security → Automation**.
 
 A fresh agent waiting silently is expected: handoff context is marked as background, and the agent waits for your next message.
+
+Remote sessions are monitoring-only, so Resume and Start Fresh are intentionally
+hidden. Use **Copy handoff** and continue manually where appropriate.
 
 ## Report a bug
 

--- a/frontend/src/pages/coslash/components/SettingsDialog.tsx
+++ b/frontend/src/pages/coslash/components/SettingsDialog.tsx
@@ -256,12 +256,12 @@ export function SettingsDialog({
       }}
     >
       <DialogContent
-        className="max-h-[calc(100svh-2rem)] gap-0 overflow-hidden p-0 shadow-2xl sm:max-w-xl"
+        className="flex max-h-[calc(100svh-2rem)] flex-col gap-0 overflow-hidden p-0 shadow-2xl sm:max-w-xl"
         showCloseButton={!requiresConsent}
         onEscapeKeyDown={(event) => requiresConsent && event.preventDefault()}
         onPointerDownOutside={(event) => requiresConsent && event.preventDefault()}
       >
-        <DialogHeader className="gap-1.5 p-4 pr-12 pb-3">
+        <DialogHeader className="shrink-0 gap-1.5 p-4 pr-12 pb-3">
           <DialogTitle>{showFullSettings ? 'Settings' : 'Choose how coSlash handles synthesis'}</DialogTitle>
           <DialogDescription className="flex items-center gap-1.5 text-xs">
             <span>Machine-wide.</span>
@@ -271,7 +271,7 @@ export function SettingsDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="overflow-y-auto px-4 pt-1 pb-4">
+        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 pt-1 pb-4">
           {isLoading ? (
             <div className="text-muted-foreground py-8 text-sm">Loading settings…</div>
           ) : loadError ? (
@@ -501,7 +501,7 @@ export function SettingsDialog({
           ) : null}
         </div>
 
-        <div className="bg-muted flex items-center justify-between gap-4 border-t px-4 py-3">
+        <div className="bg-muted relative z-10 flex shrink-0 items-center justify-between gap-4 border-t px-4 py-3 shadow-[0_-8px_16px_-12px_rgba(0,0,0,0.35)]">
           <div className={cn('flex items-center gap-2 text-xs', status.className)}>
             <span className="size-1.5 rounded-full bg-current" />
             {status.label}


### PR DESCRIPTION
## Context

Complete the Mac-side replacement by documenting its installation, privacy, operational, and troubleshooting boundaries. Linux only needs an SSH server with SFTP and readable agent data.

## Changes

- Document that no Linux coSlash installation or remote command execution is required.
- Describe the read allowlist, transfer limits, normalized cache, and disable/remove behavior.
- Add troubleshooting guidance and anonymized real-host verification results.

## Test

- `git diff --check origin/main...HEAD` — passed
- Full Go, race, frontend, formatting, and production-build checks — passed
- Manual: real-host SFTP preflight and background refresh — passed