### PR TITLE
Improve timeline defaults, filter persistence, and debrief readability

### DIFF
--- a/frontend/src/pages/coslash/CoslashPage.tsx
+++ b/frontend/src/pages/coslash/CoslashPage.tsx
@@ -26,7 +26,6 @@ import {
   AgentVendorFilterTabMenu,
   TimeWindowFilterTabMenu,
   ViewingModeTabMenu,
-  type AgentVendor,
   type ViewMode,
 } from '@/pages/coslash/CoslashTabMenus';
 import { loadHubDestination } from '@/pages/coslash/features/sharing/api';
@@ -39,6 +38,11 @@ import { ShareToHubDialog } from '@/pages/coslash/features/sharing/ShareToHubDia
 import { useDiagnostics } from '@/pages/coslash/hooks/use-diagnostics';
 import { useSessions } from '@/pages/coslash/hooks/use-sessions';
 import { useSettings } from '@/pages/coslash/hooks/use-settings';
+import {
+  loadBoardFilters,
+  saveBoardFilters,
+  vendorsForFilterMenu,
+} from '@/pages/coslash/lib/board-filters';
 import type { Diagnostics } from '@/pages/coslash/lib/diagnostics';
 import { formatEstimatedCost } from '@/pages/coslash/lib/format';
 import {
@@ -296,8 +300,8 @@ function CoslashContent({
 }
 
 export function CoslashPage() {
-  const [vendor, setVendor] = useState<AgentVendor>('all');
-  const [timeWindow, setTimeWindow] = useState<TimeWindow>('week');
+  const [vendor, setVendor] = useState(() => loadBoardFilters().vendor);
+  const [timeWindow, setTimeWindow] = useState(() => loadBoardFilters().timeWindow);
   const shareParams = new URLSearchParams(window.location.search);
   const shareFixtureEnabled = shareParams.get('team-share') === '1';
   const [hubDestination, setHubDestination] = useState<DestinationResult | null>(null);
@@ -336,7 +340,7 @@ export function CoslashPage() {
       ),
     [sessions, shareFixtureEnabled],
   );
-  const sessionVendors = getSessionVendors(sessions);
+  const sessionVendors = vendorsForFilterMenu(getSessionVendors(sessions), vendor);
   const configuredRemote = remoteConfigured(machines);
   const remoteHost = remoteMachine(machines);
   const showHostStrip = hostStripVisible(remoteHost);
@@ -361,8 +365,8 @@ export function CoslashPage() {
     if (settingsState.response) setTheme(settingsState.response.settings.appearance.theme);
   }, [settingsState.response]);
   useEffect(() => {
-    if (vendor !== 'all' && !sessions.some((session) => session.agent === vendor)) setVendor('all');
-  }, [sessions, vendor]);
+    saveBoardFilters({ vendor, timeWindow });
+  }, [vendor, timeWindow]);
   // Held by source-aware key, not by value: the inspector must render the freshest
   // record each refresh, and a stored object would freeze at click time. Looked up
   // from the unfiltered list so filters never close an open inspector.

--- a/frontend/src/pages/coslash/CoslashPage.tsx
+++ b/frontend/src/pages/coslash/CoslashPage.tsx
@@ -38,11 +38,7 @@ import { ShareToHubDialog } from '@/pages/coslash/features/sharing/ShareToHubDia
 import { useDiagnostics } from '@/pages/coslash/hooks/use-diagnostics';
 import { useSessions } from '@/pages/coslash/hooks/use-sessions';
 import { useSettings } from '@/pages/coslash/hooks/use-settings';
