### PR TITLE
Fix macOS Hub device pairing persistence

### DIFF
--- a/collector/internal/hubclient/client.go
+++ b/collector/internal/hubclient/client.go
@@ -196,7 +196,9 @@ func (c *Client) PollPairing(ctx context.Context, pairingID string) (PairingResu
 		token.Credential == "" || token.TokenType != "Device" || token.Scope != "ingest" {
 		return PairingResult{}, errors.New("decode Hub credential: invalid response")
 	}
-	if err := c.Credentials.Save(ctx, token.Credential); err != nil {
+	saveContext, cancelSave := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancelSave()
+	if err := c.Credentials.Save(saveContext, token.Credential); err != nil {
 		return PairingResult{}, err
 	}
 	c.forgetPairing(pairingID)

--- a/collector/internal/hubclient/client_test.go
+++ b/collector/internal/hubclient/client_test.go
@@ -14,6 +14,11 @@ type memoryCredentials struct {
 	saved string
 }
 
+type contextCredentials struct {
+	saved  string
+	cancel context.CancelFunc
+}
+
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) { return f(request) }
@@ -29,6 +34,17 @@ func response(status int, body string) *http.Response {
 func (s *memoryCredentials) Load(context.Context) (string, error) { return "credential", nil }
 
 func (s *memoryCredentials) Save(_ context.Context, credential string) error {
+	s.saved = credential
+	return nil
+}
+
+func (s *contextCredentials) Load(context.Context) (string, error) { return "credential", nil }
+
+func (s *contextCredentials) Save(ctx context.Context, credential string) error {
+	s.cancel()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	s.saved = credential
 	return nil
 }
@@ -129,6 +145,24 @@ func TestPollPairingValidatesCredentialMetadata(t *testing.T) {
 				t.Fatalf("saved = %q, error = %v", credentials.saved, err)
 			}
 		})
+	}
+}
+
+func TestPollPairingSavesCredentialAfterRequestCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	credentials := &contextCredentials{cancel: cancel}
+	base, _ := url.Parse("https://hub.example")
+	client := Client{
+		BaseURL: base, Credentials: credentials,
+		pairings: map[string]pairingSecret{"pair": {deviceCode: "code", expiresAt: time.Now().Add(time.Minute)}},
+		HTTP: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return response(http.StatusOK, `{"deviceId":"device","credential":"secret","tokenType":"Device","scope":"ingest"}`), nil
+		})},
+	}
+
+	result, err := client.PollPairing(ctx, "pair")
+	if err != nil || result.State != "paired" || credentials.saved != "secret" {
+		t.Fatalf("result = %#v, saved = %q, error = %v", result, credentials.saved, err)
 	}
 }
 

--- a/collector/internal/hubclient/credential.go
+++ b/collector/internal/hubclient/credential.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+	"syscall"
 )
 
 var ErrNotPaired = errors.New("hub device credential is not available")
@@ -50,8 +51,7 @@ func (s OSKeychain) Save(ctx context.Context, credential string) error {
 	var command *exec.Cmd
 	switch runtime.GOOS {
 	case "darwin":
-		command = exec.CommandContext(ctx, "/usr/bin/security", "add-generic-password", "-U", "-s", s.Service, "-a", s.Account, "-w")
-		command.Stdin = bytes.NewBufferString(credential)
+		command = darwinCredentialCommand(ctx, s, credential)
 	case "linux":
 		command = exec.CommandContext(ctx, "secret-tool", "store", "--label=coSlash Hub device", "service", s.Service, "account", s.Account)
 		command.Stdin = bytes.NewBufferString(credential)
@@ -62,4 +62,15 @@ func (s OSKeychain) Save(ctx context.Context, credential string) error {
 		return fmt.Errorf("save Hub credential: keychain command failed: %w (%s)", err, strings.TrimSpace(string(output)))
 	}
 	return nil
+}
+
+func darwinCredentialCommand(ctx context.Context, store OSKeychain, credential string) *exec.Cmd {
+	command := exec.CommandContext(ctx, "/usr/bin/security", "add-generic-password", "-U", "-s", store.Service, "-a", store.Account, "-w")
+	command.Stdin = darwinCredentialInput(credential)
+	command.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	return command
+}
+
+func darwinCredentialInput(credential string) *bytes.Buffer {
+	return bytes.NewBufferString(credential + "\n" + credential + "\n")
 }


### PR DESCRIPTION
## Context

macOS device pairing failed when coSlash ran from a terminal. The Keychain command inherited the terminal and waited for interactive password input. A canceled polling request could also stop credential storage after Hub approved the device.

## Changes

- Run the macOS Keychain command in a separate session.
- Provide both password lines required for a new Keychain item.
- Finish credential storage after request cancellation, with a 30-second limit.
- Add regression coverage for canceled polling requests.

## Test

- `go test ./internal/hubclient ./cmd/coslash -count=1` — passed
- `make release` — passed
- Manual: verified Keychain storage from a macOS PTY.