### PR TITLE
fix(remote): keep partial SSH sessions when one agent times out

### DIFF
--- a/collector/cmd/coslash/api.go
+++ b/collector/cmd/coslash/api.go
@@ -60,7 +60,10 @@ func handleList(
 		log.Printf("list sessions: %d", len(sessions))
 		return
 	}
-	response := sessionsResponse{Machines: []machineFact{localMachineFact()}}
+	response := sessionsResponse{
+		Sessions: []boardSession{},
+		Machines: []machineFact{localMachineFact()},
+	}
 	for _, value := range sessions {
 		response.Sessions = append(response.Sessions, boardLocalSession(value))
 	}

--- a/collector/internal/remote/limits.go
+++ b/collector/internal/remote/limits.go
@@ -7,7 +7,8 @@ import (
 
 const (
 	DefaultConnectTimeout = 60 * time.Second
-	DefaultDeadline       = 90 * time.Second
+	// Covers Claude and Codex over one SFTP session; large remote trees need headroom.
+	DefaultDeadline       = 3 * time.Minute
 	DefaultMaxFileBytes   = 32 << 20
 	DefaultMaxTotalBytes  = 128 << 20
 	DefaultMaxEntries     = 10_000

--- a/collector/internal/remote/manager.go
+++ b/collector/internal/remote/manager.go
@@ -372,26 +372,15 @@ func (manager *Manager) runRefresh(
 		manager.observeRefreshLocked(result, remoteSinceMs, len(result.Sessions), false)
 		return
 	}
-	coverage := slices.Clone(result.Coverage)
 	if reason := limitedResultReason(result); reason != nil {
-		manager.state = StateLimited
-		manager.reason = reason
-		manager.complete = false
+		manager.applyLimitedLocked(result, *reason, remoteSinceMs, fetchedAt)
+		manager.observeRefreshLocked(result, remoteSinceMs, len(result.Sessions), manager.state == StateLimited)
+		return
+	}
+	if !manager.publishSnapshotLocked(result, remoteSinceMs, fetchedAt) {
 		manager.observeRefreshLocked(result, remoteSinceMs, len(result.Sessions), false)
 		return
 	}
-	cached := snapshotForCache(
-		result.Sessions, coverage, result.Fingerprints,
-		remoteSinceMs, fetchedAt, result.RoundTrip.Milliseconds(),
-	)
-	if err := manager.cache.Store(config.ID, cached); err != nil {
-		manager.applyFailureLocked(ReasonLocalCacheFailed, "")
-		manager.observeRefreshLocked(result, remoteSinceMs, len(result.Sessions), false)
-		return
-	}
-	manager.cached = &cached
-	manager.sessions = result.Sessions
-	manager.lastSuccessAt = int64Ptr(fetchedAt)
 	manager.failures = 0
 	manager.nextRetryAt = time.Time{}
 	manager.errorCopy = ""
@@ -434,6 +423,41 @@ func (manager *Manager) observeRefreshLocked(
 	)
 }
 
+func (manager *Manager) publishSnapshotLocked(
+	result refreshResult,
+	remoteSinceMs, fetchedAt int64,
+) bool {
+	cached := snapshotForCache(
+		result.Sessions, slices.Clone(result.Coverage), result.Fingerprints,
+		remoteSinceMs, fetchedAt, result.RoundTrip.Milliseconds(),
+	)
+	if err := manager.cache.Store(manager.cfg.ID, cached); err != nil {
+		manager.applyFailureLocked(ReasonLocalCacheFailed, "")
+		return false
+	}
+	manager.cached = &cached
+	manager.sessions = result.Sessions
+	manager.lastSuccessAt = int64Ptr(fetchedAt)
+	return true
+}
+
+func (manager *Manager) applyLimitedLocked(
+	result refreshResult,
+	reason Reason,
+	remoteSinceMs, fetchedAt int64,
+) {
+	if !manager.publishSnapshotLocked(result, remoteSinceMs, fetchedAt) {
+		return
+	}
+	manager.failures++
+	manager.nextRetryAt = manager.now().Add(retryBackoff(manager.failures))
+	manager.state = StateLimited
+	manager.reason = reasonPtr(reason)
+	manager.complete = false
+	manager.errorCopy = genericErrorCopy(reason)
+	manager.diagnostic = ""
+}
+
 func (manager *Manager) applyFailureLocked(reason Reason, stderr string) {
 	manager.failures++
 	manager.nextRetryAt = manager.now().Add(retryBackoff(manager.failures))
@@ -453,6 +477,7 @@ func (manager *Manager) sessionsLocked(remoteSinceMs int64) []IndexedSession {
 		return nil
 	}
 	eligible := manager.state == StateOK && manager.complete
+	displayStale := manager.state != StateOK && manager.state != StateLimited
 	result := []IndexedSession{}
 	for _, item := range manager.sessions {
 		if remoteSinceMs > 0 && item.Status == nil && item.LastActivityTime < remoteSinceMs {
@@ -461,7 +486,7 @@ func (manager *Manager) sessionsLocked(remoteSinceMs int64) []IndexedSession {
 		indexed := IndexedSession{
 			Key:         SessionKey{SourceID: manager.cfg.ID, Agent: item.Agent, SourceSessionID: item.ID},
 			SourceLabel: manager.cfg.SSHAlias, Session: item,
-			EligibleForAggregates: eligible, DisplayStale: !eligible,
+			EligibleForAggregates: eligible, DisplayStale: displayStale,
 		}
 		if indexed.DisplayStale {
 			indexed.LastSeenStatus = item.Status
@@ -538,21 +563,39 @@ func refreshSFTPWithOpen(
 	parseSince := max(0, since-(24*time.Hour).Milliseconds())
 	collections := map[string]vendors.RemoteCollection{}
 	result := refreshResult{Fingerprints: map[string][]vendors.FileFingerprint{}}
-	claudeCoverage, claudeCollection, claudeErr := collectClaudeRemote(source, parseSince, now)
-	result.Coverage = append(result.Coverage, claudeCoverage)
-	if claudeErr != nil {
-		result.Failures = append(result.Failures, claudeErr)
-	} else {
-		collections[vendors.AgentClaude] = claudeCollection
-		result.Fingerprints[vendors.AgentClaude] = claudeCollection.Fingerprints
+	type agentOutcome struct {
+		agent      string
+		coverage   AgentCoverage
+		collection vendors.RemoteCollection
+		err        error
 	}
-	codexCoverage, codexCollection, codexErr := collectCodexRemote(source, parseSince)
-	result.Coverage = append(result.Coverage, codexCoverage)
-	if codexErr != nil {
-		result.Failures = append(result.Failures, codexErr)
-	} else {
-		collections[vendors.AgentCodex] = codexCollection
-		result.Fingerprints[vendors.AgentCodex] = codexCollection.Fingerprints
+	outcomes := make(chan agentOutcome, 2)
+	go func() {
+		coverage, collection, collectErr := collectClaudeRemote(source, parseSince, now)
+		outcomes <- agentOutcome{
+			agent: vendors.AgentClaude, coverage: coverage, collection: collection, err: collectErr,
+		}
+	}()
+	go func() {
+		coverage, collection, collectErr := collectCodexRemote(source, parseSince)
+		outcomes <- agentOutcome{
+			agent: vendors.AgentCodex, coverage: coverage, collection: collection, err: collectErr,
+		}
+	}()
+	byAgent := map[string]agentOutcome{}
+	for range 2 {
+		item := <-outcomes
+		byAgent[item.agent] = item
+	}
+	for _, agent := range []string{vendors.AgentClaude, vendors.AgentCodex} {
+		item := byAgent[agent]
+		result.Coverage = append(result.Coverage, item.coverage)
+		if item.err != nil {
+			result.Failures = append(result.Failures, item.err)
+			continue
+		}
+		collections[agent] = item.collection
+		result.Fingerprints[agent] = item.collection.Fingerprints
 	}
 	result.BytesRead, result.Entries = source.Stats()
 	if len(result.Failures) == 2 {
@@ -589,7 +632,7 @@ func collectClaudeRemote(
 	collection, err := claude.CollectRemote(source, source.Home(), parseSince, now)
 	bytesAfter, entriesAfter := source.Stats()
 	if err != nil {
-		err = fmt.Errorf("parse Claude remote data: %w", err)
+		err = fmt.Errorf("collect Claude remote data: %w", err)
 		reason := classifyError(err)
 		coverage := AgentCoverage{
 			Agent: vendors.AgentClaude, Error: genericErrorCopy(reason), ErrorReason: string(reason),
@@ -613,7 +656,7 @@ func collectCodexRemote(
 	collection, err := codex.CollectRemote(source, source.Home(), parseSince)
 	bytesAfter, entriesAfter := source.Stats()
 	if err != nil {
-		err = fmt.Errorf("parse Codex remote data: %w", err)
+		err = fmt.Errorf("collect Codex remote data: %w", err)
 		reason := classifyError(err)
 		coverage := AgentCoverage{
 			Agent: vendors.AgentCodex, Error: genericErrorCopy(reason), ErrorReason: string(reason),
@@ -657,6 +700,8 @@ func classifyError(err error) Reason {
 	switch {
 	case errors.Is(err, context.DeadlineExceeded):
 		return ReasonRefreshTimeout
+	case errors.Is(err, context.Canceled):
+		return ReasonRefreshTimeout
 	case errors.Is(err, fs.ErrPermission), errors.Is(err, ErrPathDenied):
 		return ReasonPermissionDenied
 	case errors.Is(err, ErrFileLimit), errors.Is(err, ErrTotalLimit),
@@ -676,6 +721,9 @@ func classifyError(err error) Reason {
 		strings.Contains(message, "too many authentication failures") {
 		return ReasonAuthentication
 	}
+	if strings.Contains(message, "i/o timeout") || strings.Contains(message, "deadline exceeded") {
+		return ReasonRefreshTimeout
+	}
 	if strings.Contains(message, "broken pipe") || strings.Contains(message, "connection reset") ||
 		strings.Contains(message, "connection refused") || strings.Contains(message, "unexpected eof") {
 		return ReasonConnectionFailed
@@ -683,7 +731,9 @@ func classifyError(err error) Reason {
 	if strings.Contains(message, "subsystem") || strings.Contains(message, "sftp") {
 		return ReasonSFTPUnavailable
 	}
-	if strings.Contains(message, "parse") || strings.Contains(message, "json") {
+	if strings.Contains(message, "json") ||
+		strings.Contains(message, "unmarshal") ||
+		strings.Contains(message, "decode") {
 		return ReasonInvalidData
 	}
 	return ReasonConnectionFailed

--- a/collector/internal/remote/manager.go
+++ b/collector/internal/remote/manager.go
@@ -709,6 +709,8 @@ func classifyError(err error) Reason {
 		return ReasonHistoryTruncated
 	case errors.Is(err, ErrSymlink):
 		return ReasonInvalidData
+	case errors.Is(err, vendors.ErrInvalidData):
+		return ReasonInvalidData
 	}
 	message := strings.ToLower(err.Error() + " " + sshErrorStderr(err))
 	if strings.Contains(message, "host key verification failed") ||

--- a/collector/internal/remote/manager_test.go
+++ b/collector/internal/remote/manager_test.go
@@ -1,0 +1,108 @@
+package remote
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/centauri-ai/coslash/collector/internal/session"
+	"github.com/centauri-ai/coslash/collector/internal/settings"
+	"github.com/centauri-ai/coslash/collector/internal/vendors"
+)
+
+func TestApplyLimitedPublishesSessionsAndBacksOff(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("COSLASH_HOME", home)
+	now := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	manager := NewManager(Options{
+		Cache: NewCache(filepath.Join(home, "remote-cache")),
+		Now:   func() time.Time { return now },
+		Refresh: func(context.Context, string, int64, time.Time) (refreshResult, error) {
+			return refreshResult{
+				Sessions: []*session.Session{{
+					Agent: vendors.AgentClaude, ID: "s1", LastActivityTime: now.UnixMilli(),
+				}},
+				Coverage: []AgentCoverage{
+					{Agent: vendors.AgentClaude, CandidateFiles: 12, SelectedFiles: 12},
+					{Agent: vendors.AgentCodex, Error: genericErrorCopy(ReasonRefreshTimeout)},
+				},
+				Failures: []error{fmt.Errorf("collect Codex remote data: %w", context.DeadlineExceeded)},
+			}, nil
+		},
+	})
+	if err := manager.ApplySettings(&settings.RemoteSettings{
+		ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true,
+	}); err != nil {
+		t.Fatalf("ApplySettings: %v", err)
+	}
+	waitUntil(t, func() bool {
+		manager.mu.Lock()
+		defer manager.mu.Unlock()
+		return !manager.refreshing && manager.state == StateLimited
+	})
+
+	view := manager.ListView(0)
+	if view.Health.State != StateLimited {
+		t.Fatalf("state=%s, want limited", view.Health.State)
+	}
+	if len(view.Sessions) != 1 {
+		t.Fatalf("sessions=%d, want 1 published", len(view.Sessions))
+	}
+	if view.Sessions[0].DisplayStale {
+		t.Fatal("limited partial snapshot should not display as stale")
+	}
+	if view.Sessions[0].EligibleForAggregates {
+		t.Fatal("limited snapshot should not be eligible for aggregates")
+	}
+
+	manager.mu.Lock()
+	if manager.cached == nil {
+		t.Fatal("expected limited snapshot to be cached")
+	}
+	if manager.nextRetryAt.IsZero() {
+		t.Fatal("expected retry backoff after limited refresh")
+	}
+	manager.cached.FetchedAtMs = now.Add(-FreshnessInterval - time.Second).UnixMilli()
+	manager.nextRetryAt = now.Add(time.Hour)
+	started := 0
+	manager.refresh = func(context.Context, string, int64, time.Time) (refreshResult, error) {
+		started++
+		return refreshResult{}, errors.New("should not refresh during backoff")
+	}
+	manager.mu.Unlock()
+
+	_ = manager.ListView(0)
+	if started != 0 {
+		t.Fatalf("refresh starts during backoff: %d", started)
+	}
+}
+
+func TestClassifyErrorTimeoutNotInvalidData(t *testing.T) {
+	err := fmt.Errorf("collect Codex remote data: %w", context.DeadlineExceeded)
+	if got := classifyError(err); got != ReasonRefreshTimeout {
+		t.Fatalf("classifyError=%s, want refresh_timeout", got)
+	}
+	// Legacy wrap used "parse …", which previously matched invalid_remote_data.
+	legacy := fmt.Errorf("parse Codex remote data: %w", context.DeadlineExceeded)
+	if got := classifyError(legacy); got != ReasonRefreshTimeout {
+		t.Fatalf("legacy wrap classifyError=%s, want refresh_timeout", got)
+	}
+	if got := classifyError(errors.New("collect Codex remote data: unexpected EOF")); got != ReasonConnectionFailed {
+		t.Fatalf("classifyError EOF=%s, want connection_failed", got)
+	}
+}
+
+func waitUntil(t *testing.T, ready func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if ready() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for condition")
+}

--- a/collector/internal/remote/manager_test.go
+++ b/collector/internal/remote/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -92,6 +93,29 @@ func TestClassifyErrorTimeoutNotInvalidData(t *testing.T) {
 	}
 	if got := classifyError(errors.New("collect Codex remote data: unexpected EOF")); got != ReasonConnectionFailed {
 		t.Fatalf("classifyError EOF=%s, want connection_failed", got)
+	}
+}
+
+func TestClassifyErrorMalformedTranscript(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "malformed.jsonl")
+	if err := os.WriteFile(path, []byte("{x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, parseErr := vendors.ParseJSONLSource[map[string]any](vendors.LocalReadSource, path)
+	if parseErr == nil {
+		t.Fatal("expected malformed transcript error")
+	}
+	tests := []error{
+		fmt.Errorf("collect Codex remote data: %w", parseErr),
+		fmt.Errorf(
+			"collect Codex remote data: %w: first row type %q is not session_meta",
+			vendors.ErrInvalidData, "event_msg",
+		),
+	}
+	for _, err := range tests {
+		if got := classifyError(err); got != ReasonInvalidData {
+			t.Errorf("classifyError(%q)=%s, want invalid_remote_data", err, got)
+		}
 	}
 }
 

--- a/collector/internal/vendors/codex/discovery.go
+++ b/collector/internal/vendors/codex/discovery.go
@@ -30,17 +30,20 @@ func readHeaderSource(source vendors.ReadSource, path string) (string, string, e
 	defer file.Close()
 	var row codexRow
 	if err := json.NewDecoder(file).Decode(&row); err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("%w: %w", vendors.ErrInvalidData, err)
 	}
 	id := SessionIDFromRollout(path)
 	if row.Type != "session_meta" {
-		return "", "", fmt.Errorf("first row type %q is not session_meta", row.Type)
+		return "", "", fmt.Errorf("%w: first row type %q is not session_meta", vendors.ErrInvalidData, row.Type)
 	}
 	if id == "" {
-		return "", "", fmt.Errorf("rollout filename has no session ID")
+		return "", "", fmt.Errorf("%w: rollout filename has no session ID", vendors.ErrInvalidData)
 	}
 	if row.Payload.ID != id {
-		return "", "", fmt.Errorf("header session ID %q does not match filename ID %q", row.Payload.ID, id)
+		return "", "", fmt.Errorf(
+			"%w: header session ID %q does not match filename ID %q",
+			vendors.ErrInvalidData, row.Payload.ID, id,
+		)
 	}
 	return id, row.Payload.ParentThreadID, nil
 }

--- a/collector/internal/vendors/codex/discovery_test.go
+++ b/collector/internal/vendors/codex/discovery_test.go
@@ -1,0 +1,24 @@
+package codex
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/centauri-ai/coslash/collector/internal/vendors"
+)
+
+func TestReadHeaderSourceMarksInvalidHeaderData(t *testing.T) {
+	path := filepath.Join(
+		t.TempDir(),
+		"rollout-2026-08-31T12-00-00-01234567-89ab-cdef-0123-456789abcdef.jsonl",
+	)
+	if err := os.WriteFile(path, []byte(`{"type":"event_msg"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := readHeaderSource(vendors.LocalReadSource, path)
+	if !errors.Is(err, vendors.ErrInvalidData) {
+		t.Fatalf("readHeaderSource error=%v, want invalid transcript data", err)
+	}
+}

--- a/collector/internal/vendors/readsource.go
+++ b/collector/internal/vendors/readsource.go
@@ -5,12 +5,16 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
 )
+
+// ErrInvalidData marks transcript content that cannot be parsed or validated.
+var ErrInvalidData = errors.New("invalid transcript data")
 
 func FingerprintSourceFiles(
 	source ReadSource,
@@ -220,7 +224,7 @@ func ParseJSONLSource[T any](source ReadSource, path string) ([]T, error) {
 			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 				break
 			}
-			return nil, err
+			return nil, fmt.Errorf("%w: %w", ErrInvalidData, err)
 		}
 		records = append(records, record)
 	}

--- a/frontend/src/pages/coslash/hooks/use-sessions.test.ts
+++ b/frontend/src/pages/coslash/hooks/use-sessions.test.ts
@@ -73,9 +73,17 @@ describe('decodeSessionsResponse', () => {
     expect(decodeSessionsResponse({ sessions, machines })).toEqual({ sessions, machines });
   });
 
+  it('treats a null or missing sessions list as empty', () => {
+    const machines = [{ sourceId: 'local', label: 'This Mac', state: 'ok', complete: true }];
+    expect(decodeSessionsResponse({ sessions: null, machines })).toEqual({ sessions: [], machines });
+    expect(decodeSessionsResponse({ machines })).toEqual({ sessions: [], machines });
+  });
+
   it('rejects invalid bodies and unknown machine enums', () => {
-    expect(() => decodeSessionsResponse({ machines: [] })).toThrow('Invalid sessions response');
     expect(() => decodeSessionsResponse(null)).toThrow('Invalid sessions response');
+    expect(() => decodeSessionsResponse({ sessions: 'nope', machines: [] })).toThrow(
+      'Invalid sessions response',
+    );
     expect(() =>
       decodeSessionsResponse({
         sessions: [],

--- a/frontend/src/pages/coslash/hooks/use-sessions.ts
+++ b/frontend/src/pages/coslash/hooks/use-sessions.ts
@@ -49,14 +49,24 @@ export function decodeSessionsResponse(body: unknown): SessionsPayload {
     throw new Error('Invalid sessions response');
   }
   const sessions = (body as { sessions?: unknown }).sessions;
+  if (sessions == null) {
+    return {
+      sessions: [],
+      machines: machinesFromBody(body),
+    };
+  }
   if (!Array.isArray(sessions)) {
     throw new Error('Invalid sessions response');
   }
-  const machinesRaw = (body as { machines?: unknown }).machines;
   return {
     sessions: sessions.map((session) => withLocalSourceDefaults(session as Session)),
-    machines: machinesRaw === undefined ? [] : decodeMachineFacts(machinesRaw),
+    machines: machinesFromBody(body),
   };
+}
+
+function machinesFromBody(body: object): MachineFact[] {
+  const machinesRaw = (body as { machines?: unknown }).machines;
+  return machinesRaw === undefined ? [] : decodeMachineFacts(machinesRaw);
 }
 
 /** Independent local/remote cutoffs; omit local `since` for Hub all-history without widening remote. */


### PR DESCRIPTION
## Context

This PR fixes two separate bugs that made remote/empty session views look broken. Same fixes as https://github.com/centauri-ai/coslash/pull/128, ported onto `test/observability` so the testing branch keeps observability logging and gets the product fixes.

## Problems solved

### #1 — Remote SSH refresh dropped good sessions and reconnect-looped

A large Claude scan could use most of the shared SFTP deadline, Codex then failed, and coSlash discarded even the Claude sessions it had already loaded. With no cache, every `/api/sessions` poll started another full scan, so the UI stayed empty or stuck on “connecting.”

**Fix:** Cache and show partial results when only one agent fails; back off limited retries; collect Claude and Codex in parallel; raise the SFTP deadline to 3 minutes; classify deadline cancellations as `refresh_timeout`.

### #2 — Empty time windows looked like an API failure

When “This week” (or any window) matched **zero** sessions, source-aware `/api/sessions` left `sessions` as Go `nil`, which JSON-encoded as `sessions: null`. The UI rejected that and showed “CoSlash couldn’t load sessions from the API” instead of the empty state.

**Fix:** Always return `sessions: []` when empty, and treat `null`/missing `sessions` as an empty list in the client.

## Changes

- Publish limited / `partial_agent_data` snapshots instead of dropping them
- Retry backoff on limited refreshes (no immediate rescan loop)
- Parallel Claude ∥ Codex remote collect on one SFTP session (keeps `remote.collect` observe lines)
- 3-minute SFTP deadline; clearer timeout vs invalid-data classification
- Empty session lists encode and decode as `[]`, not `null`

## Test

- `cd collector && go test ./internal/remote/ ./cmd/coslash/ -count=1` — passed
- `cd frontend && npm test -- --run src/pages/coslash/hooks/use-sessions.test.ts` — passed
- Manual: Not run against a live remote host in this change

Made with [Cursor](https://cursor.com)