### PR TITLE
fix: fail fast when Go or npm is missing for make release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ make release
 ./bin/coslash
 ```
 
-`make release` checks for `go` and `npm` before building. If either is missing, install the toolchain or use a release archive / Homebrew install.
+`make release` checks Go and Node versions before building. If either is missing or unsupported, install the toolchain or use a release archive / Homebrew install.
 
 For UI development, run the API and Vite separately:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ The Go collector and local API live in `collector/`; the React, Vite, and Tailwi
 
 ## Develop
 
-Requires Go 1.26+ and Node 24+.
+Building from source requires **Go 1.26+** and **Node 24+** (see `collector/go.mod` and `frontend/.nvmrc`). End users should install a prebuilt binary instead; see the [README Install section](../README.md#install).
 
 Build the embedded production binary:
 
@@ -25,6 +25,8 @@ cd collector
 make release
 ./bin/coslash
 ```
+
+`make release` checks for `go` and `npm` before building. If either is missing, install the toolchain or use a release archive / Homebrew install.
 
 For UI development, run the API and Vite separately:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ The Go collector and local API live in `collector/`; the React, Vite, and Tailwi
 
 ## Develop
 
-Building from source requires **Go 1.26+** and **Node 24+** (see `collector/go.mod` and `frontend/.nvmrc`). End users should install a prebuilt binary instead; see the [README Install section](../README.md#install).
+Building from source requires **Go 1.26+** and **Node 24+** (see `collector/go.mod` and `frontend/.nvmrc`). End users should install a prebuilt binary instead; see the [README Install section](README.md#install).
 
 Build the embedded production binary:
 

--- a/README.md
+++ b/README.md
@@ -243,13 +243,17 @@ Read [Data and privacy](docs/data-and-privacy.md) before pointing coSlash at sen
 
 ## Develop
 
-Requires Go 1.26+ and Node 24+. The Go collector and local API live in `collector/`; the React, Vite, and Tailwind UI lives in `frontend/`.
+Building from source requires **Go 1.26+** and **Node 24+** (see `collector/go.mod` and `frontend/.nvmrc`). End users do not need these tools — use [Install](#install) above for a prebuilt binary.
+
+The Go collector and local API live in `collector/`; the React, Vite, and Tailwind UI lives in `frontend/`.
 
 ```sh
 cd collector
 make release
 ./bin/coslash
 ```
+
+If `make release` reports a missing `go` or `npm` command, install the toolchain first or switch to the curl/Homebrew install path.
 
 See [Contributing](CONTRIBUTING.md) for the development loop and checks.
 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ make release
 ./bin/coslash
 ```
 
-If `make release` reports a missing `go` or `npm` command, install the toolchain first or switch to the curl/Homebrew install path.
+If `make release` reports a missing or unsupported Go or Node version, install the toolchain first or switch to the curl/Homebrew install path.
 
 See [Contributing](CONTRIBUTING.md) for the development loop and checks.
 

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -18,6 +18,7 @@ LITELLM_URL := https://raw.githubusercontent.com/BerriAI/litellm/main/model_pric
 OPENCODE_MODELS_URL := https://models.opencode.ai/api.json
 GO_REQUIRED := $(shell sed -n 's/^go //p' go.mod)
 NODE_REQUIRED := $(shell tr -d 'v\n' < $(FRONTEND)/.nvmrc)
+VERSION_AT_LEAST = awk -v actual="$(1)" -v required="$(2)" 'BEGIN { if (actual !~ /^[0-9]+(\.[0-9]+)*$$/ || required !~ /^[0-9]+(\.[0-9]+)*$$/) exit 1; actual_count = split(actual, actual_parts, "."); required_count = split(required, required_parts, "."); count = actual_count > required_count ? actual_count : required_count; for (i = 1; i <= count; i++) { actual_part = i <= actual_count ? actual_parts[i] + 0 : 0; required_part = i <= required_count ? required_parts[i] + 0 : 0; if (actual_part > required_part) exit 0; if (actual_part < required_part) exit 1 } }'
 
 .PHONY: build run test check tidy clean release stage unstage smoke smoke-dev dist models check-go check-node \
 	helper helper-dist helper-assets test-embedded-helpers
@@ -29,10 +30,24 @@ check-go:
 		echo "To install a prebuilt binary instead, see the Install section in README.md."; \
 		exit 1; \
 	}
+	@installed=$$(go version | sed -n 's/^go version go\([0-9][0-9.]*\).*/\1/p'); \
+	$(call VERSION_AT_LEAST,$$installed,$(GO_REQUIRED)) || { \
+		echo "error: Go $$installed is unsupported; Go $(GO_REQUIRED)+ is required to build coSlash from source."; \
+		echo "Install Go from https://go.dev/dl/ or run: brew install go"; \
+		echo "To install a prebuilt binary instead, see the Install section in README.md."; \
+		exit 1; \
+	}
 
 check-node:
-	@command -v npm >/dev/null 2>&1 || { \
-		echo "error: npm (Node $(NODE_REQUIRED)+) is required to build the frontend."; \
+	@command -v node >/dev/null 2>&1 && command -v npm >/dev/null 2>&1 || { \
+		echo "error: Node $(NODE_REQUIRED)+ and npm are required to build the frontend."; \
+		echo "Install Node from https://nodejs.org/ or run: brew install node"; \
+		echo "To install a prebuilt binary instead, see the Install section in README.md."; \
+		exit 1; \
+	}
+	@installed=$$(node --version | sed -n 's/^v\([0-9][0-9.]*\).*/\1/p'); \
+	$(call VERSION_AT_LEAST,$$installed,$(NODE_REQUIRED)) || { \
+		echo "error: Node $$installed is unsupported; Node $(NODE_REQUIRED)+ is required to build the frontend."; \
 		echo "Install Node from https://nodejs.org/ or run: brew install node"; \
 		echo "To install a prebuilt binary instead, see the Install section in README.md."; \
 		exit 1; \

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -16,17 +16,35 @@ EMBEDDED_LDFLAGS := -s -w -X main.version=$(VERSION) -X github.com/centauri-ai/c
 MODELS := internal/session/models.json
 LITELLM_URL := https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json
 OPENCODE_MODELS_URL := https://models.opencode.ai/api.json
+GO_REQUIRED := $(shell sed -n 's/^go //p' go.mod)
+NODE_REQUIRED := $(shell tr -d 'v\n' < $(FRONTEND)/.nvmrc)
 
-.PHONY: build run test check tidy clean release stage unstage smoke smoke-dev dist models \
+.PHONY: build run test check tidy clean release stage unstage smoke smoke-dev dist models check-go check-node \
 	helper helper-dist helper-assets test-embedded-helpers
 
-release: stage helper-assets
+check-go:
+	@command -v go >/dev/null 2>&1 || { \
+		echo "error: Go $(GO_REQUIRED)+ is required to build coSlash from source."; \
+		echo "Install Go from https://go.dev/dl/ or run: brew install go"; \
+		echo "To install a prebuilt binary instead, see the Install section in README.md."; \
+		exit 1; \
+	}
+
+check-node:
+	@command -v npm >/dev/null 2>&1 || { \
+		echo "error: npm (Node $(NODE_REQUIRED)+) is required to build the frontend."; \
+		echo "Install Node from https://nodejs.org/ or run: brew install node"; \
+		echo "To install a prebuilt binary instead, see the Install section in README.md."; \
+		exit 1; \
+	}
+
+release: check-go check-node stage helper-assets
 	@set -eu; trap 'rm -rf $(HELPER_ASSETS)' EXIT; \
 		go build -tags embedded_helpers -ldflags '$(EMBEDDED_LDFLAGS)' -o bin/$(BINARY) $(PKG)
 	@echo "built bin/$(BINARY) $(VERSION)"
 
 # Go cannot embed $(FRONTEND)/dist directly, so copy it into the module first.
-stage:
+stage: check-node
 	npm --prefix $(FRONTEND) ci
 	npm --prefix $(FRONTEND) run build
 	@test -f $(FRONTEND)/dist/index.html || { \
@@ -37,7 +55,7 @@ stage:
 	touch $(STAGED)/.gitkeep
 
 # Cross-compile every shipped platform from one staged frontend build.
-dist: stage helper-assets
+dist: check-go check-node stage helper-assets
 	@test -f $(STAGED)/index.html || { \
 		echo "error: $(STAGED)/index.html is missing; refusing to package a binary with no frontend"; exit 1; }
 	rm -rf $(DIST)
@@ -104,19 +122,19 @@ unstage:
 	@find $(STAGED) -mindepth 1 ! -name .gitkeep -delete
 	@touch $(STAGED)/.gitkeep
 
-build: unstage helper-assets
+build: check-go unstage helper-assets
 	@set -eu; trap 'rm -rf $(HELPER_ASSETS)' EXIT; \
 		go build -tags embedded_helpers -ldflags '$(EMBEDDED_LDFLAGS)' -o bin/$(BINARY) $(PKG)
 
-run: unstage helper-assets
+run: check-go unstage helper-assets
 	@set -eu; trap 'rm -rf $(HELPER_ASSETS)' EXIT; \
 		go run -tags embedded_helpers -ldflags '$(EMBEDDED_LDFLAGS)' $(PKG) --no-open $(ARGS)
 
-test:
+test: check-go
 	go test ./...
 	$(MAKE) test-embedded-helpers
 
-check:
+check: check-go
 	@unformatted=$$(gofmt -l .); \
 		test -z "$$unformatted" || { echo "gofmt needed:"; echo "$$unformatted"; exit 1; }
 	go vet ./...
@@ -129,7 +147,7 @@ smoke:
 smoke-dev:
 	./scripts/smoke.sh bin/$(BINARY) bare
 
-tidy:
+tidy: check-go
 	go mod tidy
 
 # Rewrites the embedded model table from LiteLLM. The Models workflow runs this

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -45,6 +45,14 @@ A port conflict is reported in the terminal. Stop the other process or run:
 coslash --port 8888
 ```
 
+## Building from source fails
+
+`make release` in `collector/` needs both Go and Node installed. It checks for them before building and prints install hints if either is missing.
+
+- **End users** should not build from source. Install a prebuilt binary with `curl -fsSL https://coslash.io/install.sh | bash`, Homebrew, or a release archive (see the README Install section).
+- **Developers** need Go 1.26+ (`brew install go` or https://go.dev/dl/) and Node 24+ (`brew install node` or https://nodejs.org/). Versions are pinned in `collector/go.mod` and `frontend/.nvmrc`.
+- If the binary starts but the UI is missing, it was built with `make build` instead of `make release`. Rebuild with `make release` so the frontend is embedded.
+
 ## Synthesis does not appear
 
 Confirm that synthesis is enabled in Settings and that the selected CLI is installed, authenticated, and supports the selected model. Short sessions may not be eligible. Storage errors, timeouts, and recent failures also prevent a result; opening the inspector surfaces the current error.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -47,7 +47,7 @@ coslash --port 8888
 
 ## Building from source fails
 
-`make release` in `collector/` needs both Go and Node installed. It checks for them before building and prints install hints if either is missing.
+`make release` in `collector/` needs supported Go and Node versions. It checks them before building and prints install hints if either is missing or unsupported.
 
 - **End users** should not build from source. Install a prebuilt binary with `curl -fsSL https://coslash.io/install.sh | bash`, Homebrew, or a release archive (see the README Install section).
 - **Developers** need Go 1.26+ (`brew install go` or https://go.dev/dl/) and Node 24+ (`brew install node` or https://nodejs.org/). Versions are pinned in `collector/go.mod` and `frontend/.nvmrc`.


### PR DESCRIPTION
## Summary
- Add `check-go` and `check-node` Makefile prerequisites so `make release` fails immediately with install hints instead of after the frontend build
- Clarify in README and CONTRIBUTING that building from source requires Go and Node, while end users should use the prebuilt install paths
- Add a troubleshooting section for source-build failures

## Context
A customer hit `go: not found` after running `make release` without Go installed. The build spent time on `npm ci`/`npm run build` first, then failed with an unhelpful error.

## Test plan
- [x] Verified `make release` without Go in PATH fails immediately with the new error message
- [ ] CI release job passes unchanged (toolchain already present in Actions)


Made with [Cursor](https://cursor.com)