### PR TITLE
Make remote connection tests fast

### DIFF
--- a/collector/cmd/coslash/api_remote.go
+++ b/collector/cmd/coslash/api_remote.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/centauri-ai/coslash/collector/internal/remote"
 	"github.com/centauri-ai/coslash/collector/internal/settings"
@@ -22,7 +23,7 @@ func handleRemoteTest(w http.ResponseWriter, request *http.Request, manager *rem
 		http.Error(w, "invalid remote test request", http.StatusBadRequest)
 		return
 	}
-	ctx, cancel := context.WithTimeout(request.Context(), remote.DefaultDeadline)
+	ctx, cancel := context.WithTimeout(request.Context(), remote.DefaultConnectTimeout+5*time.Second)
 	defer cancel()
 	health, err := manager.TestAlias(ctx, body.SSHAlias)
 	if err != nil {

--- a/collector/internal/remote/manager.go
+++ b/collector/internal/remote/manager.go
@@ -107,8 +107,8 @@ func NewManager(options Options) *Manager {
 	}
 	test := options.Test
 	if test == nil {
-		test = func(ctx context.Context, alias string, _ int64, now time.Time) (refreshResult, error) {
-			return refreshSFTPWithOpen(ctx, alias, now.UnixMilli(), now, open)
+		test = func(ctx context.Context, alias string, _ int64, _ time.Time) (refreshResult, error) {
+			return probeSFTPWithOpen(ctx, alias, open)
 		}
 	}
 	return &Manager{
@@ -448,6 +448,20 @@ func (manager *Manager) healthLocked(remoteSinceMs int64) Health {
 
 func refreshSFTP(ctx context.Context, alias string, since int64, now time.Time) (refreshResult, error) {
 	return refreshSFTPWithOpen(ctx, alias, since, now, OpenSession)
+}
+
+func probeSFTPWithOpen(ctx context.Context, alias string, open openFunc) (refreshResult, error) {
+	started := time.Now()
+	connection, err := open(ctx, alias, OpenOptions{})
+	if err != nil {
+		return refreshResult{RoundTrip: time.Since(started)}, err
+	}
+	closeErr := connection.Close()
+	result := refreshResult{RoundTrip: time.Since(started), Stderr: connection.Stderr()}
+	if closeErr != nil && !benignSessionCloseErr(closeErr) {
+		return result, closeErr
+	}
+	return result, nil
 }
 
 func refreshSFTPWithOpen(


### PR DESCRIPTION
## Context

Testing a remote SSH alias could scan remote session history before returning. A working SFTP connection could therefore appear unresponsive.

## Changes

- Make Test connection verify SSH/SFTP readiness without parsing remote session history.
- Use a request budget aligned with the SSH connection timeout.

## Test

- `cd collector && go test ./...` — passed
- `cd collector && go vet ./...` — passed