### PR TITLE
Clear stale waiting status for closed Codex sessions

### DIFF
--- a/collector/internal/collector/collector.go
+++ b/collector/internal/collector/collector.go
@@ -129,7 +129,7 @@ func finalizeSessionsSource(
 		removeUnresolvedSpawnRows(p.Session)
 	}
 	resolveNames(composition.roots, metadata)
-	resolveStatus(composition.roots, metadata)
+	resolveStatus(composition.roots, metadata, source == vendors.LocalReadSource)
 	return composition.roots
 }
 
@@ -419,15 +419,17 @@ func resolveNames(roots []*vendors.ParsedSession, metadata map[string]*vendors.S
 func resolveStatus(
 	roots []*vendors.ParsedSession,
 	metadata map[string]*vendors.SessionMetadata,
+	livenessAuthoritative bool,
 ) {
 	now := time.Now().UnixMilli()
 	for _, p := range roots {
 		s := p.Session
-		if deref(s.Status) == "waiting" {
+		raw, live := sessionMetadata(metadata, s.Agent).Live[s.ID]
+		if deref(s.Status) == "waiting" && (!livenessAuthoritative || live) {
 			continue
 		}
 		s.Status = nil
-		if raw, live := sessionMetadata(metadata, s.Agent).Live[s.ID]; live {
+		if live {
 			status := raw
 			if raw == "interactive" {
 				status = session.LiveStatus(p.InTurn, s.LastActivityTime, now)

--- a/collector/internal/collector/collector_test.go
+++ b/collector/internal/collector/collector_test.go
@@ -40,6 +40,22 @@ func TestApplyActivityFallbacksKeepsSessionsExportable(t *testing.T) {
 	}
 }
 
+func TestResolveStatusClearsWaitingForClosedSession(t *testing.T) {
+	waiting := "waiting"
+	root := &vendors.ParsedSession{Session: &session.Session{
+		Agent: "codex", ID: "closed", Status: &waiting,
+	}}
+	metadata := map[string]*vendors.SessionMetadata{
+		"codex": vendors.EmptySessionMetadata(),
+	}
+
+	resolveStatus([]*vendors.ParsedSession{root}, metadata, true)
+
+	if root.Session.Status != nil {
+		t.Fatalf("closed session status = %q; want nil", *root.Session.Status)
+	}
+}
+
 func TestGetSessionForPreviewLoadsOnlyTheComposedFamily(t *testing.T) {
 	original := vendorSources
 	t.Cleanup(func() { vendorSources = original })


### PR DESCRIPTION
## Context

A Codex rollout can retain a pending input request after its process closes. The UI then shows the closed session as waiting.

## Changes

- Clear the waiting status when local process data shows that the Codex session is closed.
- Keep the waiting status for remote sessions because remote collection has no local process data.
- Add a regression test for a closed session with stale waiting state.

## Test

- `go test ./... -count=1` — passed, 188 tests
- `git diff --check origin/main...HEAD` — passed
- Manual: inspected the affected rollout and its local process data.

### Screenshots

- [x] Before — closed Codex session shows the waiting status
<img width="2317" height="921" alt="Screenshot 2026-08-31 at 14 54 32" src="https://github.com/user-attachments/assets/438b2f89-b964-4686-a64e-6867cb58a783" />


- [x] After — closed Codex session does not show the waiting status
<img width="2318" height="899" alt="Screenshot 2026-08-31 at 15 01 39" src="https://github.com/user-attachments/assets/a7a77bfb-23e9-48ea-83a4-01972e64b662" />
