### PR TITLE
Fix remote connection results and expired-tab polling

### DIFF
--- a/collector/internal/remote/manager.go
+++ b/collector/internal/remote/manager.go
@@ -218,14 +218,7 @@ func (manager *Manager) TestAlias(ctx context.Context, alias string) (Health, er
 		health.DiagnosticStderr = redactDiagnostic(diagnostic)
 		return health, nil
 	}
-	if reason := limitedResultReason(result); reason != nil {
-		health.State = StateLimited
-		health.Complete = false
-		health.Reason = reason
-		health.Error = genericErrorCopy(*reason)
-	} else {
-		health.State = StateOK
-	}
+	health.State = StateOK
 	return health, nil
 }
 

--- a/frontend/src/pages/coslash/hooks/use-sessions.ts
+++ b/frontend/src/pages/coslash/hooks/use-sessions.ts
@@ -178,15 +178,16 @@ export function useSessions({ localWindow, remoteWindow }: SessionsQuery) {
         })
         .catch((error: unknown) => {
           if (controller.signal.aborted) return;
-          authenticationFailed = error instanceof ApiAuthenticationError;
+          const requestAuthenticationFailed = error instanceof ApiAuthenticationError;
+          if (requestAuthenticationFailed) authenticationFailed = true;
           // Keep showing the last good list when an ordinary background
           // refresh fails. Authentication failures invalidate that private data.
-          if (!background || authenticationFailed) {
+          if (!background || requestAuthenticationFailed) {
             setSessions([]);
             setMachines([]);
             setIsLoading(false);
             setLoadError(
-              authenticationFailed ? error.message : 'CoSlash couldn’t load sessions from the API.',
+              requestAuthenticationFailed ? error.message : 'CoSlash couldn’t load sessions from the API.',
             );
           }
           console.error('Failed to load sessions', error);

--- a/frontend/src/pages/coslash/hooks/use-sessions.ts
+++ b/frontend/src/pages/coslash/hooks/use-sessions.ts
@@ -148,8 +148,10 @@ export function useSessions({ localWindow, remoteWindow }: SessionsQuery) {
 
   useEffect(() => {
     const controller = new AbortController();
+    let authenticationFailed = false;
 
     const load = (background: boolean) => {
+      if (authenticationFailed) return;
       if (!background) {
         setIsLoading(true);
         setLoadError(null);
@@ -176,7 +178,7 @@ export function useSessions({ localWindow, remoteWindow }: SessionsQuery) {
         })
         .catch((error: unknown) => {
           if (controller.signal.aborted) return;
-          const authenticationFailed = error instanceof ApiAuthenticationError;
+          authenticationFailed = error instanceof ApiAuthenticationError;
           // Keep showing the last good list when an ordinary background
           // refresh fails. Authentication failures invalidate that private data.
           if (!background || authenticationFailed) {


### PR DESCRIPTION
## Context

A successful remote SFTP probe could be reported as missing agent data because the connection check reused refresh coverage rules. Separately, an expired browser link continued polling the local API after authentication failed.

## Changes

- Report successful SSH/SFTP connection tests as ready without evaluating Claude or Codex session coverage.
- Stop session polling after an authentication failure while showing the existing expired-link message.

## Test

- `cd collector && go test ./...` — passed
- `cd collector && go vet ./...` — passed
- `cd frontend && npm test -- --run` — passed
- `cd frontend && npm run lint` — passed with existing warnings
- `cd frontend && npm run format:check` — passed