-import {
-  loadBoardFilters,
-  saveBoardFilters,
-  vendorsForFilterMenu,
-} from '@/pages/coslash/lib/board-filters';
+import { loadBoardFilters, saveBoardFilters, vendorsForFilterMenu } from '@/pages/coslash/lib/board-filters';
 import type { Diagnostics } from '@/pages/coslash/lib/diagnostics';
 import { formatEstimatedCost } from '@/pages/coslash/lib/format';
 import {

--- a/frontend/src/pages/coslash/CoslashTabMenus.tsx
+++ b/frontend/src/pages/coslash/CoslashTabMenus.tsx
@@ -1,9 +1,10 @@
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { type AgentVendor } from '@/pages/coslash/lib/board-filters';
 import { assertOneOf } from '@/pages/coslash/lib/narrow';
 import { getVendor, VENDOR_KEYS, type VendorKey } from '@/pages/coslash/lib/session';
 import { TIME_WINDOW_VALUES, TIME_WINDOWS, type TimeWindow } from '@/pages/coslash/lib/time-window';
 
-export type AgentVendor = 'all' | VendorKey;
+export type { AgentVendor };
 export type ViewMode = 'list' | 'board';
 
 const AGENT_VENDORS = ['all', ...VENDOR_KEYS] as const satisfies readonly AgentVendor[];

--- a/frontend/src/pages/coslash/components/SessionInspector.tsx
+++ b/frontend/src/pages/coslash/components/SessionInspector.tsx
@@ -34,6 +34,12 @@ import { useLaunchTerminal } from '@/pages/coslash/hooks/use-launch-terminal';
 import { synthesisRequestPath, useFileDiff, type FileSelection } from '@/pages/coslash/hooks/use-sessions';
 import { ApiAuthenticationError, apiFetch } from '@/pages/coslash/lib/api';
 import {
+  blocksFromTexts,
+  collapseDebriefBlocks,
+  parseDebriefText,
+  type DebriefBlock,
+} from '@/pages/coslash/lib/debrief-text';
+import {
   digestDateKey,
   formatDigestDateDivider,
   formatDigestDateRange,
@@ -44,12 +50,6 @@ import {
   formatTokens,
 } from '@/pages/coslash/lib/format';
 import { handoffBrief } from '@/pages/coslash/lib/handoff';
-import {
-  blocksFromTexts,
-  collapseDebriefBlocks,
-  parseDebriefText,
-  type DebriefBlock,
-} from '@/pages/coslash/lib/debrief-text';
 import { teamPreviewEnabled } from '@/pages/coslash/lib/preview';
 import {
   boardStatusKey,
@@ -470,11 +470,7 @@ function RecapSection({ detail }: { detail: SessionDetail }) {
           synthesisPlaceholder
         ) : (
           <div className="pt-1">
-            <DebriefProse
-              blocks={outcome ? parseDebriefText(outcome) : []}
-              empty="—"
-              tone="outcome"
-            />
+            <DebriefProse blocks={outcome ? parseDebriefText(outcome) : []} empty="—" tone="outcome" />
           </div>
         )}
         <div className="text-muted-foreground pt-3 text-xs">KEY DECISIONS</div>
@@ -564,7 +560,7 @@ function DebriefBlocks({ blocks, tone }: { blocks: DebriefBlock[]; tone: 'goal' 
               className={cn('flex flex-col gap-1.5 text-xs', {
                 'list-decimal pl-4': block.ordered,
                 'list-none': !block.ordered,
-                italic: tone === 'goal',
+                'italic': tone === 'goal',
               })}
             >
               {block.items.map((item, itemIndex) => (

--- a/frontend/src/pages/coslash/components/SessionInspector.tsx
+++ b/frontend/src/pages/coslash/components/SessionInspector.tsx
@@ -462,7 +462,7 @@ function RecapSection({ detail }: { detail: SessionDetail }) {
           </Badge>
         </div>
         <div className="pt-2">
-          <DebriefProse blocks={blocksFromTexts(goal.texts)} tone="goal" />
+          <DebriefProse key={`${sessionKey(detail)}:goal`} blocks={blocksFromTexts(goal.texts)} tone="goal" />
         </div>
         <div className="border-b pt-3" />
         <div className="text-muted-foreground pt-3 text-xs">OUTCOME</div>
@@ -470,7 +470,12 @@ function RecapSection({ detail }: { detail: SessionDetail }) {
           synthesisPlaceholder
         ) : (
           <div className="pt-1">
-            <DebriefProse blocks={outcome ? parseDebriefText(outcome) : []} empty="—" tone="outcome" />
+            <DebriefProse
+              key={`${sessionKey(detail)}:outcome`}
+              blocks={outcome ? parseDebriefText(outcome) : []}
+              empty="—"
+              tone="outcome"
+            />
           </div>
         )}
         <div className="text-muted-foreground pt-3 text-xs">KEY DECISIONS</div>
@@ -553,25 +558,36 @@ function DebriefBlocks({ blocks, tone }: { blocks: DebriefBlock[]; tone: 'goal' 
           );
         }
         if (block.kind === 'list') {
-          const ListTag = block.ordered ? 'ol' : 'ul';
+          if (block.ordered) {
+            return (
+              <ol
+                key={`l-${index}`}
+                className={cn('list-decimal space-y-1.5 pl-4 text-xs', {
+                  italic: tone === 'goal',
+                })}
+              >
+                {block.items.map((item, itemIndex) => (
+                  <li key={`${index}-${itemIndex}`} className="leading-relaxed">
+                    {item}
+                  </li>
+                ))}
+              </ol>
+            );
+          }
           return (
-            <ListTag
+            <ul
               key={`l-${index}`}
-              className={cn('flex flex-col gap-1.5 text-xs', {
-                'list-decimal pl-4': block.ordered,
-                'list-none': !block.ordered,
-                'italic': tone === 'goal',
+              className={cn('flex list-none flex-col gap-1.5 text-xs', {
+                italic: tone === 'goal',
               })}
             >
               {block.items.map((item, itemIndex) => (
                 <li key={`${index}-${itemIndex}`} className="flex items-start gap-2">
-                  {!block.ordered && (
-                    <span className="bg-muted-foreground mt-1.5 size-1 shrink-0 rounded-full" />
-                  )}
+                  <span className="bg-muted-foreground mt-1.5 size-1 shrink-0 rounded-full" />
                   <span className="min-w-0 flex-1 leading-relaxed">{item}</span>
                 </li>
               ))}
-            </ListTag>
+            </ul>
           );
         }
         return (

--- a/frontend/src/pages/coslash/components/SessionInspector.tsx
+++ b/frontend/src/pages/coslash/components/SessionInspector.tsx
@@ -44,6 +44,12 @@ import {
   formatTokens,
 } from '@/pages/coslash/lib/format';
 import { handoffBrief } from '@/pages/coslash/lib/handoff';
+import {
+  blocksFromTexts,
+  collapseDebriefBlocks,
+  parseDebriefText,
+  type DebriefBlock,
+} from '@/pages/coslash/lib/debrief-text';
 import { teamPreviewEnabled } from '@/pages/coslash/lib/preview';
 import {
   boardStatusKey,
@@ -438,6 +444,7 @@ function RecapSection({ detail }: { detail: SessionDetail }) {
       <span>Synthesizing…</span>
     </div>
   );
+  const outcome = getSessionOutcome(detail);
 
   return (
     <div>
@@ -454,24 +461,21 @@ function RecapSection({ detail }: { detail: SessionDetail }) {
             {goalSourceLabel(goal.source)}
           </Badge>
         </div>
-        {goal.texts.length === 1 ? (
-          <div className="line-clamp-4 pt-2 text-xs italic">{goal.texts[0]}</div>
-        ) : (
-          <div className="flex flex-col gap-1 pt-2">
-            {goal.texts.map((text) => (
-              <div key={text} className="flex items-start gap-2 text-xs italic">
-                <span className="bg-muted-foreground mt-1 size-1 shrink-0 rounded-full" />
-                <span className="line-clamp-2">{text}</span>
-              </div>
-            ))}
-          </div>
-        )}
+        <div className="pt-2">
+          <DebriefProse blocks={blocksFromTexts(goal.texts)} tone="goal" />
+        </div>
         <div className="border-b pt-3" />
         <div className="text-muted-foreground pt-3 text-xs">OUTCOME</div>
         {synthesizing ? (
           synthesisPlaceholder
         ) : (
-          <div className="pt-1 text-xs">{getSessionOutcome(detail) ?? '—'}</div>
+          <div className="pt-1">
+            <DebriefProse
+              blocks={outcome ? parseDebriefText(outcome) : []}
+              empty="—"
+              tone="outcome"
+            />
+          </div>
         )}
         <div className="text-muted-foreground pt-3 text-xs">KEY DECISIONS</div>
         {synthesizing ? (
@@ -493,9 +497,105 @@ function RecapSection({ detail }: { detail: SessionDetail }) {
   );
 }
 
+const DEBRIEF_PREVIEW_UNITS = 3;
+
+function DebriefProse({
+  blocks,
+  empty = '—',
+  tone,
+}: {
+  blocks: DebriefBlock[];
+  empty?: string;
+  tone: 'goal' | 'outcome';
+}) {
+  const [expanded, setExpanded] = useState(false);
+  if (blocks.length === 0) return <div className="text-xs">{empty}</div>;
+
+  const preview = collapseDebriefBlocks(blocks, DEBRIEF_PREVIEW_UNITS);
+  const canExpand = preview.truncated;
+  const shown = expanded ? blocks : preview.blocks;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div
+        key={expanded ? 'full' : 'preview'}
+        className={cn('border-border border-l-2 pl-3', {
+          'border-l-brand/40': tone === 'goal',
+          'border-l-recap/40': tone === 'outcome',
+        })}
+      >
+        <DebriefBlocks blocks={shown} tone={tone} />
+      </div>
+      {canExpand && (
+        <div
+          className="text-brand flex w-fit cursor-pointer items-center gap-1 text-xs select-none"
+          onClick={() => setExpanded((value) => !value)}
+        >
+          {expanded ? <ChevronDownIcon className="size-3" /> : <ChevronRightIcon className="size-3" />}
+          <span>
+            {expanded
+              ? 'show less'
+              : preview.hiddenCount > 0
+                ? `show full · ${preview.hiddenCount} more`
+                : 'show full'}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DebriefBlocks({ blocks, tone }: { blocks: DebriefBlock[]; tone: 'goal' | 'outcome' }) {
+  return (
+    <div className="flex flex-col gap-2">
+      {blocks.map((block, index) => {
+        if (block.kind === 'heading') {
+          return (
+            <div key={`h-${index}`} className="text-xs font-semibold tracking-wide">
+              {block.text}
+            </div>
+          );
+        }
+        if (block.kind === 'list') {
+          const ListTag = block.ordered ? 'ol' : 'ul';
+          return (
+            <ListTag
+              key={`l-${index}`}
+              className={cn('flex flex-col gap-1.5 text-xs', {
+                'list-decimal pl-4': block.ordered,
+                'list-none': !block.ordered,
+                italic: tone === 'goal',
+              })}
+            >
+              {block.items.map((item, itemIndex) => (
+                <li key={`${index}-${itemIndex}`} className="flex items-start gap-2">
+                  {!block.ordered && (
+                    <span className="bg-muted-foreground mt-1.5 size-1 shrink-0 rounded-full" />
+                  )}
+                  <span className="min-w-0 flex-1 leading-relaxed">{item}</span>
+                </li>
+              ))}
+            </ListTag>
+          );
+        }
+        return (
+          <p
+            key={`p-${index}`}
+            className={cn('text-xs leading-relaxed', {
+              italic: tone === 'goal',
+            })}
+          >
+            {block.text}
+          </p>
+        );
+      })}
+    </div>
+  );
+}
+
 type DigestCategory = DigestEntry['category'];
 
-const DEFAULT_HIDDEN_CATEGORIES: DigestCategory[] = ['user', 'compaction'];
+const DEFAULT_HIDDEN_CATEGORIES: DigestCategory[] = [];
 
 const DIGEST_CATEGORIES: Record<DigestCategory, { label: string; fg: string; dot: string }> = {
   first_prompt: { label: 'FIRST PROMPT', fg: 'text-success-fg', dot: 'bg-success-fg' },

--- a/frontend/src/pages/coslash/lib/board-filters.test.ts
+++ b/frontend/src/pages/coslash/lib/board-filters.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_BOARD_FILTERS,
+  loadBoardFilters,
+  saveBoardFilters,
+  vendorsForFilterMenu,
+} from './board-filters';
+
+function memoryStorage(initial: Record<string, string> = {}) {
+  const data = { ...initial };
+  return {
+    getItem: (key: string) => data[key] ?? null,
+    setItem: (key: string, value: string) => {
+      data[key] = value;
+    },
+  };
+}
+
+describe('board filters', () => {
+  it('defaults when nothing is stored', () => {
+    expect(loadBoardFilters(memoryStorage())).toEqual(DEFAULT_BOARD_FILTERS);
+  });
+
+  it('round-trips vendor and timeframe', () => {
+    const storage = memoryStorage();
+    saveBoardFilters({ vendor: 'codex', timeWindow: 'all' }, storage);
+    expect(loadBoardFilters(storage)).toEqual({ vendor: 'codex', timeWindow: 'all' });
+  });
+
+  it('falls back on corrupt or unknown values', () => {
+    expect(loadBoardFilters(memoryStorage({ 'coslash.board-filters': '{' }))).toEqual(
+      DEFAULT_BOARD_FILTERS,
+    );
+    expect(
+      loadBoardFilters(
+        memoryStorage({ 'coslash.board-filters': JSON.stringify({ vendor: 'nope', timeWindow: 7 }) }),
+      ),
+    ).toEqual(DEFAULT_BOARD_FILTERS);
+  });
+
+  it('keeps a selected vendor visible when absent from results', () => {
+    expect(vendorsForFilterMenu(['claude'], 'codex')).toEqual(['claude', 'codex']);
+    expect(vendorsForFilterMenu(['claude'], 'claude')).toEqual(['claude']);
+    expect(vendorsForFilterMenu(['claude'], 'all')).toEqual(['claude']);
+  });
+});

--- a/frontend/src/pages/coslash/lib/board-filters.test.ts
+++ b/frontend/src/pages/coslash/lib/board-filters.test.ts
@@ -21,6 +21,24 @@ describe('board filters', () => {
     expect(loadBoardFilters(memoryStorage())).toEqual(DEFAULT_BOARD_FILTERS);
   });
 
+  it('falls back when the browser blocks session storage access', () => {
+    const original = Object.getOwnPropertyDescriptor(globalThis, 'sessionStorage');
+    Object.defineProperty(globalThis, 'sessionStorage', {
+      configurable: true,
+      get: () => {
+        throw new DOMException('Blocked by browser settings', 'SecurityError');
+      },
+    });
+
+    try {
+      expect(loadBoardFilters()).toEqual(DEFAULT_BOARD_FILTERS);
+      expect(() => saveBoardFilters(DEFAULT_BOARD_FILTERS)).not.toThrow();
+    } finally {
+      if (original) Object.defineProperty(globalThis, 'sessionStorage', original);
+      else delete (globalThis as { sessionStorage?: Storage }).sessionStorage;
+    }
+  });
+
   it('round-trips vendor and timeframe', () => {
     const storage = memoryStorage();
     saveBoardFilters({ vendor: 'codex', timeWindow: 'all' }, storage);

--- a/frontend/src/pages/coslash/lib/board-filters.test.ts
+++ b/frontend/src/pages/coslash/lib/board-filters.test.ts
@@ -28,9 +28,7 @@ describe('board filters', () => {
   });
 
   it('falls back on corrupt or unknown values', () => {
-    expect(loadBoardFilters(memoryStorage({ 'coslash.board-filters': '{' }))).toEqual(
-      DEFAULT_BOARD_FILTERS,
-    );
+    expect(loadBoardFilters(memoryStorage({ 'coslash.board-filters': '{' }))).toEqual(DEFAULT_BOARD_FILTERS);
     expect(
       loadBoardFilters(
         memoryStorage({ 'coslash.board-filters': JSON.stringify({ vendor: 'nope', timeWindow: 7 }) }),

--- a/frontend/src/pages/coslash/lib/board-filters.ts
+++ b/frontend/src/pages/coslash/lib/board-filters.ts
@@ -22,9 +22,9 @@ function oneOf<T extends string>(value: unknown, allowed: readonly T[], fallback
     : fallback;
 }
 
-export function loadBoardFilters(storage: Pick<Storage, 'getItem'> = sessionStorage): BoardFilters {
+export function loadBoardFilters(storage?: Pick<Storage, 'getItem'>): BoardFilters {
   try {
-    const raw = storage.getItem(STORAGE_KEY);
+    const raw = (storage ?? sessionStorage).getItem(STORAGE_KEY);
     if (raw == null) return DEFAULT_BOARD_FILTERS;
     const parsed: unknown = JSON.parse(raw);
     if (parsed == null || typeof parsed !== 'object') return DEFAULT_BOARD_FILTERS;
@@ -38,12 +38,9 @@ export function loadBoardFilters(storage: Pick<Storage, 'getItem'> = sessionStor
   }
 }
 
-export function saveBoardFilters(
-  filters: BoardFilters,
-  storage: Pick<Storage, 'setItem'> = sessionStorage,
-): void {
+export function saveBoardFilters(filters: BoardFilters, storage?: Pick<Storage, 'setItem'>): void {
   try {
-    storage.setItem(STORAGE_KEY, JSON.stringify(filters));
+    (storage ?? sessionStorage).setItem(STORAGE_KEY, JSON.stringify(filters));
   } catch {
     // Private mode / quota — filters still work for the current page life.
   }

--- a/frontend/src/pages/coslash/lib/board-filters.ts
+++ b/frontend/src/pages/coslash/lib/board-filters.ts
@@ -1,0 +1,59 @@
+import { VENDOR_KEYS, type VendorKey } from '@/pages/coslash/lib/session';
+import { TIME_WINDOW_VALUES, type TimeWindow } from '@/pages/coslash/lib/time-window';
+
+export type AgentVendor = 'all' | VendorKey;
+
+export type BoardFilters = {
+  vendor: AgentVendor;
+  timeWindow: TimeWindow;
+};
+
+const STORAGE_KEY = 'coslash.board-filters';
+const AGENT_VENDORS = ['all', ...VENDOR_KEYS] as const satisfies readonly AgentVendor[];
+
+export const DEFAULT_BOARD_FILTERS: BoardFilters = {
+  vendor: 'all',
+  timeWindow: 'week',
+};
+
+function oneOf<T extends string>(value: unknown, allowed: readonly T[], fallback: T): T {
+  return typeof value === 'string' && (allowed as readonly string[]).includes(value)
+    ? (value as T)
+    : fallback;
+}
+
+export function loadBoardFilters(storage: Pick<Storage, 'getItem'> = sessionStorage): BoardFilters {
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+    if (raw == null) return DEFAULT_BOARD_FILTERS;
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed == null || typeof parsed !== 'object') return DEFAULT_BOARD_FILTERS;
+    const record = parsed as Record<string, unknown>;
+    return {
+      vendor: oneOf(record.vendor, AGENT_VENDORS, DEFAULT_BOARD_FILTERS.vendor),
+      timeWindow: oneOf(record.timeWindow, TIME_WINDOW_VALUES, DEFAULT_BOARD_FILTERS.timeWindow),
+    };
+  } catch {
+    return DEFAULT_BOARD_FILTERS;
+  }
+}
+
+export function saveBoardFilters(
+  filters: BoardFilters,
+  storage: Pick<Storage, 'setItem'> = sessionStorage,
+): void {
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(filters));
+  } catch {
+    // Private mode / quota — filters still work for the current page life.
+  }
+}
+
+/** Keep a selected vendor tab mounted even when the current result set has none. */
+export function vendorsForFilterMenu(
+  present: readonly VendorKey[],
+  selected: AgentVendor,
+): VendorKey[] {
+  if (selected === 'all' || present.includes(selected)) return [...present];
+  return VENDOR_KEYS.filter((vendor) => present.includes(vendor) || vendor === selected);
+}

--- a/frontend/src/pages/coslash/lib/board-filters.ts
+++ b/frontend/src/pages/coslash/lib/board-filters.ts
@@ -50,10 +50,7 @@ export function saveBoardFilters(
 }
 
 /** Keep a selected vendor tab mounted even when the current result set has none. */
-export function vendorsForFilterMenu(
-  present: readonly VendorKey[],
-  selected: AgentVendor,
-): VendorKey[] {
+export function vendorsForFilterMenu(present: readonly VendorKey[], selected: AgentVendor): VendorKey[] {
   if (selected === 'all' || present.includes(selected)) return [...present];
   return VENDOR_KEYS.filter((vendor) => present.includes(vendor) || vendor === selected);
 }

--- a/frontend/src/pages/coslash/lib/debrief-text.test.ts
+++ b/frontend/src/pages/coslash/lib/debrief-text.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { blocksFromTexts, collapseDebriefBlocks, parseDebriefText, previewDebriefBlocks } from './debrief-text';
+import {
+  blocksFromTexts,
+  collapseDebriefBlocks,
+  parseDebriefText,
+  previewDebriefBlocks,
+} from './debrief-text';
 
 describe('parseDebriefText', () => {
   it('keeps plain prose as paragraphs', () => {

--- a/frontend/src/pages/coslash/lib/debrief-text.test.ts
+++ b/frontend/src/pages/coslash/lib/debrief-text.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { blocksFromTexts, collapseDebriefBlocks, parseDebriefText, previewDebriefBlocks } from './debrief-text';
+
+describe('parseDebriefText', () => {
+  it('keeps plain prose as paragraphs', () => {
+    expect(parseDebriefText('Understand the SSH problem.\n\nPropose a helper.')).toEqual([
+      { kind: 'paragraph', text: 'Understand the SSH problem.' },
+      { kind: 'paragraph', text: 'Propose a helper.' },
+    ]);
+  });
+
+  it('parses bullet and numbered lists', () => {
+    expect(
+      parseDebriefText(`Committed successfully.
+
+- Commit: abc
+- Pushed to origin
+
+1. First
+2. Second`),
+    ).toEqual([
+      { kind: 'paragraph', text: 'Committed successfully.' },
+      { kind: 'list', ordered: false, items: ['Commit: abc', 'Pushed to origin'] },
+      { kind: 'list', ordered: true, items: ['First', 'Second'] },
+    ]);
+  });
+
+  it('turns multiple goal texts into one list', () => {
+    expect(blocksFromTexts(['Diagnose SFTP cost', 'Design Linux helper'])).toEqual([
+      {
+        kind: 'list',
+        ordered: false,
+        items: ['Diagnose SFTP cost', 'Design Linux helper'],
+      },
+    ]);
+  });
+});
+
+describe('previewDebriefBlocks', () => {
+  it('bounds list items and reports what remains', () => {
+    const blocks = parseDebriefText(`Done.
+
+- one
+- two
+- three
+- four
+- five`);
+    expect(previewDebriefBlocks(blocks, 4)).toEqual({
+      blocks: [
+        { kind: 'paragraph', text: 'Done.' },
+        { kind: 'list', ordered: false, items: ['one', 'two', 'three'] },
+      ],
+      hiddenCount: 2,
+      truncated: true,
+    });
+  });
+});
+
+describe('collapseDebriefBlocks', () => {
+  it('shortens long paragraphs in the collapsed preview', () => {
+    const long = 'a'.repeat(200);
+    const collapsed = collapseDebriefBlocks([{ kind: 'paragraph', text: long }], 4, 160);
+    expect(collapsed.truncated).toBe(true);
+    expect(collapsed.blocks[0]).toEqual({
+      kind: 'paragraph',
+      text: `${'a'.repeat(159)}…`,
+    });
+  });
+});

--- a/frontend/src/pages/coslash/lib/debrief-text.test.ts
+++ b/frontend/src/pages/coslash/lib/debrief-text.test.ts
@@ -62,13 +62,22 @@ describe('previewDebriefBlocks', () => {
 });
 
 describe('collapseDebriefBlocks', () => {
-  it('shortens long paragraphs in the collapsed preview', () => {
+  it('shortens long text in every visible block type', () => {
     const long = 'a'.repeat(200);
-    const collapsed = collapseDebriefBlocks([{ kind: 'paragraph', text: long }], 4, 160);
+    const collapsed = collapseDebriefBlocks(
+      [
+        { kind: 'heading', text: long },
+        { kind: 'list', ordered: false, items: [long] },
+        { kind: 'paragraph', text: long },
+      ],
+      4,
+      160,
+    );
     expect(collapsed.truncated).toBe(true);
-    expect(collapsed.blocks[0]).toEqual({
-      kind: 'paragraph',
-      text: `${'a'.repeat(159)}…`,
-    });
+    expect(collapsed.blocks).toEqual([
+      { kind: 'heading', text: `${'a'.repeat(159)}…` },
+      { kind: 'list', ordered: false, items: [`${'a'.repeat(159)}…`] },
+      { kind: 'paragraph', text: `${'a'.repeat(159)}…` },
+    ]);
   });
 });

--- a/frontend/src/pages/coslash/lib/debrief-text.ts
+++ b/frontend/src/pages/coslash/lib/debrief-text.ts
@@ -78,7 +78,10 @@ export type DebriefPreview = {
 
 const DEFAULT_PREVIEW_UNITS = 4;
 
-function listPreview(block: Extract<DebriefBlock, { kind: 'list' }>, budget: number): {
+function listPreview(
+  block: Extract<DebriefBlock, { kind: 'list' }>,
+  budget: number,
+): {
   block: DebriefBlock;
   used: number;
   hidden: number;

--- a/frontend/src/pages/coslash/lib/debrief-text.ts
+++ b/frontend/src/pages/coslash/lib/debrief-text.ts
@@ -1,0 +1,151 @@
+export type DebriefBlock =
+  | { kind: 'paragraph'; text: string }
+  | { kind: 'list'; ordered: boolean; items: string[] }
+  | { kind: 'heading'; text: string };
+
+const LIST_ITEM = /^(?:[-*•]|\d+[.)])\s+(.*\S.*)$/;
+const HEADING = /^(#{1,3})\s+(.*\S.*)$/;
+
+/** Turn freeform goal/outcome text into paragraphs, lists, and headings when markers fit. */
+export function parseDebriefText(text: string): DebriefBlock[] {
+  const trimmed = text.trim();
+  if (!trimmed) return [];
+
+  const blocks: DebriefBlock[] = [];
+  let paragraph: string[] = [];
+  let list: { ordered: boolean; items: string[] } | null = null;
+
+  const flushParagraph = () => {
+    if (paragraph.length === 0) return;
+    blocks.push({ kind: 'paragraph', text: paragraph.join(' ').trim() });
+    paragraph = [];
+  };
+
+  const flushList = () => {
+    if (list == null || list.items.length === 0) return;
+    blocks.push({ kind: 'list', ordered: list.ordered, items: list.items });
+    list = null;
+  };
+
+  for (const rawLine of trimmed.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line === '') {
+      flushParagraph();
+      flushList();
+      continue;
+    }
+
+    const heading = line.match(HEADING);
+    if (heading) {
+      flushParagraph();
+      flushList();
+      blocks.push({ kind: 'heading', text: heading[2].trim() });
+      continue;
+    }
+
+    const item = line.match(LIST_ITEM);
+    if (item) {
+      flushParagraph();
+      const ordered = /^\d/.test(line);
+      if (list == null || list.ordered !== ordered) {
+        flushList();
+        list = { ordered, items: [] };
+      }
+      list.items.push(item[1].trim());
+      continue;
+    }
+
+    flushList();
+    paragraph.push(line);
+  }
+
+  flushParagraph();
+  flushList();
+  return blocks;
+}
+
+export function blocksFromTexts(texts: string[]): DebriefBlock[] {
+  if (texts.length === 0) return [];
+  if (texts.length === 1) return parseDebriefText(texts[0]);
+  return [{ kind: 'list', ordered: false, items: texts.map((text) => text.trim()).filter(Boolean) }];
+}
+
+export type DebriefPreview = {
+  blocks: DebriefBlock[];
+  hiddenCount: number;
+  truncated: boolean;
+};
+
+const DEFAULT_PREVIEW_UNITS = 4;
+
+function listPreview(block: Extract<DebriefBlock, { kind: 'list' }>, budget: number): {
+  block: DebriefBlock;
+  used: number;
+  hidden: number;
+} {
+  if (budget <= 0) return { block: { ...block, items: [] }, used: 0, hidden: block.items.length };
+  const items = block.items.slice(0, budget);
+  return {
+    block: { ...block, items },
+    used: items.length,
+    hidden: block.items.length - items.length,
+  };
+}
+
+/** Keep a bounded preview: each list item and each paragraph/heading costs one unit. */
+export function previewDebriefBlocks(
+  blocks: DebriefBlock[],
+  maxUnits = DEFAULT_PREVIEW_UNITS,
+): DebriefPreview {
+  if (blocks.length === 0) return { blocks: [], hiddenCount: 0, truncated: false };
+
+  const visible: DebriefBlock[] = [];
+  let budget = maxUnits;
+  let hidden = 0;
+
+  for (const block of blocks) {
+    if (budget <= 0) {
+      if (block.kind === 'list') hidden += block.items.length;
+      else hidden += 1;
+      continue;
+    }
+
+    if (block.kind === 'list') {
+      const next = listPreview(block, budget);
+      if (next.block.kind === 'list' && next.block.items.length > 0) visible.push(next.block);
+      budget -= next.used;
+      hidden += next.hidden;
+      continue;
+    }
+
+    visible.push(block);
+    budget -= 1;
+  }
+
+  return { blocks: visible, hiddenCount: hidden, truncated: hidden > 0 };
+}
+
+export const DEBRIEF_PARAGRAPH_PREVIEW_CHARS = 160;
+
+/** Collapse for display: bound block count and shorten long paragraphs in the source text. */
+export function collapseDebriefBlocks(
+  blocks: DebriefBlock[],
+  maxUnits = DEFAULT_PREVIEW_UNITS,
+  maxParagraphChars = DEBRIEF_PARAGRAPH_PREVIEW_CHARS,
+): DebriefPreview {
+  const preview = previewDebriefBlocks(blocks, maxUnits);
+  let shortened = false;
+  const collapsed = preview.blocks.map((block) => {
+    if (block.kind !== 'paragraph' || block.text.length <= maxParagraphChars) return block;
+    shortened = true;
+    return {
+      kind: 'paragraph' as const,
+      text: `${block.text.slice(0, Math.max(0, maxParagraphChars - 1)).trimEnd()}…`,
+    };
+  });
+  return {
+    blocks: collapsed,
+    hiddenCount: preview.hiddenCount,
+    truncated: preview.truncated || shortened,
+  };
+}

--- a/frontend/src/pages/coslash/lib/debrief-text.ts
+++ b/frontend/src/pages/coslash/lib/debrief-text.ts
@@ -128,23 +128,24 @@ export function previewDebriefBlocks(
   return { blocks: visible, hiddenCount: hidden, truncated: hidden > 0 };
 }
 
-export const DEBRIEF_PARAGRAPH_PREVIEW_CHARS = 160;
+export const DEBRIEF_PREVIEW_CHARS = 160;
 
-/** Collapse for display: bound block count and shorten long paragraphs in the source text. */
+/** Collapse for display: bound block count and shorten long text in the source text. */
 export function collapseDebriefBlocks(
   blocks: DebriefBlock[],
   maxUnits = DEFAULT_PREVIEW_UNITS,
-  maxParagraphChars = DEBRIEF_PARAGRAPH_PREVIEW_CHARS,
+  maxTextChars = DEBRIEF_PREVIEW_CHARS,
 ): DebriefPreview {
   const preview = previewDebriefBlocks(blocks, maxUnits);
   let shortened = false;
-  const collapsed = preview.blocks.map((block) => {
-    if (block.kind !== 'paragraph' || block.text.length <= maxParagraphChars) return block;
+  const shorten = (text: string) => {
+    if (text.length <= maxTextChars) return text;
     shortened = true;
-    return {
-      kind: 'paragraph' as const,
-      text: `${block.text.slice(0, Math.max(0, maxParagraphChars - 1)).trimEnd()}…`,
-    };
+    return `${text.slice(0, Math.max(0, maxTextChars - 1)).trimEnd()}…`;
+  };
+  const collapsed = preview.blocks.map((block) => {
+    if (block.kind === 'list') return { ...block, items: block.items.map(shorten) };
+    return { ...block, text: shorten(block.text) };
   });
   return {
     blocks: collapsed,


### PR DESCRIPTION
## Summary

- Default all timeline category chips on (first prompt, user turn, recap, todos, etc.) so key events are visible without toggling filters.
- Persist vendor and timeframe board filters in `sessionStorage`, and stop resetting vendor on refresh when that agent briefly has no sessions.
- Format debrief goal/outcome as readable paragraphs/bullets with an expandable preview; presentation-only, no collector or session-data changes.
- Reset debrief expand state when switching sessions, and keep ordered-list numbering visible (no flex on `ol`).

## Test plan
- [ ] Open a session inspector and confirm timeline chips (including USER TURN / TODOS when present) start selected
- [ ] Set vendor + timeframe, refresh the page, confirm both filters are restored
- [ ] Open a session with a long goal/outcome and confirm collapsed preview + **show full / show less** swaps real content
- [ ] Expand debrief on one session, switch to another without closing the sheet, confirm the new session starts collapsed
- [ ] Confirm numbered outcome/goal lists show `1. 2. 3.` markers
- [ ] Confirm session list payloads / summaries are unchanged aside from UI rendering

## UI screenshots

Board view:
<img width="1366" height="200" alt="board view" src="https://github.com/user-attachments/assets/e846a16e-b244-409a-bf3d-4a32ec4c5611" />

### Debrief formatting
<img width="580" height="210" alt="clipboard" src="https://github.com/user-attachments/assets/035d5e8b-4a7f-4df8-b91d-81c3d80d860a" />

### Timeline filters
<img width="580" height="85" alt="clipboard" src="https://github.com/user-attachments/assets/fff5630b-0c0e-4060-8198-751aa39fd6c8" />
