### PR TITLE
Integrate SSH monitoring in Machines and releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,20 @@ configuration. coSlash runs the system `ssh` client on the Mac, requests the
 host's SFTP subsystem, and parses Claude Code and Codex files locally. It may
 reuse an OpenSSH multiplexed connection through a control socket under
 `~/.coslash/ssh`; it does not edit your SSH config. The Linux host needs only
-its SSH server with SFTP enabled and agent files readable by the SSH user. Do
-not install or run coSlash on Linux.
+its SSH server with SFTP enabled and agent files readable by the SSH user.
+
+SFTP is the compatible fallback. After testing the connection, you can choose
+**Install helper**. That action asks for explicit consent before coSlash uploads
+the matching Linux collector embedded in the coSlash release into the SSH
+user's private `~/.coslash/helpers` directory. The app verifies its size,
+digest, platform, owner, and mode before execution. The helper reads only the
+supported agent paths and returns bounded, normalized facts; it has no root
+access, no network access, and does not run your agent CLI. Machines shows
+whether collection is using the helper or SFTP, including any stale or partial
+coverage. An incompatible, blocked, or failed helper never runs silently:
+coSlash keeps the SFTP fallback visible and offers repair or upgrade where
+available. Initial installation and every upgrade require separate consent;
+disabling a machine does not uninstall its helper.
 
 Remote v1 is monitoring-only. Cards, transcript-derived facts, costs, tokens,
 file-edit summaries, and **Copy handoff** are available. Resume, Start Fresh,

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -4,6 +4,7 @@ HELPER := coslash-helper
 HELPER_PKG := ./cmd/coslash-helper
 HELPER_PLATFORMS := linux/amd64 linux/arm64
 HELPER_DIST := dist/helper
+HELPER_ASSETS := internal/remote/helperassets
 FRONTEND := ../frontend
 STAGED := internal/web/dist
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
@@ -11,15 +12,17 @@ DIST := dist
 PLATFORMS := darwin/arm64 darwin/amd64
 ARGS :=
 LDFLAGS := -X main.version=$(VERSION)
+EMBEDDED_LDFLAGS := -s -w -X main.version=$(VERSION) -X github.com/centauri-ai/coslash/collector/internal/remote.embeddedHelperVersion=$(VERSION)
 MODELS := internal/session/models.json
 LITELLM_URL := https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json
 OPENCODE_MODELS_URL := https://models.opencode.ai/api.json
 
 .PHONY: build run test check tidy clean release stage unstage smoke smoke-dev dist models \
-	helper helper-dist
+	helper helper-dist helper-assets test-embedded-helpers
 
-release: stage
-	go build -ldflags "$(LDFLAGS)" -o bin/$(BINARY) $(PKG)
+release: stage helper-assets
+	@set -eu; trap 'rm -rf $(HELPER_ASSETS)' EXIT; \
+		go build -tags embedded_helpers -ldflags '$(EMBEDDED_LDFLAGS)' -o bin/$(BINARY) $(PKG)
 	@echo "built bin/$(BINARY) $(VERSION)"
 
 # Go cannot embed $(FRONTEND)/dist directly, so copy it into the module first.
@@ -34,17 +37,17 @@ stage:
 	touch $(STAGED)/.gitkeep
 
 # Cross-compile every shipped platform from one staged frontend build.
-dist: stage
+dist: stage helper-assets
 	@test -f $(STAGED)/index.html || { \
 		echo "error: $(STAGED)/index.html is missing; refusing to package a binary with no frontend"; exit 1; }
 	rm -rf $(DIST)
 	mkdir -p $(DIST)
-	@for platform in $(PLATFORMS); do \
+	@set -eu; trap 'rm -rf $(HELPER_ASSETS)' EXIT; for platform in $(PLATFORMS); do \
 		goos=$${platform%/*}; goarch=$${platform#*/}; \
 		stem=$(BINARY)_$(VERSION)_$${goos}_$${goarch}; \
 		mkdir -p $(DIST)/$$stem; \
 		CGO_ENABLED=0 GOOS=$$goos GOARCH=$$goarch \
-			go build -trimpath -ldflags '-s -w -X main.version=$(VERSION)' \
+			go build -trimpath -tags embedded_helpers -ldflags '$(EMBEDDED_LDFLAGS)' \
 			-o $(DIST)/$$stem/$(BINARY) $(PKG) || exit 1; \
 		cp ../LICENSE ../README.md $(DIST)/$$stem/; \
 		find $(DIST)/$$stem -exec touch -t 198001010000 {} +; \
@@ -57,6 +60,24 @@ dist: stage
 # The Linux collection helper, for local iteration on the host platform.
 helper:
 	CGO_ENABLED=0 go build -ldflags '-X main.build=$(VERSION)' -o bin/$(HELPER) $(HELPER_PKG)
+
+# Generated immediately before a tagged Coslash build. The release executable
+# embeds these exact bytes; the trap in every consumer removes them afterward.
+helper-assets:
+	rm -rf $(HELPER_ASSETS)
+	mkdir -p $(HELPER_ASSETS)
+	@for platform in $(HELPER_PLATFORMS); do \
+		goos=$${platform%/*}; goarch=$${platform#*/}; \
+		CGO_ENABLED=0 GOOS=$$goos GOARCH=$$goarch \
+			go build -trimpath -ldflags '-s -w -X main.build=$(VERSION)' \
+			-o $(HELPER_ASSETS)/$(HELPER)_$${goos}_$${goarch} $(HELPER_PKG) || exit 1; \
+	done
+
+test-embedded-helpers: helper-assets
+	@set -eu; trap 'rm -rf $(HELPER_ASSETS)' EXIT; \
+		go test -tags embedded_helpers \
+		-ldflags '-X github.com/centauri-ai/coslash/collector/internal/remote.embeddedHelperVersion=$(VERSION)' \
+		-run '^TestEmbeddedHelperReleaseProvider$$' ./internal/remote
 
 # Cross-compiles the shipped helper targets. Reproducible on purpose: -trimpath
 # and no CGO, so rebuilding one commit yields identical binaries and therefore
@@ -83,14 +104,17 @@ unstage:
 	@find $(STAGED) -mindepth 1 ! -name .gitkeep -delete
 	@touch $(STAGED)/.gitkeep
 
-build: unstage
-	go build -ldflags "$(LDFLAGS)" -o bin/$(BINARY) $(PKG)
+build: unstage helper-assets
+	@set -eu; trap 'rm -rf $(HELPER_ASSETS)' EXIT; \
+		go build -tags embedded_helpers -ldflags '$(EMBEDDED_LDFLAGS)' -o bin/$(BINARY) $(PKG)
 
-run: unstage
-	go run -ldflags "$(LDFLAGS)" $(PKG) --no-open $(ARGS)
+run: unstage helper-assets
+	@set -eu; trap 'rm -rf $(HELPER_ASSETS)' EXIT; \
+		go run -tags embedded_helpers -ldflags '$(EMBEDDED_LDFLAGS)' $(PKG) --no-open $(ARGS)
 
 test:
 	go test ./...
+	$(MAKE) test-embedded-helpers
 
 check:
 	@unformatted=$$(gofmt -l .); \

--- a/collector/cmd/coslash/api.go
+++ b/collector/cmd/coslash/api.go
@@ -380,6 +380,10 @@ func handleSaveSettings(
 		err = remoteManager.ValidateSettingsChangeWithOwnershipAction(config.Remote, ownershipAction)
 	}
 	if err != nil {
+		if errors.Is(err, remote.ErrHelperSetupInProgress) {
+			writeAPIError(w, http.StatusConflict, "remote_helper_setup_in_progress", "wait for helper setup to finish before changing this host")
+			return
+		}
 		if errors.Is(err, remote.ErrHelperOwnershipConflict) {
 			writeAPIError(w, http.StatusConflict, "remote_helper_ownership_conflict", "uninstall or explicitly leave the helper before changing this host")
 			return
@@ -418,6 +422,13 @@ func handleSaveSettings(
 	mgr.SetRunner(runner)
 	if err := remoteManager.ApplySettings(config.Remote); err != nil {
 		log.Printf("apply remote settings: %v", err)
+		if restoreErr := store.Save(previous); restoreErr != nil {
+			log.Printf("restore settings after remote apply failure: %v", restoreErr)
+		}
+		if errors.Is(err, remote.ErrHelperSetupInProgress) {
+			writeAPIError(w, http.StatusConflict, "remote_helper_setup_in_progress", "wait for helper setup to finish before changing this host")
+			return
+		}
 		http.Error(w, "could not apply remote settings", http.StatusInternalServerError)
 		return
 	}

--- a/collector/cmd/coslash/api.go
+++ b/collector/cmd/coslash/api.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -21,6 +23,41 @@ import (
 	"github.com/centauri-ai/coslash/collector/internal/synthesis"
 	"github.com/centauri-ai/coslash/collector/internal/vendors/opencode"
 )
+
+// decodeSettingsSave accepts the legacy bare settings document and the T05
+// envelope used when a settings replacement also has an explicit helper
+// ownership action. The action never becomes part of settings.json.
+func decodeSettingsSave(data []byte) (settings.Config, remote.OwnershipAction, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return settings.Config{}, "", err
+	}
+	rawSettings, enveloped := fields["settings"]
+	if !enveloped {
+		config, err := settings.Decode(data)
+		return config, remote.OwnershipActionNone, err
+	}
+	for key := range fields {
+		if key != "settings" && key != "remoteOwnershipAction" {
+			return settings.Config{}, "", errors.New("settings save contains unknown fields")
+		}
+	}
+	var action string
+	if rawAction, ok := fields["remoteOwnershipAction"]; ok {
+		if err := json.Unmarshal(rawAction, &action); err != nil {
+			return settings.Config{}, "", errors.New("invalid remote ownership action")
+		}
+	}
+	config, err := settings.Decode(rawSettings)
+	if err != nil {
+		return settings.Config{}, "", err
+	}
+	parsed := remote.OwnershipAction(action)
+	if parsed != remote.OwnershipActionNone && parsed != remote.OwnershipActionRelease && parsed != remote.OwnershipActionUninstall {
+		return settings.Config{}, "", errors.New("invalid remote ownership action")
+	}
+	return config, parsed, nil
+}
 
 // /api/sessions → complete session records, optionally limited by an
 // epoch-millisecond activity cutoff before transcript parsing.
@@ -327,7 +364,7 @@ func handleSaveSettings(
 		)
 		return
 	}
-	config, err := settings.Decode(data)
+	config, ownershipAction, err := decodeSettingsSave(data)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -337,6 +374,24 @@ func handleSaveSettings(
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	if ownershipAction == remote.OwnershipActionNone {
+		err = remoteManager.ValidateSettingsChange(config.Remote)
+	} else {
+		err = remoteManager.ValidateSettingsChangeWithOwnershipAction(config.Remote, ownershipAction)
+	}
+	if err != nil {
+		if errors.Is(err, remote.ErrHelperOwnershipConflict) {
+			writeAPIError(w, http.StatusConflict, "remote_helper_ownership_conflict", "uninstall or explicitly leave the helper before changing this host")
+			return
+		}
+		if errors.Is(err, remote.ErrHelperOwnershipCorrupt) {
+			writeAPIError(w, http.StatusConflict, "remote_helper_ownership_corrupt", "helper ownership needs explicit recovery before changing this host")
+			return
+		}
+		http.Error(w, "could not validate remote settings", http.StatusInternalServerError)
+		return
+	}
+	previous := store.State().Config
 	if err := store.Save(config); err != nil {
 		log.Printf("save settings: %v", err)
 		http.Error(
@@ -345,6 +400,20 @@ func handleSaveSettings(
 			http.StatusInternalServerError,
 		)
 		return
+	}
+	if ownershipAction != remote.OwnershipActionNone {
+		ctx, cancel := context.WithTimeout(r.Context(), 2*time.Minute)
+		err := remoteManager.ApplyOwnershipAction(ctx, ownershipAction)
+		cancel()
+		if err != nil {
+			// No settings draft is committed if its requested ownership action
+			// cannot complete. The remote manager is still on the old config.
+			if restoreErr := store.Save(previous); restoreErr != nil {
+				log.Printf("restore settings after helper action failure: %v", restoreErr)
+			}
+			writeAPIError(w, http.StatusBadGateway, "remote_helper_action_failed", "could not complete helper action; settings were kept")
+			return
+		}
 	}
 	mgr.SetRunner(runner)
 	if err := remoteManager.ApplySettings(config.Remote); err != nil {

--- a/collector/cmd/coslash/api_remote.go
+++ b/collector/cmd/coslash/api_remote.go
@@ -15,6 +15,61 @@ type remoteTestRequest struct {
 	SSHAlias string `json:"sshAlias"`
 }
 
+type remoteHelperSetupRequest struct {
+	Install bool `json:"install"`
+	Upgrade bool `json:"upgrade"`
+}
+
+type helperSetupResponse struct {
+	Machine machineFact `json:"machine"`
+	Outcome string      `json:"outcome"`
+	Error   string      `json:"error,omitempty"`
+}
+
+// helperSetupOutcome is separate from machine collection health. A host may
+// have a healthy SFTP cache while a requested helper action has failed; the
+// setup response must never present that operation as a green success.
+func helperSetupOutcome(health remote.Health, testSucceeded bool) (outcome, errorCopy string, succeeded bool) {
+	helper := health.Helper
+	if helper == nil || !helper.Compatible {
+		if helper == nil || helper.Reason == nil {
+			return "sftp_fallback", "helper setup did not complete; SFTP remains active", false
+		}
+		switch *helper.Reason {
+		case remote.ReasonHelperConsent:
+			return "consent_required", genericHelperCopy(*helper.Reason), false
+		case remote.ReasonHelperUnsupported:
+			return "unsupported", genericHelperCopy(*helper.Reason), false
+		case remote.ReasonHelperBlocked:
+			return "blocked", genericHelperCopy(*helper.Reason), false
+		case remote.ReasonHelperIncompatible:
+			return "incompatible", genericHelperCopy(*helper.Reason), false
+		case remote.ReasonHelperUpgrade:
+			return "incompatible", genericHelperCopy(*helper.Reason), false
+		case remote.ReasonHelperRevoked:
+			return "revoked", genericHelperCopy(*helper.Reason), false
+		case remote.ReasonHelperVerification:
+			return "verification_failed", genericHelperCopy(*helper.Reason), false
+		case remote.ReasonHelperInstallation:
+			return "installation_failed", genericHelperCopy(*helper.Reason), false
+		case remote.ReasonHelperRollback:
+			return "rolled_back", genericHelperCopy(*helper.Reason), false
+		default:
+			return "sftp_fallback", genericHelperCopy(*helper.Reason), false
+		}
+	}
+	if !testSucceeded {
+		return "helper_test_failed", "helper installed but its collection test did not complete", false
+	}
+	if helper.State == remote.LifecycleDeprecated {
+		return "deprecated_helper_active", "", true
+	}
+	if helper.Reused {
+		return "reused_and_tested", "", true
+	}
+	return "installed_and_tested", "", true
+}
+
 func handleRemoteTest(w http.ResponseWriter, request *http.Request, manager *remote.Manager) {
 	var body remoteTestRequest
 	decoder := json.NewDecoder(io.LimitReader(request.Body, 4<<10))
@@ -47,4 +102,83 @@ func handleRemoteRetry(w http.ResponseWriter, _ *http.Request, manager *remote.M
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
 	_ = json.NewEncoder(w).Encode(machineFromHealth(health))
+}
+
+func handleRemoteHelperSetup(w http.ResponseWriter, request *http.Request, manager *remote.Manager) {
+	var body remoteHelperSetupRequest
+	decoder := json.NewDecoder(io.LimitReader(request.Body, 4<<10))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&body); err != nil || decoder.Decode(&struct{}{}) != io.EOF {
+		http.Error(w, "invalid helper setup request", http.StatusBadRequest)
+		return
+	}
+	if body.Install == body.Upgrade {
+		http.Error(w, "choose exactly one helper consent action", http.StatusBadRequest)
+		return
+	}
+	health := manager.DiagnosticsHealth()
+	if health.SourceID == "" {
+		writeAPIError(w, http.StatusNotFound, errCodeRemoteNotConfigured, "remote not configured")
+		return
+	}
+	if health.State == remote.StateDisabled {
+		writeAPIError(w, http.StatusConflict, errCodeRemoteDisabled, "remote disabled")
+		return
+	}
+	ctx, cancel := context.WithTimeout(request.Context(), 2*time.Minute)
+	defer cancel()
+	setup := manager.SetupHelper(ctx, remote.Consent{Install: body.Install, Upgrade: body.Upgrade})
+	testSucceeded := false
+	if setup.Helper != nil && setup.Helper.Compatible {
+		test := manager.TestHelper(ctx)
+		setup = test.Health
+		testSucceeded = test.Succeeded
+	}
+	outcome, errorCopy, succeeded := helperSetupOutcome(setup, testSucceeded)
+	machine := machineFromHealth(setup)
+	response := helperSetupResponse{Machine: machine, Outcome: outcome, Error: errorCopy}
+	if !succeeded {
+		// This response represents the setup operation, not an ordinary refresh.
+		// Preserve the safe lifecycle reason and SFTP status, but make the failure
+		// unambiguous to every client even if its prior SFTP collection was OK.
+		response.Machine.State = remote.StateLimited
+		response.Machine.Complete = false
+		response.Machine.Error = errorCopy
+		if setup.Helper != nil && setup.Helper.Reason != nil {
+			response.Machine.Reason = setup.Helper.Reason
+		}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if !succeeded {
+		w.WriteHeader(http.StatusConflict)
+	}
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+func genericHelperCopy(reason remote.Reason) string {
+	return remote.HelperErrorCopy(reason)
+}
+
+func handleRemoteStatus(w http.ResponseWriter, _ *http.Request, manager *remote.Manager) {
+	health := manager.InspectHelper()
+	if health.SourceID == "" {
+		writeAPIError(w, http.StatusNotFound, errCodeRemoteNotConfigured, "remote not configured")
+		return
+	}
+	writeJSON(w, machineFromHealth(health))
+}
+
+func handleRemoteHelperUninstall(w http.ResponseWriter, request *http.Request, manager *remote.Manager) {
+	health := manager.DiagnosticsHealth()
+	if health.SourceID == "" {
+		writeAPIError(w, http.StatusNotFound, errCodeRemoteNotConfigured, "remote not configured")
+		return
+	}
+	ctx, cancel := context.WithTimeout(request.Context(), 2*time.Minute)
+	defer cancel()
+	if err := manager.UninstallHelper(ctx); err != nil {
+		writeAPIError(w, http.StatusBadGateway, "remote_helper_uninstall_failed", "could not uninstall helper; host settings were kept")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/collector/cmd/coslash/api_remote.go
+++ b/collector/cmd/coslash/api_remote.go
@@ -138,6 +138,10 @@ func handleRemoteHelperSetup(w http.ResponseWriter, request *http.Request, manag
 		writeAPIError(w, http.StatusConflict, "remote_alias_mismatch", "SSH alias changed; save settings and test that host before setting up its helper")
 		return
 	}
+	if errors.Is(err, remote.ErrHelperSetupInProgress) {
+		writeAPIError(w, http.StatusConflict, "remote_helper_setup_in_progress", "helper setup is already running for this host")
+		return
+	}
 	testSucceeded := false
 	if setup.Helper != nil && setup.Helper.Compatible {
 		test := manager.TestHelper(ctx)

--- a/collector/cmd/coslash/api_remote.go
+++ b/collector/cmd/coslash/api_remote.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"time"
@@ -16,8 +17,9 @@ type remoteTestRequest struct {
 }
 
 type remoteHelperSetupRequest struct {
-	Install bool `json:"install"`
-	Upgrade bool `json:"upgrade"`
+	SSHAlias string `json:"sshAlias"`
+	Install  bool   `json:"install"`
+	Upgrade  bool   `json:"upgrade"`
 }
 
 type helperSetupResponse struct {
@@ -112,8 +114,8 @@ func handleRemoteHelperSetup(w http.ResponseWriter, request *http.Request, manag
 		http.Error(w, "invalid helper setup request", http.StatusBadRequest)
 		return
 	}
-	if body.Install == body.Upgrade {
-		http.Error(w, "choose exactly one helper consent action", http.StatusBadRequest)
+	if !settings.ValidSSHAlias(body.SSHAlias) || body.Install == body.Upgrade {
+		http.Error(w, "invalid helper setup request", http.StatusBadRequest)
 		return
 	}
 	health := manager.DiagnosticsHealth()
@@ -125,9 +127,17 @@ func handleRemoteHelperSetup(w http.ResponseWriter, request *http.Request, manag
 		writeAPIError(w, http.StatusConflict, errCodeRemoteDisabled, "remote disabled")
 		return
 	}
+	if !manager.SetupAliasMatches(body.SSHAlias) {
+		writeAPIError(w, http.StatusConflict, "remote_alias_mismatch", "SSH alias changed; save settings and test that host before setting up its helper")
+		return
+	}
 	ctx, cancel := context.WithTimeout(request.Context(), 2*time.Minute)
 	defer cancel()
-	setup := manager.SetupHelper(ctx, remote.Consent{Install: body.Install, Upgrade: body.Upgrade})
+	setup, err := manager.SetupHelperForAlias(ctx, body.SSHAlias, remote.Consent{Install: body.Install, Upgrade: body.Upgrade})
+	if errors.Is(err, remote.ErrHelperAliasMismatch) {
+		writeAPIError(w, http.StatusConflict, "remote_alias_mismatch", "SSH alias changed; save settings and test that host before setting up its helper")
+		return
+	}
 	testSucceeded := false
 	if setup.Helper != nil && setup.Helper.Compatible {
 		test := manager.TestHelper(ctx)

--- a/collector/cmd/coslash/api_source.go
+++ b/collector/cmd/coslash/api_source.go
@@ -39,16 +39,23 @@ type boardSession struct {
 }
 
 type machineFact struct {
-	SourceID        string                 `json:"sourceId"`
-	Label           string                 `json:"label"`
-	State           remote.State           `json:"state"`
-	Complete        bool                   `json:"complete"`
-	Reason          *remote.Reason         `json:"reason,omitempty"`
-	LastSuccessAtMs *int64                 `json:"lastSuccessAtMs,omitempty"`
-	CoverageSinceMs *int64                 `json:"coverageSinceMs,omitempty"`
-	RoundTripMs     *int64                 `json:"roundTripMs,omitempty"`
-	Coverage        []remote.AgentCoverage `json:"coverage,omitempty"`
-	Error           string                 `json:"error,omitempty"`
+	SourceID                    string                   `json:"sourceId"`
+	Label                       string                   `json:"label"`
+	State                       remote.State             `json:"state"`
+	Complete                    bool                     `json:"complete"`
+	Reason                      *remote.Reason           `json:"reason,omitempty"`
+	LastSuccessAtMs             *int64                   `json:"lastSuccessAtMs,omitempty"`
+	CoverageSinceMs             *int64                   `json:"coverageSinceMs,omitempty"`
+	RoundTripMs                 *int64                   `json:"roundTripMs,omitempty"`
+	Coverage                    []remote.AgentCoverage   `json:"coverage,omitempty"`
+	Error                       string                   `json:"error,omitempty"`
+	Transport                   remote.Transport         `json:"transport,omitempty"`
+	Helper                      *remote.HelperStatus     `json:"helper,omitempty"`
+	Metrics                     remote.CollectionMetrics `json:"metrics"`
+	HelperInstallationAvailable bool                     `json:"helperInstallationAvailable"`
+	HelperProbeState            string                   `json:"helperProbeState,omitempty"`
+	HelperOwnershipRecorded     bool                     `json:"helperOwnershipRecorded"`
+	HelperOwnershipCorrupt      bool                     `json:"helperOwnershipCorrupt"`
 }
 
 func localMachineFact() machineFact {
@@ -61,6 +68,11 @@ func machineFromHealth(health remote.Health) machineFact {
 		Complete: health.Complete, Reason: health.Reason,
 		LastSuccessAtMs: health.LastSuccessAtMs, CoverageSinceMs: health.CoverageSinceMs,
 		RoundTripMs: health.RoundTripMs, Coverage: health.Coverage, Error: health.Error,
+		Transport: health.Transport, Helper: health.Helper, Metrics: health.Metrics,
+		HelperInstallationAvailable: health.HelperInstallationAvailable,
+		HelperProbeState:            health.HelperProbeState,
+		HelperOwnershipRecorded:     health.HelperOwnershipRecorded,
+		HelperOwnershipCorrupt:      health.HelperOwnershipCorrupt,
 	}
 }
 

--- a/collector/cmd/coslash/api_source.go
+++ b/collector/cmd/coslash/api_source.go
@@ -79,7 +79,7 @@ func machineFromHealth(health remote.Health) machineFact {
 func boardLocalSession(value *session.Session) boardSession {
 	return boardSession{
 		SourceID: localSourceID, SourceLabel: localSourceLabel,
-		EligibleForAggregates: true, Session: *value,
+		EligibleForAggregates: true, Session: sessionWithJSONCollections(*value),
 	}
 }
 
@@ -88,8 +88,57 @@ func boardRemoteSession(value remote.IndexedSession) boardSession {
 		SourceID: value.Key.SourceID, SourceLabel: value.SourceLabel,
 		EligibleForAggregates: value.EligibleForAggregates,
 		DisplayStale:          value.DisplayStale, LastSeenStatus: value.LastSeenStatus,
-		Session: *value.Session,
+		Session: sessionWithJSONCollections(*value.Session),
 	}
+}
+
+// sessionWithJSONCollections keeps the API's array/object contract stable for
+// sparse normalized remote facts. Go encodes nil slices as null, but the board
+// renders these fields as collections and must receive [] rather than null.
+func sessionWithJSONCollections(value session.Session) session.Session {
+	if value.Tokens == nil {
+		value.Tokens = map[string]session.ModelTokens{}
+	}
+	if value.UnpricedModels == nil {
+		value.UnpricedModels = []string{}
+	}
+	if value.Subagents == nil {
+		value.Subagents = []session.Subagent{}
+	}
+	for index := range value.Subagents {
+		if value.Subagents[index].Commands == nil {
+			value.Subagents[index].Commands = []session.SubagentCommand{}
+		}
+		if value.Subagents[index].Tokens == nil {
+			value.Subagents[index].Tokens = map[string]session.ModelTokens{}
+		}
+	}
+	if value.Commands == nil {
+		value.Commands = []string{}
+	}
+	if value.Commits == nil {
+		value.Commits = []string{}
+	}
+	if value.Todos == nil {
+		value.Todos = []session.Todo{}
+	}
+	if value.Digest == nil {
+		value.Digest = []session.DigestEntry{}
+	}
+	if value.FileEdits == nil {
+		value.FileEdits = []session.FileEdit{}
+	}
+	if value.Synthesis != nil {
+		synthesis := *value.Synthesis
+		if synthesis.Goals == nil {
+			synthesis.Goals = []string{}
+		}
+		if synthesis.KeyDecisions == nil {
+			synthesis.KeyDecisions = []string{}
+		}
+		value.Synthesis = &synthesis
+	}
+	return value
 }
 
 func parseSourceID(value string) (string, error) {

--- a/collector/cmd/coslash/main.go
+++ b/collector/cmd/coslash/main.go
@@ -106,7 +106,10 @@ func main() {
 		return collector.List(today.UnixMilli())
 	})
 	go cleanupHandoffs()
-	remoteManager := remote.NewManager(remote.Options{})
+	remoteManager, err := newProductionRemoteManager()
+	if err != nil {
+		log.Fatalf("remote manager: %v", err)
+	}
 	if settingsState.Valid {
 		if err := remoteManager.ApplySettings(settingsState.Config.Remote); err != nil {
 			log.Printf("remote settings: %v", err)
@@ -152,6 +155,10 @@ func main() {
 	if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		log.Fatalf("coslash: %v", err)
 	}
+}
+
+func newProductionRemoteManager() (*remote.Manager, error) {
+	return remote.NewProductionManager()
 }
 
 func newServer(
@@ -220,6 +227,15 @@ func routes(
 	api.HandleFunc("POST /api/remote/retry", func(w http.ResponseWriter, r *http.Request) {
 		handleRemoteRetry(w, r, remoteManager)
 	})
+	api.HandleFunc("GET /api/remote/status", func(w http.ResponseWriter, r *http.Request) {
+		handleRemoteStatus(w, r, remoteManager)
+	})
+	api.HandleFunc("POST /api/remote/helper/setup", func(w http.ResponseWriter, r *http.Request) {
+		handleRemoteHelperSetup(w, r, remoteManager)
+	})
+	api.HandleFunc("POST /api/remote/helper/uninstall", func(w http.ResponseWriter, r *http.Request) {
+		handleRemoteHelperUninstall(w, r, remoteManager)
+	})
 	api.HandleFunc("GET /api/diagnostics", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, diagnostics.CollectWithRemote(r.Context(), version, false, remoteHealthFact(remoteManager)))
 	})
@@ -248,12 +264,27 @@ func remoteHealthFact(manager *remote.Manager) *diagnostics.RemoteHealth {
 		value := string(*health.Reason)
 		reason = &value
 	}
-	return &diagnostics.RemoteHealth{
+	var helperReason *string
+	if health.Helper != nil && health.Helper.Reason != nil {
+		value := string(*health.Helper.Reason)
+		helperReason = &value
+	}
+	remoteHealth := &diagnostics.RemoteHealth{
 		SourceID: health.SourceID, Label: health.Label, State: string(health.State),
 		Complete: health.Complete, Reason: reason, LastSuccessAtMs: health.LastSuccessAtMs,
 		CoverageSinceMs: health.CoverageSinceMs, RoundTripMs: health.RoundTripMs,
-		Error: health.Error, DiagnosticStderr: health.DiagnosticStderr,
+		Error:     health.Error,
+		Transport: string(health.Transport), RequestBytes: health.Metrics.RequestBytes,
+		ResponseBytes: health.Metrics.ResponseBytes, Records: health.Metrics.Records,
+		HelperReason: helperReason,
 	}
+	if health.Helper != nil {
+		remoteHealth.HelperState = string(health.Helper.State)
+		remoteHealth.HelperVersion = health.Helper.Version
+		remoteHealth.HelperCompatible = health.Helper.Compatible
+		remoteHealth.HelperFallback = health.Helper.Fallback
+	}
+	return remoteHealth
 }
 
 func listen(port int) (net.Listener, error) {

--- a/collector/cmd/coslash/main_test.go
+++ b/collector/cmd/coslash/main_test.go
@@ -96,6 +96,28 @@ func TestHelperSetupRequiresExactlyOneConsent(t *testing.T) {
 	}
 }
 
+func TestBoardRemoteSessionSerializesCollectionsAsArrays(t *testing.T) {
+	encoded, err := json.Marshal(boardRemoteSession(remote.IndexedSession{
+		Key:     remote.SessionKey{SourceID: "r_0123456789abcdef"},
+		Session: &session.Session{Agent: "codex", ID: "empty"},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(encoded, &body); err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"unpricedModels", "subagents", "commands", "commits", "todos", "digest", "fileEdits"} {
+		if value, ok := body[field].([]any); !ok || value == nil {
+			t.Fatalf("%s = %#v, want JSON array", field, body[field])
+		}
+	}
+	if value, ok := body["tokens"].(map[string]any); !ok || value == nil {
+		t.Fatalf("tokens = %#v, want JSON object", body["tokens"])
+	}
+}
+
 func TestHelperSetupFailureIsNotReportedAsGreenMachineSuccess(t *testing.T) {
 	manager := remote.NewManager(remote.Options{})
 	if err := manager.ApplySettings(&settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}); err != nil {

--- a/collector/cmd/coslash/main_test.go
+++ b/collector/cmd/coslash/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -60,6 +61,195 @@ func TestAPIRoutesRejectUnsupportedMethods(t *testing.T) {
 				t.Fatalf("status = %d, want %d", response.Code, http.StatusMethodNotAllowed)
 			}
 		})
+	}
+}
+
+func TestLocalMachineFactOmitsRemoteOnlyEnums(t *testing.T) {
+	encoded, err := json.Marshal(localMachineFact())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document map[string]any
+	if err := json.Unmarshal(encoded, &document); err != nil {
+		t.Fatal(err)
+	}
+	if _, present := document["transport"]; present {
+		t.Fatalf("local fact serialized empty transport: %s", encoded)
+	}
+	if _, present := document["helperProbeState"]; present {
+		t.Fatalf("local fact serialized empty helper probe state: %s", encoded)
+	}
+}
+
+func TestHelperSetupRequiresExactlyOneConsent(t *testing.T) {
+	manager := remote.NewManager(remote.Options{})
+	if err := manager.ApplySettings(&settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	for _, body := range []string{`{"install":false,"upgrade":false}`, `{"install":true,"upgrade":true}`} {
+		request := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/api/remote/helper/setup", bytes.NewBufferString(body))
+		response := httptest.NewRecorder()
+		handleRemoteHelperSetup(response, request, manager)
+		if response.Code != http.StatusBadRequest {
+			t.Fatalf("body %s: status = %d, want %d", body, response.Code, http.StatusBadRequest)
+		}
+	}
+}
+
+func TestHelperSetupFailureIsNotReportedAsGreenMachineSuccess(t *testing.T) {
+	manager := remote.NewManager(remote.Options{})
+	if err := manager.ApplySettings(&settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/api/remote/helper/setup", bytes.NewBufferString(`{"install":true,"upgrade":false}`))
+	response := httptest.NewRecorder()
+	handleRemoteHelperSetup(response, request, manager)
+	if response.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusConflict)
+	}
+	var body helperSetupResponse
+	if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Outcome != "sftp_fallback" || body.Error == "" || body.Machine.State != remote.StateLimited || body.Machine.Complete {
+		t.Fatalf("failed setup response = %#v", body)
+	}
+}
+
+func TestHelperSetupOutcomeUsesOperationSuccessNotBoardCoverage(t *testing.T) {
+	health := remote.Health{
+		State: remote.StateOK, Complete: false,
+		Helper: &remote.HelperStatus{State: remote.LifecycleReady, Compatible: true},
+	}
+	outcome, _, succeeded := helperSetupOutcome(health, true)
+	if !succeeded || outcome != "installed_and_tested" {
+		t.Fatalf("outcome = %q, succeeded=%v", outcome, succeeded)
+	}
+}
+
+func TestSettingsSaveCommitsOwnershipReleaseOnlyWithAliasReplacement(t *testing.T) {
+	t.Setenv("COSLASH_HOME", t.TempDir())
+	store := settings.Open()
+	cache := remote.NewCache(t.TempDir())
+	manager := remote.NewManager(remote.Options{Cache: cache})
+	previous := settings.Defaults()
+	previous.Remote = &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "old-host", Enabled: true}
+	if err := store.Save(previous); err != nil {
+		t.Fatal(err)
+	}
+	if err := cache.StoreHelperVersion(previous.Remote.ID, "v1", previous.Remote.SSHAlias); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.ApplySettings(previous.Remote); err != nil {
+		t.Fatal(err)
+	}
+	next := previous
+	next.Remote = &settings.RemoteSettings{ID: previous.Remote.ID, SSHAlias: "new-host", Enabled: true}
+	body, err := json.Marshal(map[string]any{"settings": next, "remoteOwnershipAction": "release"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodPut, "http://127.0.0.1/api/settings", bytes.NewReader(body))
+	response := httptest.NewRecorder()
+	handleSaveSettings(response, request, store, synthesis.NewManager(nil), manager)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", response.Code, response.Body.String())
+	}
+	if got := store.State().Config.Remote; got == nil || got.SSHAlias != "new-host" {
+		t.Fatalf("saved remote = %#v", got)
+	}
+	if _, owned, err := cache.LoadHelperOwnership(previous.Remote.ID); err != nil || owned {
+		t.Fatalf("ownership was not released with replacement: owned=%v err=%v", owned, err)
+	}
+}
+
+func TestSettingsSaveRestoresOldSettingsWhenOwnershipActionFails(t *testing.T) {
+	t.Setenv("COSLASH_HOME", t.TempDir())
+	store := settings.Open()
+	cache := remote.NewCache(t.TempDir())
+	manager := remote.NewManager(remote.Options{Cache: cache})
+	previous := settings.Defaults()
+	previous.Remote = &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "old-host", Enabled: true}
+	if err := store.Save(previous); err != nil {
+		t.Fatal(err)
+	}
+	if err := cache.StoreHelperVersion(previous.Remote.ID, "v1", previous.Remote.SSHAlias); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.ApplySettings(previous.Remote); err != nil {
+		t.Fatal(err)
+	}
+	next := previous
+	next.Remote = nil
+	body, err := json.Marshal(map[string]any{"settings": next, "remoteOwnershipAction": "uninstall"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodPut, "http://127.0.0.1/api/settings", bytes.NewReader(body))
+	response := httptest.NewRecorder()
+	handleSaveSettings(response, request, store, synthesis.NewManager(nil), manager)
+	if response.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d: %s", response.Code, response.Body.String())
+	}
+	if got := store.State().Config.Remote; got == nil || got.SSHAlias != previous.Remote.SSHAlias {
+		t.Fatalf("settings were not restored: %#v", got)
+	}
+	if _, owned, err := cache.LoadHelperOwnership(previous.Remote.ID); err != nil || !owned {
+		t.Fatalf("failed uninstall lost ownership: owned=%v err=%v", owned, err)
+	}
+}
+
+func TestSettingsSaveCanExplicitlyRecoverCorruptOwnershipByRemovingHost(t *testing.T) {
+	t.Setenv("COSLASH_HOME", t.TempDir())
+	store := settings.Open()
+	cache := remote.NewCache(t.TempDir())
+	manager := remote.NewManager(remote.Options{Cache: cache})
+	previous := settings.Defaults()
+	previous.Remote = &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "old-host", Enabled: true}
+	if err := store.Save(previous); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(cache.Root, "remotes", previous.Remote.ID, "helper.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{"version":"?"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.ApplySettings(previous.Remote); err != nil {
+		t.Fatalf("corrupt ownership must retain a displayable host: %v", err)
+	}
+	if health := manager.DiagnosticsHealth(); !health.HelperOwnershipCorrupt || health.Helper == nil {
+		t.Fatalf("corrupt ownership health = %#v", health)
+	}
+	next := previous
+	next.Remote = nil
+	body, err := json.Marshal(map[string]any{"settings": next, "remoteOwnershipAction": "release"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodPut, "http://127.0.0.1/api/settings", bytes.NewReader(body))
+	response := httptest.NewRecorder()
+	handleSaveSettings(response, request, store, synthesis.NewManager(nil), manager)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", response.Code, response.Body.String())
+	}
+	if store.State().Config.Remote != nil {
+		t.Fatalf("recovery did not remove host: %#v", store.State().Config.Remote)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("corrupt ownership record remains: %v", err)
+	}
+}
+
+func TestSettingsSaveEnvelopeRejectsUnknownFields(t *testing.T) {
+	config := settings.Defaults()
+	body, err := json.Marshal(map[string]any{"settings": config, "unexpected": true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := decodeSettingsSave(body); err == nil {
+		t.Fatal("unknown envelope field was accepted")
 	}
 }
 

--- a/collector/cmd/coslash/main_test.go
+++ b/collector/cmd/coslash/main_test.go
@@ -86,7 +86,7 @@ func TestHelperSetupRequiresExactlyOneConsent(t *testing.T) {
 	if err := manager.ApplySettings(&settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}); err != nil {
 		t.Fatal(err)
 	}
-	for _, body := range []string{`{"install":false,"upgrade":false}`, `{"install":true,"upgrade":true}`} {
+	for _, body := range []string{`{"sshAlias":"agent-box","install":false,"upgrade":false}`, `{"sshAlias":"agent-box","install":true,"upgrade":true}`} {
 		request := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/api/remote/helper/setup", bytes.NewBufferString(body))
 		response := httptest.NewRecorder()
 		handleRemoteHelperSetup(response, request, manager)
@@ -123,7 +123,7 @@ func TestHelperSetupFailureIsNotReportedAsGreenMachineSuccess(t *testing.T) {
 	if err := manager.ApplySettings(&settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}); err != nil {
 		t.Fatal(err)
 	}
-	request := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/api/remote/helper/setup", bytes.NewBufferString(`{"install":true,"upgrade":false}`))
+	request := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/api/remote/helper/setup", bytes.NewBufferString(`{"sshAlias":"agent-box","install":true,"upgrade":false}`))
 	response := httptest.NewRecorder()
 	handleRemoteHelperSetup(response, request, manager)
 	if response.Code != http.StatusConflict {
@@ -135,6 +135,26 @@ func TestHelperSetupFailureIsNotReportedAsGreenMachineSuccess(t *testing.T) {
 	}
 	if body.Outcome != "sftp_fallback" || body.Error == "" || body.Machine.State != remote.StateLimited || body.Machine.Complete {
 		t.Fatalf("failed setup response = %#v", body)
+	}
+}
+
+func TestHelperSetupRejectsUnsavedAlias(t *testing.T) {
+	manager := remote.NewManager(remote.Options{})
+	if err := manager.ApplySettings(&settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "saved-host", Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/api/remote/helper/setup", bytes.NewBufferString(`{"sshAlias":"tested-draft","install":true,"upgrade":false}`))
+	response := httptest.NewRecorder()
+	handleRemoteHelperSetup(response, request, manager)
+	if response.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusConflict)
+	}
+	var body apiErrorBody
+	if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Code != "remote_alias_mismatch" {
+		t.Fatalf("error = %#v", body)
 	}
 }
 

--- a/collector/internal/diagnostics/checks.go
+++ b/collector/internal/diagnostics/checks.go
@@ -150,7 +150,11 @@ func remoteCheck(remote *Remote) Check {
 	check := Check{ID: "remote", Title: "Remote SSH host", Status: StatusOK}
 	switch remote.State {
 	case "ok":
-		check.Detail = remote.Label + " is connected over SFTP."
+		transport := remote.Transport
+		if transport == "" {
+			transport = "SFTP"
+		}
+		check.Detail = remote.Label + " is connected over " + transport + "."
 	case "connecting":
 		check.Status = StatusWarn
 		check.Detail = "Connecting to " + remote.Label + "."

--- a/collector/internal/diagnostics/remote_test.go
+++ b/collector/internal/diagnostics/remote_test.go
@@ -1,0 +1,23 @@
+package diagnostics
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestRemoteDiagnosticsNeverSerializeStderr(t *testing.T) {
+	reason := "helper_failed"
+	snapshot := CollectWithRemote(context.Background(), "test", false, &RemoteHealth{
+		SourceID: "r_0123456789abcdef", Label: "agent-box", State: "error", Complete: false,
+		Reason: &reason, Error: "collection helper failed", Transport: "helper",
+	})
+	encoded, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(strings.ToLower(string(encoded)), "stderr") {
+		t.Fatalf("diagnostics exposed stderr: %s", encoded)
+	}
+}

--- a/collector/internal/diagnostics/snapshot.go
+++ b/collector/internal/diagnostics/snapshot.go
@@ -56,7 +56,15 @@ type Remote struct {
 	CoverageSinceMs  *int64  `json:"coverageSinceMs,omitempty"`
 	RoundTripMs      *int64  `json:"roundTripMs,omitempty"`
 	Error            string  `json:"error,omitempty"`
-	DiagnosticStderr string  `json:"diagnosticStderr,omitempty"`
+	Transport        string  `json:"transport,omitempty"`
+	HelperState      string  `json:"helperState,omitempty"`
+	HelperVersion    string  `json:"helperVersion,omitempty"`
+	HelperCompatible bool    `json:"helperCompatible,omitempty"`
+	HelperFallback   bool    `json:"helperFallback,omitempty"`
+	HelperReason     *string `json:"helperReason,omitempty"`
+	RequestBytes     int     `json:"requestBytes,omitempty"`
+	ResponseBytes    int     `json:"responseBytes,omitempty"`
+	Records          int     `json:"records,omitempty"`
 }
 
 type RemoteHealth struct {
@@ -69,7 +77,15 @@ type RemoteHealth struct {
 	CoverageSinceMs  *int64
 	RoundTripMs      *int64
 	Error            string
-	DiagnosticStderr string
+	Transport        string
+	HelperState      string
+	HelperVersion    string
+	HelperCompatible bool
+	HelperFallback   bool
+	HelperReason     *string
+	RequestBytes     int
+	ResponseBytes    int
+	Records          int
 }
 
 type Platform struct {
@@ -145,7 +161,11 @@ func CollectWithRemote(
 		State: remoteHealth.State, Complete: remoteHealth.Complete, Reason: remoteHealth.Reason,
 		LastSuccessAtMs: remoteHealth.LastSuccessAtMs, CoverageSinceMs: remoteHealth.CoverageSinceMs,
 		RoundTripMs: remoteHealth.RoundTripMs, Error: remoteHealth.Error,
-		DiagnosticStderr: remoteHealth.DiagnosticStderr,
+		Transport: remoteHealth.Transport, HelperState: remoteHealth.HelperState,
+		HelperVersion: remoteHealth.HelperVersion, HelperCompatible: remoteHealth.HelperCompatible,
+		HelperFallback: remoteHealth.HelperFallback, HelperReason: remoteHealth.HelperReason,
+		RequestBytes: remoteHealth.RequestBytes, ResponseBytes: remoteHealth.ResponseBytes,
+		Records: remoteHealth.Records,
 	}
 	snapshot.Checks = append(snapshot.Checks, remoteCheck(snapshot.Remote))
 	return snapshot

--- a/collector/internal/remote/cache.go
+++ b/collector/internal/remote/cache.go
@@ -1,7 +1,9 @@
 package remote
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -16,6 +18,15 @@ import (
 )
 
 const cacheVersion = 1
+
+var (
+	// ErrHelperOwnershipCorrupt is fail-closed: ownership protects remote code
+	// from being silently orphaned and malformed evidence cannot mean "none".
+	ErrHelperOwnershipCorrupt = errors.New("helper ownership record is corrupt")
+	// ErrHelperOwnershipLegacy marks the former {"version":"..."} format.
+	// Manager migrates it only after binding it to the configured SSH alias.
+	ErrHelperOwnershipLegacy = errors.New("helper ownership record needs alias migration")
+)
 
 type AgentCoverage struct {
 	Agent          string `json:"agent"`
@@ -119,6 +130,11 @@ func (cached CachedSnapshot) sessions() []*session.Session {
 
 type Cache struct {
 	Root string
+}
+
+type helperOwnership struct {
+	Version string `json:"version"`
+	Alias   string `json:"alias"`
 }
 
 func NewCache(root string) *Cache {
@@ -284,6 +300,107 @@ func (c *Cache) snapshotV2Path(sourceID string) (string, error) {
 	return filepath.Join(dir, "snapshot-v2.json"), nil
 }
 
+func (c *Cache) helperOwnershipPath(sourceID string) (string, error) {
+	dir, err := c.sourceDir(sourceID)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "helper.json"), nil
+}
+
+// LoadHelperVersion records local ownership, not executable authority. A
+// loaded version must still pass fresh signed-metadata, remote-file, and
+// capability verification before it becomes a helperTarget.
+func (c *Cache) LoadHelperOwnership(sourceID string) (helperOwnership, bool, error) {
+	path, err := c.helperOwnershipPath(sourceID)
+	if err != nil {
+		return helperOwnership{}, false, err
+	}
+	content, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return helperOwnership{}, false, nil
+	}
+	if err != nil {
+		return helperOwnership{}, false, err
+	}
+	if len(content) == 0 || len(content) > 256 {
+		return helperOwnership{}, false, ErrHelperOwnershipCorrupt
+	}
+	var document struct {
+		Version *string `json:"version"`
+		Alias   *string `json:"alias"`
+	}
+	decoder := json.NewDecoder(bytes.NewReader(content))
+	decoder.DisallowUnknownFields()
+	if decoder.Decode(&document) != nil || decoder.Decode(&struct{}{}) != io.EOF || document.Version == nil || !helperVersionPattern.MatchString(*document.Version) {
+		return helperOwnership{}, false, ErrHelperOwnershipCorrupt
+	}
+	if document.Alias == nil {
+		return helperOwnership{Version: *document.Version}, true, ErrHelperOwnershipLegacy
+	}
+	if !settings.ValidSSHAlias(*document.Alias) {
+		return helperOwnership{}, false, ErrHelperOwnershipCorrupt
+	}
+	return helperOwnership{Version: *document.Version, Alias: *document.Alias}, true, nil
+}
+
+func (c *Cache) StoreHelperVersion(sourceID, version, alias string) error {
+	if !helperVersionPattern.MatchString(version) || !settings.ValidSSHAlias(alias) {
+		return ErrHelperArtifact
+	}
+	dir, err := c.sourceDir(sourceID)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		return err
+	}
+	content, err := json.Marshal(helperOwnership{Version: version, Alias: alias})
+	if err != nil {
+		return err
+	}
+	temporary, err := os.CreateTemp(dir, ".helper-*")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	if err := temporary.Chmod(0o600); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if _, err := temporary.Write(content); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Sync(); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	path, err := c.helperOwnershipPath(sourceID)
+	if err != nil {
+		return err
+	}
+	return os.Rename(temporaryPath, path)
+}
+
+func (c *Cache) RemoveHelperVersion(sourceID string) error {
+	path, err := c.helperOwnershipPath(sourceID)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
 // LoadV2 returns ok=false for a missing, corrupt, or out-of-bounds file
 // rather than an error, so a damaged cache degrades to a cold start instead of
 // blocking startup.
@@ -345,7 +462,7 @@ func validCachedSnapshotV2(cached CachedSnapshotV2) bool {
 		if family.Fingerprint == "" || len(family.Fingerprint) > remotefacts.MaxIDBytes {
 			return false
 		}
-		if len(family.StaleReason) > remotefacts.MaxDisplayBytes {
+		if family.StaleReason != "" && !remotefacts.ValidStaleReason(family.StaleReason) {
 			return false
 		}
 		if family.LastSuccessAtMs <= 0 || family.LastSuccessAtMs > remotefacts.MaxTimestampMs {

--- a/collector/internal/remote/cache.go
+++ b/collector/internal/remote/cache.go
@@ -32,6 +32,7 @@ type AgentCoverage struct {
 	Agent          string `json:"agent"`
 	CandidateFiles int    `json:"candidateFiles"`
 	SelectedFiles  int    `json:"selectedFiles"`
+	SkippedEntries int    `json:"skippedEntries,omitempty"`
 	Truncated      bool   `json:"truncated"`
 	Error          string `json:"error,omitempty"`
 }

--- a/collector/internal/remote/cache_test.go
+++ b/collector/internal/remote/cache_test.go
@@ -1,11 +1,14 @@
 package remote
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/centauri-ai/coslash/collector/internal/remotefacts"
+	"github.com/centauri-ai/coslash/collector/internal/remoteprotocol"
+	"github.com/centauri-ai/coslash/collector/internal/settings"
 	"github.com/centauri-ai/coslash/collector/internal/vendors"
 )
 
@@ -50,6 +53,25 @@ func TestCacheV2StoreLoadRoundTrip(t *testing.T) {
 	}
 	if len(loaded.CodexHeaders) != 1 || loaded.CodexHeaders[0].SessionID != "s1" {
 		t.Fatalf("codex headers did not round-trip: %+v", loaded.CodexHeaders)
+	}
+}
+
+func TestKnownFamiliesIncludeCodexHeaderMappings(t *testing.T) {
+	family := validFamily(t, "root-1")
+	family.Vendor = vendors.AgentCodex
+	family.HeaderMappings = []remotefacts.HeaderMapping{{Key: "file-1", SessionID: "root-1"}}
+	if err := remotefacts.Validate(family); err != nil {
+		t.Fatal(err)
+	}
+	snapshot := CachedSnapshotV2{Families: []CachedFamilyV2{{
+		Vendor: vendors.AgentCodex, FamilyID: "root-1", Fingerprint: "family-1", Facts: family,
+	}}}
+	known := knownFamiliesFor(snapshot)
+	if len(known) != 1 || len(known[0].Headers) != 1 {
+		t.Fatalf("known families = %#v", known)
+	}
+	if got, want := known[0].Headers[0], (remoteprotocol.KnownHeader{Key: "file-1", Size: 10, ModifiedAtMs: 1000, SessionID: "root-1"}); got != want {
+		t.Fatalf("known header = %#v, want %#v", got, want)
 	}
 }
 
@@ -156,6 +178,42 @@ func TestCacheV2LoadRejectsInvalidFamilyFacts(t *testing.T) {
 	}
 }
 
+func TestCacheV2LoadRejectsUnstructuredStaleReason(t *testing.T) {
+	cache := NewCache(t.TempDir())
+	snapshot := CachedSnapshotV2{
+		Version: cacheV2Version, BaselineID: "req-1",
+		Families: []CachedFamilyV2{{
+			Vendor: vendors.AgentClaude, FamilyID: "root-1", Facts: validFamily(t, "root-1"),
+			Fingerprint: "fp-1", StaleReason: "prompt text from hostile helper", LastSuccessAtMs: 1000,
+		}},
+	}
+	if err := cache.StoreV2("r_0123456789abcdef", snapshot); err != nil {
+		t.Fatalf("StoreV2: %v", err)
+	}
+	if _, ok, err := cache.LoadV2("r_0123456789abcdef"); err != nil || ok {
+		t.Fatalf("unstructured stale reason should degrade safely: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestCacheV2LoadRejectsFactStaleReasonOutsideStaleState(t *testing.T) {
+	cache := NewCache(t.TempDir())
+	facts := validFamily(t, "root-1")
+	facts.StaleReason = "hostile transcript text"
+	snapshot := CachedSnapshotV2{
+		Version: cacheV2Version, BaselineID: "req-1",
+		Families: []CachedFamilyV2{{
+			Vendor: vendors.AgentClaude, FamilyID: "root-1", Facts: facts,
+			Fingerprint: "fp-1", LastSuccessAtMs: 1000,
+		}},
+	}
+	if err := cache.StoreV2("r_0123456789abcdef", snapshot); err != nil {
+		t.Fatalf("StoreV2: %v", err)
+	}
+	if _, ok, err := cache.LoadV2("r_0123456789abcdef"); err != nil || ok {
+		t.Fatalf("fact stale reason should degrade safely: ok=%v err=%v", ok, err)
+	}
+}
+
 func TestCacheV1RemainsLoadableAlongsideV2(t *testing.T) {
 	root := t.TempDir()
 	cache := NewCache(root)
@@ -179,5 +237,65 @@ func TestCacheV1RemainsLoadableAlongsideV2(t *testing.T) {
 	}
 	if len(v1.Sessions) != 1 {
 		t.Fatalf("v1 sessions = %d, want 1", len(v1.Sessions))
+	}
+}
+
+func TestCacheHelperOwnershipPersistsOnlyAValidatedVersion(t *testing.T) {
+	cache := NewCache(t.TempDir())
+	const sourceID = "r_0123456789abcdef"
+	if err := cache.StoreHelperVersion(sourceID, "v1.2.3", "agent-box"); err != nil {
+		t.Fatalf("StoreHelperVersion: %v", err)
+	}
+	ownership, ok, err := cache.LoadHelperOwnership(sourceID)
+	if err != nil || !ok || ownership.Version != "v1.2.3" || ownership.Alias != "agent-box" {
+		t.Fatalf("LoadHelperOwnership = %#v, %v, %v", ownership, ok, err)
+	}
+	path, err := cache.helperOwnershipPath(sourceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil || info.Mode().Perm() != 0o600 {
+		t.Fatalf("helper ownership mode = %v, err=%v", info.Mode(), err)
+	}
+	if err := cache.RemoveHelperVersion(sourceID); err != nil {
+		t.Fatalf("RemoveHelperVersion: %v", err)
+	}
+	if _, ok, err := cache.LoadHelperOwnership(sourceID); err != nil || ok {
+		t.Fatalf("removed ownership should be absent: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestCacheHelperOwnershipCorruptionFailsClosedAndLegacyMigratesWithConfiguredAlias(t *testing.T) {
+	cache := NewCache(t.TempDir())
+	const sourceID = "r_0123456789abcdef"
+	path, err := cache.helperOwnershipPath(sourceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{"version":`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := cache.LoadHelperOwnership(sourceID); ok || !errors.Is(err, ErrHelperOwnershipCorrupt) {
+		t.Fatalf("corrupt ownership = ok:%v err:%v", ok, err)
+	}
+	if err := os.WriteFile(path, []byte(`{"version":"v1"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ownership, ok, err := cache.LoadHelperOwnership(sourceID)
+	if !ok || !errors.Is(err, ErrHelperOwnershipLegacy) || ownership.Version != "v1" {
+		t.Fatalf("legacy ownership = %#v, %v, %v", ownership, ok, err)
+	}
+	manager := NewManager(Options{Cache: cache})
+	config := &settings.RemoteSettings{ID: sourceID, SSHAlias: "agent-box", Enabled: true}
+	if err := manager.ApplySettings(config); err != nil {
+		t.Fatalf("migrate legacy ownership: %v", err)
+	}
+	ownership, ok, err = cache.LoadHelperOwnership(sourceID)
+	if err != nil || !ok || ownership.Alias != config.SSHAlias {
+		t.Fatalf("migrated ownership = %#v, %v, %v", ownership, ok, err)
 	}
 }

--- a/collector/internal/remote/collect.go
+++ b/collector/internal/remote/collect.go
@@ -66,6 +66,7 @@ type vendorFamilyInput struct {
 	FilesOf         map[string][]string
 	AllFamilyIDs    []string
 	CandidateFiles  int
+	SkippedEntries  int
 	Truncated       bool
 	Metadata        *vendors.SessionMetadata
 	Parse           func(files []string) ([]*vendors.ParsedSession, []vendors.FileFailure, error)
@@ -77,7 +78,7 @@ type vendorFamilyInput struct {
 
 type vendorOutcome struct {
 	Records  []remoteprotocol.Record
-	Complete remoteprotocol.Record
+	Complete *remoteprotocol.Record
 	Coverage AgentCoverage
 	Metadata *vendors.SessionMetadata
 	Failures []error
@@ -181,7 +182,7 @@ func collectVendorFamilies(in vendorFamilyInput) vendorOutcome {
 	for _, id := range in.AllFamilyIDs {
 		allSet[id] = struct{}{}
 	}
-	inventoryComplete := len(in.AllFamilyIDs) <= remoteprotocol.MaxInventoryFamilies
+	inventoryComplete := in.SkippedEntries == 0 && len(in.AllFamilyIDs) <= remoteprotocol.MaxInventoryFamilies
 	if inventoryComplete {
 		for id := range in.Baseline {
 			if _, present := allSet[id]; !present {
@@ -196,20 +197,26 @@ func collectVendorFamilies(in vendorFamilyInput) vendorOutcome {
 		inventory = append([]string(nil), in.AllFamilyIDs...)
 		sort.Strings(inventory)
 	}
-	complete := remoteprotocol.Record{
-		Type: remoteprotocol.RecordVendorComplete, Vendor: in.Vendor,
-		EnumerationComplete: true, InventoryComplete: inventoryComplete, Inventory: inventory,
+	var complete *remoteprotocol.Record
+	if in.SkippedEntries == 0 {
+		complete = &remoteprotocol.Record{
+			Type: remoteprotocol.RecordVendorComplete, Vendor: in.Vendor,
+			EnumerationComplete: true, InventoryComplete: inventoryComplete, Inventory: inventory,
+		}
+	} else {
+		familyFailures = append(familyFailures, fmt.Errorf("%s enumeration skipped %d entries", in.Vendor, in.SkippedEntries))
 	}
 	coverage := AgentCoverage{
 		Agent: in.Vendor, CandidateFiles: in.CandidateFiles, SelectedFiles: selectedFiles,
-		Truncated: in.Truncated || !inventoryComplete,
+		SkippedEntries: in.SkippedEntries,
+		Truncated:      in.Truncated || len(in.AllFamilyIDs) > remoteprotocol.MaxInventoryFamilies,
 	}
 	return vendorOutcome{Records: records, Complete: complete, Coverage: coverage, Metadata: in.Metadata, Failures: familyFailures}
 }
 
 func collectClaudeVendor(source vendors.ReadSource, home string, since int64, now time.Time, baseline map[string]CachedFamilyV2) vendorOutcome {
 	metadata := claude.RemoteMetadata(source, home, now)
-	selectedFamilies, allFamilyIDs, candidateFiles, truncated, err := claude.BuildRemoteFamilies(source, home, since, metadata.Live)
+	selectedFamilies, allFamilyIDs, candidateFiles, skippedEntries, truncated, err := claude.BuildRemoteFamilies(source, home, since, metadata.Live)
 	if err != nil {
 		return vendorOutcome{Err: fmt.Errorf("collect Claude remote data: %w", err)}
 	}
@@ -222,7 +229,7 @@ func collectClaudeVendor(source vendors.ReadSource, home string, since int64, no
 	return collectVendorFamilies(vendorFamilyInput{
 		Vendor: vendors.AgentClaude, ParserVersion: claudeParserVersion,
 		Baseline: baseline, Selected: selected, FilesOf: filesOf, AllFamilyIDs: allFamilyIDs,
-		CandidateFiles: candidateFiles, Truncated: truncated, Metadata: metadata,
+		CandidateFiles: candidateFiles, SkippedEntries: skippedEntries, Truncated: truncated, Metadata: metadata,
 		Parse: func(files []string) ([]*vendors.ParsedSession, []vendors.FileFailure, error) {
 			return claude.ParseRemoteFiles(source, files)
 		},
@@ -238,7 +245,7 @@ func collectCodexVendor(
 	baseline map[string]CachedFamilyV2, cachedHeaders map[string]codex.CachedHeader,
 ) (vendorOutcome, map[string]codex.CachedHeader) {
 	metadata := codex.RemoteMetadata(source, home)
-	selectedFamilies, allFamilyIDs, updatedHeaders, headerFailed, candidateFiles, truncated, err := codex.BuildRemoteFamilies(
+	selectedFamilies, allFamilyIDs, updatedHeaders, headerFailed, candidateFiles, skippedEntries, truncated, err := codex.BuildRemoteFamilies(
 		source, home, since, metadata.Live, cachedHeaders,
 	)
 	if err != nil {
@@ -269,7 +276,7 @@ func collectCodexVendor(
 	outcome := collectVendorFamilies(vendorFamilyInput{
 		Vendor: vendors.AgentCodex, ParserVersion: codexParserVersion,
 		Baseline: baseline, Selected: selected, FilesOf: filesOf, AllFamilyIDs: allFamilyIDs,
-		CandidateFiles: candidateFiles, Truncated: truncated, Metadata: metadata,
+		CandidateFiles: candidateFiles, SkippedEntries: skippedEntries, Truncated: truncated, Metadata: metadata,
 		Parse: func(files []string) ([]*vendors.ParsedSession, []vendors.FileFailure, error) {
 			return codex.ParseRemoteFiles(source, home, files)
 		},
@@ -411,6 +418,11 @@ func collectIncremental(
 				return CachedSnapshotV2{}, nil, failures, fmt.Errorf("apply %s record: %w", vendorName, err)
 			}
 		}
+		if outcome.Complete == nil {
+			allVendorsCompleted = false
+			coverage = append(coverage, outcome.Coverage)
+			continue
+		}
 		// Baseline-free protocol completion requires an authoritative bounded
 		// inventory. If it cannot fit, keep the partial facts but do not claim
 		// completion or advance coverage.
@@ -419,7 +431,7 @@ func collectIncremental(
 			coverage = append(coverage, outcome.Coverage)
 			continue
 		}
-		if err := apply(outcome.Complete); err != nil {
+		if err := apply(*outcome.Complete); err != nil {
 			return CachedSnapshotV2{}, nil, failures, fmt.Errorf("apply %s completion: %w", vendorName, err)
 		}
 		coverage = append(coverage, outcome.Coverage)

--- a/collector/internal/remote/collect.go
+++ b/collector/internal/remote/collect.go
@@ -25,8 +25,8 @@ import (
 // vendor_complete so request_complete — and any coverage-window advance —
 // never happens for it).
 const (
-	claudeParserVersion        = "claude-sftp/1"
-	codexParserVersion         = "codex-sftp/1"
+	claudeParserVersion        = vendors.ParserVersion
+	codexParserVersion         = vendors.ParserVersion
 	sftpCollectorParserVersion = "sftp-collector.1"
 )
 
@@ -43,15 +43,15 @@ func compositeFingerprint(fingerprints []vendors.FileFingerprint) string {
 func familySkipReason(err error) string {
 	switch {
 	case errors.Is(err, ErrFileLimit):
-		return "oversized_file"
+		return remotefacts.StaleReasonOversizedFile
 	case errors.Is(err, ErrTotalLimit):
-		return "vendor_budget_exceeded"
+		return remotefacts.StaleReasonVendorBudgetExceeded
 	case errors.Is(err, ErrSymlink), errors.Is(err, ErrPathDenied):
-		return "path_denied"
+		return remotefacts.StaleReasonPathDenied
 	case errors.Is(err, vendors.ErrInvalidData):
-		return "invalid_data"
+		return remotefacts.StaleReasonInvalidData
 	default:
-		return "read_failed"
+		return remotefacts.StaleReasonReadFailed
 	}
 }
 
@@ -70,6 +70,7 @@ type vendorFamilyInput struct {
 	Metadata        *vendors.SessionMetadata
 	Parse           func(files []string) ([]*vendors.ParsedSession, []vendors.FileFailure, error)
 	Fingerprint     func(files []string) ([]vendors.FileFingerprint, error)
+	HeaderMappings  map[string][]remotefacts.HeaderMapping
 	InitialFailures []vendors.FileFailure
 	FamilyIDOf      func(logPath string) string
 }
@@ -134,7 +135,7 @@ func collectVendorFamilies(in vendorFamilyInput) vendorOutcome {
 	for id, composite := range changed {
 		if unstableFamilies[id] {
 			records = append(records, remoteprotocol.Record{
-				Type: remoteprotocol.RecordSkipped, Vendor: in.Vendor, FamilyID: id, Reason: "unstable_file",
+				Type: remoteprotocol.RecordSkipped, Vendor: in.Vendor, FamilyID: id, Reason: remotefacts.StaleReasonUnstableFile,
 			})
 			familyFailures = append(familyFailures, fmt.Errorf("%s family unstable during collection", in.Vendor))
 			continue
@@ -150,18 +151,18 @@ func collectVendorFamilies(in vendorFamilyInput) vendorOutcome {
 		sessions := byFamily[id]
 		if len(sessions) == 0 {
 			records = append(records, remoteprotocol.Record{
-				Type: remoteprotocol.RecordSkipped, Vendor: in.Vendor, FamilyID: id, Reason: "no_data",
+				Type: remoteprotocol.RecordSkipped, Vendor: in.Vendor, FamilyID: id, Reason: remotefacts.StaleReasonNoData,
 			})
 			familyFailures = append(familyFailures, fmt.Errorf("%s family skipped: no_data", in.Vendor))
 			continue
 		}
 		family, err := remotefacts.FromParsed(
 			in.Vendor, id, in.ParserVersion, remotefacts.StateComplete, "",
-			sessions, in.Metadata, in.Selected[id],
+			sessions, in.Metadata, in.Selected[id], in.HeaderMappings[id],
 		)
 		if err != nil {
 			records = append(records, remoteprotocol.Record{
-				Type: remoteprotocol.RecordSkipped, Vendor: in.Vendor, FamilyID: id, Reason: "invalid_family_facts",
+				Type: remoteprotocol.RecordSkipped, Vendor: in.Vendor, FamilyID: id, Reason: remotefacts.StaleReasonInvalidData,
 			})
 			familyFailures = append(familyFailures, fmt.Errorf("%s family skipped: invalid_family_facts", in.Vendor))
 			continue
@@ -246,10 +247,18 @@ func collectCodexVendor(
 	selected := map[string][]vendors.FileFingerprint{}
 	filesOf := map[string][]string{}
 	familyIDOf := map[string]string{}
+	headerMappings := map[string][]remotefacts.HeaderMapping{}
 	var initialFailures []vendors.FileFailure
 	for id, family := range selectedFamilies {
 		selected[id] = family.Fingerprints
 		filesOf[id] = family.Files
+		for _, fingerprint := range family.Fingerprints {
+			if header, ok := updatedHeaders[fingerprint.Key]; ok {
+				headerMappings[id] = append(headerMappings[id], remotefacts.HeaderMapping{
+					Key: fingerprint.Key, SessionID: header.SessionID, ParentID: header.ParentID,
+				})
+			}
+		}
 		for _, file := range family.Files {
 			familyIDOf[file] = id
 		}
@@ -267,6 +276,7 @@ func collectCodexVendor(
 		Fingerprint: func(files []string) ([]vendors.FileFingerprint, error) {
 			return vendors.FingerprintSourceFilesFresh(source, codex.SessionsRoot(home), files)
 		},
+		HeaderMappings:  headerMappings,
 		InitialFailures: initialFailures,
 		FamilyIDOf: func(logPath string) string {
 			if id, ok := familyIDOf[logPath]; ok {

--- a/collector/internal/remote/collect_integration_test.go
+++ b/collector/internal/remote/collect_integration_test.go
@@ -2,6 +2,8 @@ package remote
 
 import (
 	"fmt"
+	"io/fs"
+	"os"
 	"path"
 	"sync"
 	"testing"
@@ -336,6 +338,52 @@ func TestCollectIncrementalNeverTombstonesOnHardVendorFailure(t *testing.T) {
 	}
 	if secondSnapshot.CoverageSinceMs != 0 {
 		t.Fatalf("coverage should not advance past the prior baseline on a partial refresh: got %d", secondSnapshot.CoverageSinceMs)
+	}
+}
+
+func TestCollectIncrementalNeverTombstonesAfterSkippedDirectory(t *testing.T) {
+	fake := newFakeFS()
+	retainedID := "aaaaaaaa-0000-0000-0000-000000000011"
+	writeClaudeFixture(fake, "unreadable", retainedID, 1, 1, time.Unix(1000, 0))
+	baseline, _, _, err := collectIncremental(newFakeSource(fake, Limits{}), 0, time.Unix(2000, 0), CachedSnapshotV2{})
+	if err != nil || len(baseline.Families) != 1 {
+		t.Fatalf("seed refresh: snapshot=%+v err=%v", baseline, err)
+	}
+
+	unreadable := path.Join(fakeHome, ".claude/projects/unreadable")
+	ops := fake.ops()
+	readDir := ops.readDir
+	ops.readDir = func(name string) ([]os.FileInfo, error) {
+		if name == unreadable {
+			return nil, &fs.PathError{Op: "readdir", Path: name, Err: fs.ErrPermission}
+		}
+		return readDir(name)
+	}
+	source, err := newSource(ops, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, _, failures, err := collectIncremental(source, time.Unix(2500, 0).UnixMilli(), time.Unix(3000, 0), baseline)
+	if err != nil {
+		t.Fatalf("partial refresh: %v", err)
+	}
+	if len(after.Families) != 1 || after.Families[0].FamilyID != retainedID {
+		t.Fatalf("skipped directory tombstoned cached family: %+v", after.Families)
+	}
+	var claudeCoverage *AgentCoverage
+	for index := range after.Coverage {
+		if after.Coverage[index].Agent == vendors.AgentClaude {
+			claudeCoverage = &after.Coverage[index]
+		}
+	}
+	if claudeCoverage == nil || claudeCoverage.SkippedEntries != 1 {
+		t.Fatalf("skipped directory coverage = %+v", claudeCoverage)
+	}
+	if len(failures) == 0 {
+		t.Fatal("skipped directory was not reported as partial collection")
+	}
+	if after.CoverageSinceMs != baseline.CoverageSinceMs {
+		t.Fatalf("incomplete enumeration advanced coverage from %d to %d", baseline.CoverageSinceMs, after.CoverageSinceMs)
 	}
 }
 

--- a/collector/internal/remote/collect_integration_test.go
+++ b/collector/internal/remote/collect_integration_test.go
@@ -46,7 +46,7 @@ func TestCodexRemoteFamiliesSelectRecentChildOfOldRoot(t *testing.T) {
 	root := writeCodexFixture(fs, rootID, "", time.Unix(1000, 0))
 	child := writeCodexFixture(fs, childID, rootID, time.Unix(2000, 0))
 
-	families, _, _, _, _, _, err := codex.BuildRemoteFamilies(
+	families, _, _, _, _, _, _, err := codex.BuildRemoteFamilies(
 		newFakeSource(fs, Limits{}), fakeHome, time.Unix(1500, 0).UnixMilli(), nil, nil,
 	)
 	if err != nil {
@@ -68,7 +68,7 @@ func TestCodexRemoteFamiliesSelectLiveChildOfOldRoot(t *testing.T) {
 	writeCodexFixture(fs, rootID, "", time.Unix(1000, 0))
 	writeCodexFixture(fs, childID, rootID, time.Unix(1000, 0))
 
-	families, _, _, _, _, _, err := codex.BuildRemoteFamilies(
+	families, _, _, _, _, _, _, err := codex.BuildRemoteFamilies(
 		newFakeSource(fs, Limits{}), fakeHome, time.Unix(1500, 0).UnixMilli(),
 		map[string]string{childID: "interactive"}, nil,
 	)
@@ -86,7 +86,7 @@ func TestCodexRemoteFamiliesExcludeOldUnreadableFileOutsideWindow(t *testing.T) 
 	file := path.Join(fakeHome, ".codex/sessions/2026/08/18", "rollout-2026-08-18T10-00-00-"+id+".jsonl")
 	fs.writeFile(file, "{not valid json", time.Unix(1000, 0))
 
-	families, _, _, failed, _, _, err := codex.BuildRemoteFamilies(
+	families, _, _, failed, _, _, _, err := codex.BuildRemoteFamilies(
 		newFakeSource(fs, Limits{}), fakeHome, time.Unix(1500, 0).UnixMilli(), nil, nil,
 	)
 	if err != nil {
@@ -97,6 +97,50 @@ func TestCodexRemoteFamiliesExcludeOldUnreadableFileOutsideWindow(t *testing.T) 
 	}
 	if len(families) != 0 {
 		t.Fatalf("old unreadable file bypassed the requested window: %#v", families)
+	}
+}
+
+func TestCollectIncrementalHandlesMissingVendorRoots(t *testing.T) {
+	tests := []struct {
+		name         string
+		setup        func(*fakeFS)
+		wantFamilies int
+	}{
+		{name: "neither vendor installed", wantFamilies: 0},
+		{
+			name: "Claude only",
+			setup: func(fs *fakeFS) {
+				writeClaudeFixture(fs, "project", "aaaaaaaa-0000-0000-0000-000000000001", 1, 1, time.Unix(1000, 0))
+			},
+			wantFamilies: 1,
+		},
+		{
+			name: "Codex only",
+			setup: func(fs *fakeFS) {
+				writeCodexFixture(fs, "11111111-2222-3333-4444-555555555555", "", time.Unix(1000, 0))
+			},
+			wantFamilies: 1,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fs := newFakeFS()
+			if test.setup != nil {
+				test.setup(fs)
+			}
+			snapshot, sessions, failures, err := collectIncremental(
+				newFakeSource(fs, Limits{}), 0, time.Unix(2000, 0), CachedSnapshotV2{},
+			)
+			if err != nil {
+				t.Fatalf("collectIncremental: %v", err)
+			}
+			if len(failures) != 0 {
+				t.Fatalf("missing optional vendor root produced failures: %v", failures)
+			}
+			if len(snapshot.Families) != test.wantFamilies || len(sessions) != test.wantFamilies {
+				t.Fatalf("families=%d sessions=%d, want %d", len(snapshot.Families), len(sessions), test.wantFamilies)
+			}
+		})
 	}
 }
 

--- a/collector/internal/remote/embedded_helpers.go
+++ b/collector/internal/remote/embedded_helpers.go
@@ -1,0 +1,74 @@
+//go:build embedded_helpers
+
+package remote
+
+import (
+	"context"
+	_ "embed"
+	"errors"
+	"math"
+	"slices"
+
+	"github.com/centauri-ai/coslash/collector/internal/remotefacts"
+	"github.com/centauri-ai/coslash/collector/internal/remoteprotocol"
+)
+
+// These files are generated immediately before an embedded release build and
+// removed afterward. They are never checked into the repository.
+//
+//go:embed helperassets/coslash-helper_linux_amd64
+var embeddedHelperAMD64 []byte
+
+//go:embed helperassets/coslash-helper_linux_arm64
+var embeddedHelperARM64 []byte
+
+// Set by release builds so the remote versioned install path matches the
+// containing Coslash release. A tagged build that forgets the ldflag fails
+// closed instead of publishing an ambiguous development helper.
+var embeddedHelperVersion = ""
+
+type embeddedHelperReleaseProvider struct {
+	document  SignedReleaseMetadata
+	artifacts map[string][]byte
+}
+
+func newProductionHelperReleaseProvider() (HelperReleaseProvider, bool) {
+	if !helperVersionPattern.MatchString(embeddedHelperVersion) ||
+		len(embeddedHelperAMD64) == 0 || len(embeddedHelperARM64) == 0 {
+		return unavailableReleaseProvider{}, false
+	}
+	artifacts := map[string][]byte{
+		"linux/amd64": embeddedHelperAMD64,
+		"linux/arm64": embeddedHelperARM64,
+	}
+	metadata := ReleaseMetadata{Sequence: 1, ExpiresAtUnix: math.MaxInt64}
+	for _, arch := range []string{"amd64", "arm64"} {
+		content := artifacts["linux/"+arch]
+		metadata.Artifacts = append(metadata.Artifacts, Artifact{
+			Version: embeddedHelperVersion, OS: "linux", Arch: arch,
+			Size: int64(len(content)), SHA256: digest(content), Current: true,
+			Protocol: remoteprotocol.VersionRange{Min: remoteprotocol.ProtocolVersion, Max: remoteprotocol.ProtocolVersion},
+			Schema:   remoteprotocol.VersionRange{Min: remotefacts.SchemaVersion, Max: remotefacts.SchemaVersion},
+		})
+	}
+	if err := metadata.Validate(); err != nil {
+		return unavailableReleaseProvider{}, false
+	}
+	return &embeddedHelperReleaseProvider{
+		document:  SignedReleaseMetadata{Metadata: metadata, embedded: true},
+		artifacts: artifacts,
+	}, true
+}
+
+func (provider *embeddedHelperReleaseProvider) LoadMetadata(context.Context) (SignedReleaseMetadata, error) {
+	return provider.document, nil
+}
+
+func (provider *embeddedHelperReleaseProvider) LoadArtifact(_ context.Context, artifact Artifact) ([]byte, error) {
+	content, ok := provider.artifacts[artifact.OS+"/"+artifact.Arch]
+	if !ok || artifact.Version != embeddedHelperVersion ||
+		int64(len(content)) != artifact.Size || digest(content) != artifact.SHA256 {
+		return nil, errors.New("embedded helper artifact is unavailable")
+	}
+	return slices.Clone(content), nil
+}

--- a/collector/internal/remote/embedded_helpers_disabled.go
+++ b/collector/internal/remote/embedded_helpers_disabled.go
@@ -1,0 +1,7 @@
+//go:build !embedded_helpers
+
+package remote
+
+func newProductionHelperReleaseProvider() (HelperReleaseProvider, bool) {
+	return unavailableReleaseProvider{}, false
+}

--- a/collector/internal/remote/embedded_helpers_test.go
+++ b/collector/internal/remote/embedded_helpers_test.go
@@ -1,0 +1,44 @@
+//go:build embedded_helpers
+
+package remote
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestEmbeddedHelperReleaseProvider(t *testing.T) {
+	provider, available := newProductionHelperReleaseProvider()
+	if !available {
+		t.Fatal("tagged build did not enable the embedded helper provider")
+	}
+	document, err := provider.LoadMetadata(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := (TrustStore{}).Verify(document); !errors.Is(err, ErrHelperMetadata) {
+		t.Fatalf("untrusted embedded document error = %v", err)
+	}
+	metadata, err := (TrustStore{AllowEmbedded: true}).Verify(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(metadata.Artifacts) != 2 {
+		t.Fatalf("embedded artifacts = %d, want 2", len(metadata.Artifacts))
+	}
+	seen := map[string]bool{}
+	for _, artifact := range metadata.Artifacts {
+		content, err := provider.LoadArtifact(context.Background(), artifact)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := verifyLocalArtifact(artifact, content); err != nil {
+			t.Fatalf("verify embedded linux/%s helper: %v", artifact.Arch, err)
+		}
+		seen[artifact.Arch] = true
+	}
+	if !seen["amd64"] || !seen["arm64"] {
+		t.Fatalf("embedded architectures = %v", seen)
+	}
+}

--- a/collector/internal/remote/generation.go
+++ b/collector/internal/remote/generation.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"github.com/centauri-ai/coslash/collector/internal/collector"
+	"github.com/centauri-ai/coslash/collector/internal/remotefacts"
 	"github.com/centauri-ai/coslash/collector/internal/remoteprotocol"
 	"github.com/centauri-ai/coslash/collector/internal/session"
 	"github.com/centauri-ai/coslash/collector/internal/vendors"
@@ -159,9 +160,26 @@ func baselineFamilies(snapshot CachedSnapshotV2, vendor string) map[string]Cache
 func knownFamiliesFor(snapshot CachedSnapshotV2) []remoteprotocol.KnownFamily {
 	known := make([]remoteprotocol.KnownFamily, 0, len(snapshot.Families))
 	for _, family := range snapshot.Families {
-		known = append(known, remoteprotocol.KnownFamily{
+		item := remoteprotocol.KnownFamily{
 			Vendor: family.Vendor, FamilyID: family.FamilyID, Fingerprint: family.Fingerprint,
-		})
+		}
+		if family.Vendor == vendors.AgentCodex {
+			fingerprints := make(map[string]remotefacts.Fingerprint, len(family.Facts.Fingerprints))
+			for _, fingerprint := range family.Facts.Fingerprints {
+				fingerprints[fingerprint.Key] = fingerprint
+			}
+			for _, mapping := range family.Facts.HeaderMappings {
+				fingerprint, ok := fingerprints[mapping.Key]
+				if !ok {
+					continue
+				}
+				item.Headers = append(item.Headers, remoteprotocol.KnownHeader{
+					Key: mapping.Key, Size: fingerprint.Size, ModifiedAtMs: fingerprint.ModifiedAtMs,
+					SessionID: mapping.SessionID, ParentID: mapping.ParentID,
+				})
+			}
+		}
+		known = append(known, item)
 	}
 	return known
 }

--- a/collector/internal/remote/health.go
+++ b/collector/internal/remote/health.go
@@ -36,18 +36,27 @@ const (
 )
 
 type Health struct {
-	SourceID         string          `json:"sourceId"`
-	Label            string          `json:"label"`
-	State            State           `json:"state"`
-	Complete         bool            `json:"complete"`
-	Reason           *Reason         `json:"reason,omitempty"`
-	LastSuccessAtMs  *int64          `json:"lastSuccessAtMs,omitempty"`
-	CoverageSinceMs  *int64          `json:"coverageSinceMs,omitempty"`
-	RoundTripMs      *int64          `json:"roundTripMs,omitempty"`
-	Coverage         []AgentCoverage `json:"coverage,omitempty"`
-	Error            string          `json:"error,omitempty"`
-	DiagnosticStderr string          `json:"-"`
-	Refreshing       bool            `json:"-"`
+	SourceID                    string            `json:"sourceId"`
+	Label                       string            `json:"label"`
+	State                       State             `json:"state"`
+	Complete                    bool              `json:"complete"`
+	Reason                      *Reason           `json:"reason,omitempty"`
+	LastSuccessAtMs             *int64            `json:"lastSuccessAtMs,omitempty"`
+	CoverageSinceMs             *int64            `json:"coverageSinceMs,omitempty"`
+	RoundTripMs                 *int64            `json:"roundTripMs,omitempty"`
+	Coverage                    []AgentCoverage   `json:"coverage,omitempty"`
+	Error                       string            `json:"error,omitempty"`
+	Refreshing                  bool              `json:"-"`
+	Transport                   Transport         `json:"transport"`
+	Helper                      *HelperStatus     `json:"helper,omitempty"`
+	Metrics                     CollectionMetrics `json:"metrics"`
+	HelperInstallationAvailable bool              `json:"helperInstallationAvailable"`
+	HelperProbeState            string            `json:"helperProbeState"`
+	// HelperOwnershipRecorded is deliberately separate from Helper.Version:
+	// a persisted ownership record survives a failed read-only inspection and
+	// must still prevent a silent alias replacement.
+	HelperOwnershipRecorded bool `json:"helperOwnershipRecorded"`
+	HelperOwnershipCorrupt  bool `json:"helperOwnershipCorrupt"`
 }
 
 func reasonPtr(reason Reason) *Reason { return &reason }
@@ -104,6 +113,11 @@ func genericErrorCopy(reason Reason) string {
 		return "refresh timed out"
 	case ReasonHistoryTruncated:
 		return "history truncated by safety limits"
+	case ReasonHelperMissing, ReasonHelperBlocked, ReasonHelperIncompatible,
+		ReasonHelperFailed, ReasonOutputLimit, ReasonHelperUnsupported,
+		ReasonHelperVerification, ReasonHelperInstallation, ReasonHelperRevoked,
+		ReasonHelperUpgrade, ReasonHelperRollback:
+		return helperErrorCopy(reason)
 	default:
 		return "remote refresh failed"
 	}

--- a/collector/internal/remote/helperexec.go
+++ b/collector/internal/remote/helperexec.go
@@ -113,6 +113,7 @@ func shellQuote(value string) string {
 type HelperResult struct {
 	Capabilities    remoteprotocol.Capabilities
 	Proposal        remoteprotocol.Generation
+	Coverage        []AgentCoverage
 	Records         int
 	ResponseBytes   int
 	RequestBytes    int
@@ -227,6 +228,7 @@ func HelperCollect(
 	writeErr := <-written
 	result := HelperResult{
 		Proposal: accumulator.Proposal(), Records: stream.records,
+		Coverage:      stream.coverage,
 		ResponseBytes: stream.bytes, RequestBytes: len(payload),
 		RequestComplete: stream.complete, ExitCode: exitCode,
 		Stderr: process.stderr.String(), RoundTrip: time.Since(started),
@@ -268,6 +270,7 @@ func marshalRequestLine(request remoteprotocol.Request) ([]byte, error) {
 type streamOutcome struct {
 	records  int
 	bytes    int
+	coverage []AgentCoverage
 	complete bool
 	err      error
 }
@@ -303,6 +306,13 @@ func streamRecords(
 		if err := accumulator.Apply(record); err != nil {
 			outcome.err = fmt.Errorf("%w: %w", ErrHelperFailed, err)
 			return outcome
+		}
+		if record.Type == remoteprotocol.RecordVendorComplete {
+			outcome.coverage = append(outcome.coverage, AgentCoverage{
+				Agent: record.Vendor, CandidateFiles: record.Counts.CandidateFiles,
+				SelectedFiles: record.Counts.SelectedFiles,
+				Truncated:     !record.InventoryComplete,
+			})
 		}
 		outcome.records++
 		if record.Type == remoteprotocol.RecordRequestComplete {

--- a/collector/internal/remote/helperexec_test.go
+++ b/collector/internal/remote/helperexec_test.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -115,6 +117,42 @@ func TestHelperArgsRejectInjection(t *testing.T) {
 	}
 }
 
+func TestRunSSHCommandBoundsControlOutput(t *testing.T) {
+	options := fakeOptions([]byte(strings.Repeat("x", 100)), 0, "", false)
+	options.Limits.MaxStderrBytes = 16
+	err := runSSHCommand(context.Background(), options, []string{"-O", "check", "host"})
+	if !errors.Is(err, ErrStderrLimit) {
+		t.Fatalf("runSSHCommand error = %v, want ErrStderrLimit", err)
+	}
+}
+
+func TestRunSSHCommandKillsProcessGroupOnOutputFlood(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "child-pid")
+	t.Setenv("COSLASH_FAKE_SPAWN_CHILD", "1")
+	t.Setenv("COSLASH_FAKE_CHILD_PID", marker)
+	options := fakeOptions([]byte(strings.Repeat("x", 100)), 0, "", false)
+	options.Limits.MaxStderrBytes = 16
+	if err := runSSHCommand(context.Background(), options, []string{"-O", "check", "host"}); !errors.Is(err, ErrStderrLimit) {
+		t.Fatalf("runSSHCommand error = %v, want ErrStderrLimit", err)
+	}
+	data, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("read child pid: %v", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 {
+		t.Fatalf("child pid = %q, error = %v", data, err)
+	}
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(pid, 0); errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("control command left child process %d running", pid)
+}
+
 func completeResponse(t *testing.T) (remoteprotocol.Request, remoteprotocol.Generation, []byte) {
 	t.Helper()
 	request := remoteprotocol.Request{
@@ -158,6 +196,20 @@ func fakeOptions(output []byte, exitCode int, stderr string, hang bool) OpenOpti
 func TestHelperExecProcess(t *testing.T) {
 	if os.Getenv("COSLASH_FAKE_HELPER") != "1" {
 		return
+	}
+	if os.Getenv("COSLASH_FAKE_CHILD") == "1" {
+		time.Sleep(time.Hour)
+		return
+	}
+	if os.Getenv("COSLASH_FAKE_SPAWN_CHILD") == "1" {
+		child := exec.Command(os.Args[0], "-test.run=TestHelperExecProcess", "--")
+		child.Env = append(os.Environ(), "COSLASH_FAKE_CHILD=1")
+		if err := child.Start(); err != nil {
+			os.Exit(97)
+		}
+		if err := os.WriteFile(os.Getenv("COSLASH_FAKE_CHILD_PID"), []byte(strconv.Itoa(child.Process.Pid)), 0o600); err != nil {
+			os.Exit(98)
+		}
 	}
 	_, _ = os.Stdout.WriteString(os.Getenv("COSLASH_FAKE_OUTPUT"))
 	_, _ = os.Stderr.WriteString(os.Getenv("COSLASH_FAKE_STDERR"))

--- a/collector/internal/remote/helperhealth.go
+++ b/collector/internal/remote/helperhealth.go
@@ -36,6 +36,8 @@ func classifyHelperError(err error) Reason {
 		return ReasonHelperBlocked
 	case errors.Is(err, ErrHelperIncompatible):
 		return ReasonHelperIncompatible
+	case errors.Is(err, ErrHelperVerification):
+		return ReasonHelperVerification
 	case errors.Is(err, ErrHelperPartial):
 		return ReasonPartialAgentData
 	case errors.Is(err, ErrHelperOutputLimit), errors.Is(err, ErrStderrLimit):

--- a/collector/internal/remote/helperhealth.go
+++ b/collector/internal/remote/helperhealth.go
@@ -20,6 +20,7 @@ const (
 	ReasonHelperRevoked      Reason = "helper_revoked"
 	ReasonHelperUpgrade      Reason = "helper_upgrade_required"
 	ReasonHelperRollback     Reason = "helper_rolled_back"
+	ReasonHelperConsent      Reason = "helper_consent_required"
 )
 
 // classifyHelperError maps one collect or handshake failure to a stable reason.
@@ -47,7 +48,7 @@ func classifyHelperError(err error) Reason {
 		errors.Is(err, ErrInvalidAlias):
 		return ReasonHelperFailed
 	case errors.Is(err, ErrHelperFailed):
-		return ReasonInvalidData
+		return ReasonHelperFailed
 	default:
 		return classifyError(err)
 	}
@@ -57,6 +58,8 @@ func classifyHelperError(err error) Reason {
 // failures so callers can accurately offer SFTP, consent, or repair actions.
 func classifyLifecycleError(err error) Reason {
 	switch {
+	case errors.Is(err, errHelperReleaseUnavailable):
+		return ReasonHelperMissing
 	case errors.Is(err, ErrUnsupportedHelperPlatform):
 		return ReasonHelperUnsupported
 	case errors.Is(err, ErrHelperMetadata), errors.Is(err, ErrHelperArtifact),
@@ -66,8 +69,9 @@ func classifyLifecycleError(err error) Reason {
 		return ReasonHelperBlocked
 	case errors.Is(err, ErrHelperRevoked):
 		return ReasonHelperRevoked
-	case errors.Is(err, ErrHelperConsentRequired), errors.Is(err, ErrHelperUpgradeRequired),
-		errors.Is(err, ErrHelperIncompatible):
+	case errors.Is(err, ErrHelperConsentRequired):
+		return ReasonHelperConsent
+	case errors.Is(err, ErrHelperUpgradeRequired), errors.Is(err, ErrHelperIncompatible):
 		return ReasonHelperUpgrade
 	case errors.Is(err, ErrHelperRollback):
 		return ReasonHelperRollback
@@ -100,9 +104,15 @@ func helperErrorCopy(reason Reason) string {
 		return "collection helper was revoked and will not run"
 	case ReasonHelperUpgrade:
 		return "collection helper needs an approved upgrade"
+	case ReasonHelperConsent:
+		return "collection helper installation needs your consent"
 	case ReasonHelperRollback:
 		return "collection helper upgrade was rolled back"
 	default:
 		return genericErrorCopy(reason)
 	}
 }
+
+// HelperErrorCopy exposes only stable, generic user copy for API setup
+// outcomes. It intentionally cannot expose stderr or wrapped remote errors.
+func HelperErrorCopy(reason Reason) string { return helperErrorCopy(reason) }

--- a/collector/internal/remote/helpermanager.go
+++ b/collector/internal/remote/helpermanager.go
@@ -73,10 +73,13 @@ const (
 type lifecycleFactory func(alias string) (Lifecycle, error)
 
 type helperTarget struct {
-	path    string
-	version string
-	state   LifecycleState
+	path     string
+	version  string
+	state    LifecycleState
+	artifact Artifact
 }
+
+type helperVerifyFunc func(context.Context, string, helperTarget) error
 
 type helperProbeState string
 
@@ -244,7 +247,7 @@ func (manager *Manager) runHelperDiscovery(ctx context.Context, config settings.
 		status := lifecycleStatus(result)
 		manager.helper = &status
 		if !useSFTPFallbackAfterDiscovery(result) {
-			manager.helperTarget = &helperTarget{path: result.Path, version: result.Artifact.Version, state: result.State}
+			manager.helperTarget = &helperTarget{path: result.Path, version: result.Artifact.Version, state: result.State, artifact: result.Artifact}
 			manager.helperVersion = result.Artifact.Version
 			// This records ownership locally, never remote execution authority.
 			if storeErr := manager.cache.StoreHelperVersion(config.ID, result.Artifact.Version, config.SSHAlias); storeErr != nil {
@@ -319,7 +322,7 @@ func (manager *Manager) SetupHelper(ctx context.Context, consent Consent) Health
 			manager.helperTarget = nil
 			return manager.healthLocked(manager.lastRequestedMs)
 		}
-		manager.helperTarget = &helperTarget{path: result.Path, version: result.Artifact.Version, state: result.State}
+		manager.helperTarget = &helperTarget{path: result.Path, version: result.Artifact.Version, state: result.State, artifact: result.Artifact}
 		manager.helperVersion = result.Artifact.Version
 		manager.helperProbe = helperProbeReady
 	} else {
@@ -425,11 +428,16 @@ func (manager *Manager) TestHelper(ctx context.Context) HelperTestResult {
 	target := *manager.helperTarget
 	baseline := snapshotOrEmpty(manager.snapshot)
 	refresh := manager.helperRefresh
+	verify := manager.helperVerify
 	now := manager.now()
 	manager.mu.Unlock()
 
 	since := now.Add(-24 * time.Hour).UnixMilli()
-	result, err := refresh(ctx, config.SSHAlias, since, now, baseline, target)
+	err := verify(ctx, config.SSHAlias, target)
+	var result refreshOutcome
+	if err == nil {
+		result, err = refresh(ctx, config.SSHAlias, since, now, baseline, target)
+	}
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
 	if manager.cfg == nil || manager.cfg.ID != config.ID || manager.cfg.SSHAlias != config.SSHAlias {

--- a/collector/internal/remote/helpermanager.go
+++ b/collector/internal/remote/helpermanager.go
@@ -409,8 +409,10 @@ type HelperTestResult struct {
 
 // TestHelper performs a small, non-persisting collection after setup. It uses
 // the verified target already held by the manager, so a test can never execute
-// a frontend- or response-supplied path. The normal requested-window refresh
-// remains responsible for durable cache commits.
+// a frontend- or response-supplied path. Failure must not schedule refresh
+// backoff, flip transport, or rewrite durable board failure state; only a
+// successful probe may advertise helper transport. The normal requested-window
+// refresh remains responsible for durable cache commits and retry policy.
 func (manager *Manager) TestHelper(ctx context.Context) HelperTestResult {
 	manager.mu.Lock()
 	if manager.cfg == nil || !manager.cfg.Enabled || manager.helperTarget == nil {
@@ -434,13 +436,12 @@ func (manager *Manager) TestHelper(ctx context.Context) HelperTestResult {
 		health := manager.healthLocked(manager.lastRequestedMs)
 		return HelperTestResult{Health: health, Reason: health.Reason}
 	}
-	manager.transport = TransportHelper
-	manager.metrics = metricsFor(result)
 	if err != nil {
 		reason := classifyHelperError(err)
-		manager.applyFailureLocked(reason, result.Stderr)
 		return HelperTestResult{Health: manager.healthLocked(manager.lastRequestedMs), Reason: reasonPtr(reason)}
 	}
+	manager.transport = TransportHelper
+	manager.metrics = metricsFor(result)
 	if reason := limitedResultReason(result); reason != nil {
 		manager.state = StateLimited
 		manager.complete = false

--- a/collector/internal/remote/helpermanager.go
+++ b/collector/internal/remote/helpermanager.go
@@ -294,9 +294,24 @@ func (manager *Manager) setupHelper(ctx context.Context, expectedAlias string, c
 		manager.mu.Unlock()
 		return health, ErrHelperAliasMismatch
 	}
+	if manager.helperSetup {
+		health := manager.healthLocked(manager.lastRequestedMs)
+		manager.mu.Unlock()
+		return health, ErrHelperSetupInProgress
+	}
 	config := *manager.cfg
 	provider, factory := manager.releaseProvider, manager.lifecycleFactory
+	// Keep this host identity reserved until setup has either recorded
+	// ownership or finished without installing anything. SetupWithLoader can
+	// release this mutex while uploading the helper, so ApplySettings must not
+	// replace the alias in that interval.
+	manager.helperSetup = true
 	manager.mu.Unlock()
+	defer func() {
+		manager.mu.Lock()
+		manager.helperSetup = false
+		manager.mu.Unlock()
+	}()
 
 	if !manager.helperInstallationAvailable || provider == nil || factory == nil {
 		manager.mu.Lock()
@@ -487,6 +502,9 @@ func (manager *Manager) TestHelper(ctx context.Context) HelperTestResult {
 func (manager *Manager) ValidateSettingsChangeWithOwnershipAction(next *settings.RemoteSettings, action OwnershipAction) error {
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
+	if manager.helperSetup {
+		return ErrHelperSetupInProgress
+	}
 	if action != OwnershipActionRelease && action != OwnershipActionUninstall {
 		return ErrHelperOwnershipConflict
 	}

--- a/collector/internal/remote/helpermanager.go
+++ b/collector/internal/remote/helpermanager.go
@@ -1,0 +1,509 @@
+package remote
+
+import (
+	"context"
+	"crypto/ed25519"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/centauri-ai/coslash/collector/internal/remoteprotocol"
+	"github.com/centauri-ai/coslash/collector/internal/settings"
+)
+
+// Transport identifies the collection path that produced the current view.
+// It is deliberately independent of the cache and wire protocol.
+type Transport string
+
+const (
+	TransportSFTP   Transport = "sftp"
+	TransportHelper Transport = "helper"
+)
+
+// useSFTPFallbackAfterDiscovery is the complete pre-execution policy. A
+// helper is selected only after it is verified and capability-compatible;
+// every other discovery state retains usable, visibly labelled SFTP. Runtime
+// helper protocol/data/output failures deliberately do not call this policy:
+// they preserve cache and report the helper failure without masking it.
+func useSFTPFallbackAfterDiscovery(result LifecycleResult) bool {
+	return !result.CanExecute
+}
+
+// HelperStatus contains only display-safe lifecycle facts. It never contains
+// stderr, remote paths, release URLs, or an artifact digest.
+type HelperStatus struct {
+	State      LifecycleState `json:"state"`
+	Version    string         `json:"version,omitempty"`
+	Compatible bool           `json:"compatible"`
+	Fallback   bool           `json:"fallback"`
+	// Reused is true only when the currently selected helper was freshly
+	// re-verified in place rather than uploaded during this lifecycle pass.
+	Reused bool    `json:"reused,omitempty"`
+	Reason *Reason `json:"reason,omitempty"`
+}
+
+// CollectionMetrics are bounded, content-free diagnostics for the last
+// collection attempt.
+type CollectionMetrics struct {
+	RequestBytes  int   `json:"requestBytes,omitempty"`
+	ResponseBytes int   `json:"responseBytes,omitempty"`
+	Records       int   `json:"records,omitempty"`
+	RoundTripMs   int64 `json:"roundTripMs,omitempty"`
+}
+
+// HelperReleaseProvider supplies an app-authenticated release document and
+// exact artifact bytes. The frontend never supplies either value.
+type HelperReleaseProvider interface {
+	LoadMetadata(context.Context) (SignedReleaseMetadata, error)
+	LoadArtifact(context.Context, Artifact) ([]byte, error)
+}
+
+// OwnershipAction is carried with a settings replacement and is deliberately
+// not a standalone UI mutation.  That prevents an abandoned settings draft
+// from forgetting ownership of a still-configured remote helper.
+type OwnershipAction string
+
+const (
+	OwnershipActionNone      OwnershipAction = ""
+	OwnershipActionRelease   OwnershipAction = "release"
+	OwnershipActionUninstall OwnershipAction = "uninstall"
+)
+
+type lifecycleFactory func(alias string) (Lifecycle, error)
+
+type helperTarget struct {
+	path    string
+	version string
+	state   LifecycleState
+}
+
+type helperProbeState string
+
+const (
+	helperProbeUnknown  helperProbeState = "unknown"
+	helperProbeProbing  helperProbeState = "probing"
+	helperProbeReady    helperProbeState = "ready"
+	helperProbeFallback helperProbeState = "fallback"
+)
+
+func lifecycleStatus(result LifecycleResult) HelperStatus {
+	status := HelperStatus{
+		State: result.State, Version: result.Artifact.Version,
+		Compatible: result.CanExecute, Fallback: result.Fallback, Reused: result.Reused,
+	}
+	if result.Reason != nil {
+		status.Reason = reasonPtr(classifyLifecycleError(result.Reason))
+	}
+	return status
+}
+
+func helperRefreshWithOpen(
+	ctx context.Context,
+	alias string,
+	since int64,
+	now time.Time,
+	baseline CachedSnapshotV2,
+	target helperTarget,
+	open OpenOptions,
+) (refreshOutcome, error) {
+	request, err := buildLocalRequest(
+		fmt.Sprintf("helper-%d", now.UnixNano()), since, now.UnixMilli(), baseline.BaselineID, knownFamiliesFor(baseline),
+	)
+	if err != nil {
+		return refreshOutcome{}, fmt.Errorf("build helper collection request: %w", err)
+	}
+	effectiveBaseline := baseline
+	if request.BaselineMode == remoteprotocol.BaselineNone {
+		// Omitted known data must not be treated as an implicit baseline.
+		effectiveBaseline = CachedSnapshotV2{Version: cacheV2Version, CodexHeaders: baseline.CodexHeaders}
+	}
+	result, collectErr := HelperCollect(ctx, alias, target.path, request, toGeneration(effectiveBaseline), open)
+	snapshot := fromGeneration(result.Proposal, result.Coverage, now.UnixMilli(), result.RoundTrip.Milliseconds(), nil)
+	outcome := refreshOutcome{
+		Snapshot: snapshot,
+		Sessions: composeFromGeneration(result.Proposal, nullReadSource{}, nil, since),
+		Stderr:   result.Stderr, RoundTrip: result.RoundTrip,
+		Metrics: CollectionMetrics{RequestBytes: result.RequestBytes, ResponseBytes: result.ResponseBytes, Records: result.Records, RoundTripMs: result.RoundTrip.Milliseconds()},
+	}
+	if collectErr == nil {
+		return outcome, nil
+	}
+	// A helper can have emitted valid family records before a bounded partial
+	// result. Preserve those facts and show the exact limited reason; do not
+	// hide a protocol/data failure behind a second SFTP pass.
+	if result.Records > 1 {
+		outcome.Failures = []error{collectErr}
+		return outcome, nil
+	}
+	return outcome, collectErr
+}
+
+func defaultLifecycleFactory(trust TrustStore) lifecycleFactory {
+	return func(alias string) (Lifecycle, error) {
+		remote, err := NewSSHLifecycleRemote(alias, OpenOptions{})
+		if err != nil {
+			return Lifecycle{}, err
+		}
+		return Lifecycle{Remote: remote, Trust: trust}, nil
+	}
+}
+
+func unavailableHelperStatus(err error) HelperStatus {
+	return HelperStatus{
+		State: LifecycleSFTP, Fallback: true,
+		Reason: reasonPtr(classifyLifecycleError(err)),
+	}
+}
+
+var errHelperReleaseUnavailable = errors.New("helper release is not configured")
+
+type unavailableReleaseProvider struct{}
+
+func (unavailableReleaseProvider) LoadMetadata(context.Context) (SignedReleaseMetadata, error) {
+	return SignedReleaseMetadata{}, errHelperReleaseUnavailable
+}
+
+func (unavailableReleaseProvider) LoadArtifact(context.Context, Artifact) ([]byte, error) {
+	return nil, errHelperReleaseUnavailable
+}
+
+// NewProductionManager centralizes the production wiring. Release builds
+// compile both Linux helpers into the Coslash executable; ordinary go test and
+// go run builds deliberately use the unavailable provider so generated binary
+// assets are never required in the source tree.
+func NewProductionManager() (*Manager, error) {
+	provider, embedded := newProductionHelperReleaseProvider()
+	trust := TrustStore{
+		Keys: map[string]ed25519.PublicKey{}, RevokedKeys: map[string]bool{},
+		MinimumSequence: 0,
+		Sequences:       &FileMetadataSequenceStore{Path: filepath.Join(settings.Home(), "helper-release", "sequence")},
+		AllowEmbedded:   embedded,
+	}
+	return NewManager(Options{
+		ReleaseProvider: provider, Trust: trust,
+		HelperInstallationAvailable: embedded,
+	}), nil
+}
+
+// startHelperDiscoveryLocked starts only a read-only verification pass. The
+// Lifecycle receives empty consent, so it can authenticate metadata, probe the
+// platform, inspect files, and negotiate capabilities but can never upload or
+// modify a remote helper.
+func (manager *Manager) startHelperDiscoveryLocked() {
+	if manager.helperProbe != helperProbeUnknown || manager.cfg == nil || manager.lifeCtx == nil {
+		return
+	}
+	if !manager.helperInstallationAvailable || manager.releaseProvider == nil || manager.lifecycleFactory == nil {
+		status := unavailableHelperStatus(errHelperReleaseUnavailable)
+		manager.helper = &status
+		manager.helperProbe = helperProbeFallback
+		return
+	}
+	manager.helperProbe = helperProbeProbing
+	status := HelperStatus{State: LifecycleSFTP}
+	manager.helper = &status
+	config := *manager.cfg
+	go manager.runHelperDiscovery(manager.lifeCtx, config)
+}
+
+// InspectHelper starts (or reports) the non-mutating discovery pass for the
+// setup screen. It never waits on SSH while holding the manager lock.
+func (manager *Manager) InspectHelper() Health {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if manager.cfg != nil && manager.cfg.Enabled {
+		manager.startHelperDiscoveryLocked()
+	}
+	return manager.healthLocked(manager.lastRequestedMs)
+}
+
+func (manager *Manager) runHelperDiscovery(ctx context.Context, config settings.RemoteSettings) {
+	manager.mu.Lock()
+	provider, factory := manager.releaseProvider, manager.lifecycleFactory
+	manager.mu.Unlock()
+	document, err := provider.LoadMetadata(ctx)
+	var result LifecycleResult
+	if err == nil {
+		var lifecycle Lifecycle
+		lifecycle, err = factory(config.SSHAlias)
+		if err == nil {
+			result = lifecycle.SetupWithLoader(ctx, document, Consent{}, provider.LoadArtifact)
+		}
+	}
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if manager.cfg == nil || manager.cfg.ID != config.ID || manager.cfg.SSHAlias != config.SSHAlias || ctx.Err() != nil {
+		return
+	}
+	if err != nil {
+		status := unavailableHelperStatus(err)
+		manager.helper = &status
+		manager.helperProbe = helperProbeFallback
+	} else {
+		status := lifecycleStatus(result)
+		manager.helper = &status
+		if !useSFTPFallbackAfterDiscovery(result) {
+			manager.helperTarget = &helperTarget{path: result.Path, version: result.Artifact.Version, state: result.State}
+			manager.helperVersion = result.Artifact.Version
+			// This records ownership locally, never remote execution authority.
+			if storeErr := manager.cache.StoreHelperVersion(config.ID, result.Artifact.Version, config.SSHAlias); storeErr != nil {
+				failed := unavailableHelperStatus(fmt.Errorf("%w: %v", ErrHelperInstallation, storeErr))
+				manager.helper = &failed
+				manager.helperTarget = nil
+				manager.helperProbe = helperProbeFallback
+			} else {
+				manager.helperProbe = helperProbeReady
+			}
+		} else {
+			manager.helperTarget = nil
+			manager.helperProbe = helperProbeFallback
+		}
+	}
+	// The first ListView window was retained while discovery ran. Only now may
+	// the normal refresh choose helper or explicit SFTP fallback.
+	manager.maybeStartRefreshLocked(manager.lastRequestedMs, false)
+}
+
+// SetupHelper performs a consented setup or repair. It is the only Manager
+// method that can create a helper target; refreshes only execute that stored,
+// verified target.
+func (manager *Manager) SetupHelper(ctx context.Context, consent Consent) Health {
+	manager.mu.Lock()
+	if manager.cfg == nil {
+		manager.mu.Unlock()
+		return Health{State: StateDisabled, Complete: true, Reason: reasonPtr(ReasonDisabled)}
+	}
+	config := *manager.cfg
+	provider, factory := manager.releaseProvider, manager.lifecycleFactory
+	manager.mu.Unlock()
+
+	if !manager.helperInstallationAvailable || provider == nil || factory == nil {
+		manager.mu.Lock()
+		status := unavailableHelperStatus(errHelperReleaseUnavailable)
+		manager.helper = &status
+		health := manager.healthLocked(manager.lastRequestedMs)
+		manager.mu.Unlock()
+		return health
+	}
+	document, err := provider.LoadMetadata(ctx)
+	if err != nil {
+		manager.mu.Lock()
+		status := unavailableHelperStatus(err)
+		manager.helper = &status
+		health := manager.healthLocked(manager.lastRequestedMs)
+		manager.mu.Unlock()
+		return health
+	}
+	lifecycle, err := factory(config.SSHAlias)
+	if err != nil {
+		manager.mu.Lock()
+		status := unavailableHelperStatus(err)
+		manager.helper = &status
+		health := manager.healthLocked(manager.lastRequestedMs)
+		manager.mu.Unlock()
+		return health
+	}
+	result := lifecycle.SetupWithLoader(ctx, document, consent, provider.LoadArtifact)
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if manager.cfg == nil || manager.cfg.ID != config.ID || manager.cfg.SSHAlias != config.SSHAlias {
+		return manager.healthLocked(manager.lastRequestedMs)
+	}
+	status := lifecycleStatus(result)
+	manager.helper = &status
+	if result.CanExecute {
+		if err := manager.cache.StoreHelperVersion(config.ID, result.Artifact.Version, config.SSHAlias); err != nil {
+			status = unavailableHelperStatus(fmt.Errorf("%w: %v", ErrHelperInstallation, err))
+			manager.helper = &status
+			manager.helperTarget = nil
+			return manager.healthLocked(manager.lastRequestedMs)
+		}
+		manager.helperTarget = &helperTarget{path: result.Path, version: result.Artifact.Version, state: result.State}
+		manager.helperVersion = result.Artifact.Version
+		manager.helperProbe = helperProbeReady
+	} else {
+		manager.helperTarget = nil
+		manager.helperProbe = helperProbeFallback
+	}
+	return manager.healthLocked(manager.lastRequestedMs)
+}
+
+// ReleaseHelperOwnership explicitly forgets local ownership without modifying
+// Linux. It is the only path that permits an alias change while intentionally
+// leaving a helper installed.
+func (manager *Manager) ReleaseHelperOwnership() error {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if manager.cfg == nil || (manager.helperVersion == "" && !manager.helperOwnershipCorrupt) {
+		return nil
+	}
+	if err := manager.cache.RemoveHelperVersion(manager.cfg.ID); err != nil {
+		return err
+	}
+	manager.helperVersion = ""
+	manager.helperOwnershipCorrupt = false
+	manager.helperTarget = nil
+	status := HelperStatus{State: LifecycleSFTP, Fallback: true, Reason: reasonPtr(ReasonHelperMissing)}
+	manager.helper = &status
+	manager.helperProbe = helperProbeFallback
+	return nil
+}
+
+// UninstallHelper removes exactly the currently verified artifact. It leaves
+// the local host configuration untouched on error so the caller can retry or
+// deliberately choose remove-only.
+func (manager *Manager) UninstallHelper(ctx context.Context) error {
+	manager.mu.Lock()
+	if manager.helperOwnershipCorrupt {
+		manager.mu.Unlock()
+		return ErrHelperOwnershipCorrupt
+	}
+	if manager.cfg == nil || (manager.helperTarget == nil && manager.helperVersion == "") {
+		manager.mu.Unlock()
+		return nil
+	}
+	config := *manager.cfg
+	version := manager.helperVersion
+	if manager.helperTarget != nil {
+		version = manager.helperTarget.version
+	}
+	provider, factory := manager.releaseProvider, manager.lifecycleFactory
+	manager.mu.Unlock()
+	if provider == nil || factory == nil {
+		return errHelperReleaseUnavailable
+	}
+	document, err := provider.LoadMetadata(ctx)
+	if err != nil {
+		return err
+	}
+	lifecycle, err := factory(config.SSHAlias)
+	if err != nil {
+		return err
+	}
+	if err := lifecycle.Uninstall(ctx, document, version); err != nil {
+		return err
+	}
+	if err := manager.cache.RemoveHelperVersion(config.ID); err != nil {
+		return err
+	}
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if manager.cfg != nil && manager.cfg.ID == config.ID && manager.helperVersion == version {
+		manager.helperTarget = nil
+		manager.helperVersion = ""
+		status := HelperStatus{State: LifecycleSFTP, Fallback: true, Reason: reasonPtr(ReasonHelperMissing)}
+		manager.helper = &status
+	}
+	return nil
+}
+
+// HelperTestResult reports the result of the small setup operation itself.
+// Health remains board/cache health and can be incomplete when its durable
+// snapshot covers a different time window than this non-persisting test.
+type HelperTestResult struct {
+	Health    Health
+	Succeeded bool
+	Reason    *Reason
+}
+
+// TestHelper performs a small, non-persisting collection after setup. It uses
+// the verified target already held by the manager, so a test can never execute
+// a frontend- or response-supplied path. The normal requested-window refresh
+// remains responsible for durable cache commits.
+func (manager *Manager) TestHelper(ctx context.Context) HelperTestResult {
+	manager.mu.Lock()
+	if manager.cfg == nil || !manager.cfg.Enabled || manager.helperTarget == nil {
+		health := manager.healthLocked(manager.lastRequestedMs)
+		manager.mu.Unlock()
+		reason := ReasonHelperMissing
+		return HelperTestResult{Health: health, Reason: &reason}
+	}
+	config := *manager.cfg
+	target := *manager.helperTarget
+	baseline := snapshotOrEmpty(manager.snapshot)
+	refresh := manager.helperRefresh
+	now := manager.now()
+	manager.mu.Unlock()
+
+	since := now.Add(-24 * time.Hour).UnixMilli()
+	result, err := refresh(ctx, config.SSHAlias, since, now, baseline, target)
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if manager.cfg == nil || manager.cfg.ID != config.ID || manager.cfg.SSHAlias != config.SSHAlias {
+		health := manager.healthLocked(manager.lastRequestedMs)
+		return HelperTestResult{Health: health, Reason: health.Reason}
+	}
+	manager.transport = TransportHelper
+	manager.metrics = metricsFor(result)
+	if err != nil {
+		reason := classifyHelperError(err)
+		manager.applyFailureLocked(reason, result.Stderr)
+		return HelperTestResult{Health: manager.healthLocked(manager.lastRequestedMs), Reason: reasonPtr(reason)}
+	}
+	if reason := limitedResultReason(result); reason != nil {
+		manager.state = StateLimited
+		manager.complete = false
+		manager.reason = reasonPtr(*reason)
+		manager.errorCopy = genericErrorCopy(*reason)
+		// An empty host is a valid helper result: the executable completed the
+		// protocol and inspected every supported root, but there is simply no
+		// agent data yet. Keep that useful board state while reporting the setup
+		// operation itself as successful.
+		return HelperTestResult{
+			Health:    manager.healthLocked(manager.lastRequestedMs),
+			Succeeded: *reason == ReasonNoSupportedData,
+			Reason:    reasonPtr(*reason),
+		}
+	}
+	manager.state = StateOK
+	manager.complete = true
+	manager.reason = nil
+	manager.errorCopy = ""
+	manager.diagnostic = ""
+	return HelperTestResult{Health: manager.healthLocked(manager.lastRequestedMs), Succeeded: true}
+}
+
+// ValidateSettingsChangeWithOwnershipAction permits a replacement only when
+// the requested ownership action is bundled with that replacement.  The
+// caller must subsequently call ApplyOwnershipAction before ApplySettings.
+func (manager *Manager) ValidateSettingsChangeWithOwnershipAction(next *settings.RemoteSettings, action OwnershipAction) error {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if action != OwnershipActionRelease && action != OwnershipActionUninstall {
+		return ErrHelperOwnershipConflict
+	}
+	if manager.cfg == nil || (manager.helperVersion == "" && !manager.helperOwnershipCorrupt) {
+		return ErrHelperOwnershipConflict
+	}
+	if manager.helperOwnershipCorrupt && action == OwnershipActionUninstall {
+		return ErrHelperOwnershipCorrupt
+	}
+	if next != nil && manager.cfg.ID == next.ID && manager.cfg.SSHAlias == next.SSHAlias {
+		return ErrHelperOwnershipConflict
+	}
+	// Still validate the proposed settings shape, but ownership is released by
+	// the explicitly requested transaction rather than by this inspection.
+	if next != nil && (!settings.ValidRemoteID(next.ID) || !settings.ValidSSHAlias(next.SSHAlias)) {
+		return ErrInvalidRemoteSettings
+	}
+	return nil
+}
+
+// ApplyOwnershipAction executes the already-authorized operation while the
+// manager still owns the old settings. It is intentionally used only by the
+// settings-save transaction in cmd/coslash.
+func (manager *Manager) ApplyOwnershipAction(ctx context.Context, action OwnershipAction) error {
+	switch action {
+	case OwnershipActionRelease:
+		return manager.ReleaseHelperOwnership()
+	case OwnershipActionUninstall:
+		return manager.UninstallHelper(ctx)
+	default:
+		return ErrHelperOwnershipConflict
+	}
+}
+
+// helperRefreshFunc is kept as a named boundary so manager tests can substitute
+// a deterministic helper without accepting arbitrary remote paths.
+type helperRefreshFunc func(context.Context, string, int64, time.Time, CachedSnapshotV2, helperTarget) (refreshOutcome, error)

--- a/collector/internal/remote/helpermanager.go
+++ b/collector/internal/remote/helpermanager.go
@@ -248,14 +248,15 @@ func (manager *Manager) runHelperDiscovery(ctx context.Context, config settings.
 		manager.helper = &status
 		if !useSFTPFallbackAfterDiscovery(result) {
 			manager.helperTarget = &helperTarget{path: result.Path, version: result.Artifact.Version, state: result.State, artifact: result.Artifact}
-			manager.helperVersion = result.Artifact.Version
 			// This records ownership locally, never remote execution authority.
 			if storeErr := manager.cache.StoreHelperVersion(config.ID, result.Artifact.Version, config.SSHAlias); storeErr != nil {
 				failed := unavailableHelperStatus(fmt.Errorf("%w: %v", ErrHelperInstallation, storeErr))
 				manager.helper = &failed
 				manager.helperTarget = nil
+				manager.helperVersion = ""
 				manager.helperProbe = helperProbeFallback
 			} else {
+				manager.helperVersion = result.Artifact.Version
 				manager.helperProbe = helperProbeReady
 			}
 		} else {
@@ -272,10 +273,26 @@ func (manager *Manager) runHelperDiscovery(ctx context.Context, config settings.
 // method that can create a helper target; refreshes only execute that stored,
 // verified target.
 func (manager *Manager) SetupHelper(ctx context.Context, consent Consent) Health {
+	health, _ := manager.setupHelper(ctx, "", consent)
+	return health
+}
+
+// SetupHelperForAlias binds consented setup to the alias the user tested. It
+// rejects an unsaved settings draft before a lifecycle can contact a host.
+func (manager *Manager) SetupHelperForAlias(ctx context.Context, alias string, consent Consent) (Health, error) {
+	return manager.setupHelper(ctx, alias, consent)
+}
+
+func (manager *Manager) setupHelper(ctx context.Context, expectedAlias string, consent Consent) (Health, error) {
 	manager.mu.Lock()
 	if manager.cfg == nil {
 		manager.mu.Unlock()
-		return Health{State: StateDisabled, Complete: true, Reason: reasonPtr(ReasonDisabled)}
+		return Health{State: StateDisabled, Complete: true, Reason: reasonPtr(ReasonDisabled)}, nil
+	}
+	if expectedAlias != "" && manager.cfg.SSHAlias != expectedAlias {
+		health := manager.healthLocked(manager.lastRequestedMs)
+		manager.mu.Unlock()
+		return health, ErrHelperAliasMismatch
 	}
 	config := *manager.cfg
 	provider, factory := manager.releaseProvider, manager.lifecycleFactory
@@ -287,7 +304,7 @@ func (manager *Manager) SetupHelper(ctx context.Context, consent Consent) Health
 		manager.helper = &status
 		health := manager.healthLocked(manager.lastRequestedMs)
 		manager.mu.Unlock()
-		return health
+		return health, nil
 	}
 	document, err := provider.LoadMetadata(ctx)
 	if err != nil {
@@ -296,7 +313,7 @@ func (manager *Manager) SetupHelper(ctx context.Context, consent Consent) Health
 		manager.helper = &status
 		health := manager.healthLocked(manager.lastRequestedMs)
 		manager.mu.Unlock()
-		return health
+		return health, nil
 	}
 	lifecycle, err := factory(config.SSHAlias)
 	if err != nil {
@@ -305,13 +322,13 @@ func (manager *Manager) SetupHelper(ctx context.Context, consent Consent) Health
 		manager.helper = &status
 		health := manager.healthLocked(manager.lastRequestedMs)
 		manager.mu.Unlock()
-		return health
+		return health, nil
 	}
 	result := lifecycle.SetupWithLoader(ctx, document, consent, provider.LoadArtifact)
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
 	if manager.cfg == nil || manager.cfg.ID != config.ID || manager.cfg.SSHAlias != config.SSHAlias {
-		return manager.healthLocked(manager.lastRequestedMs)
+		return manager.healthLocked(manager.lastRequestedMs), nil
 	}
 	status := lifecycleStatus(result)
 	manager.helper = &status
@@ -320,7 +337,7 @@ func (manager *Manager) SetupHelper(ctx context.Context, consent Consent) Health
 			status = unavailableHelperStatus(fmt.Errorf("%w: %v", ErrHelperInstallation, err))
 			manager.helper = &status
 			manager.helperTarget = nil
-			return manager.healthLocked(manager.lastRequestedMs)
+			return manager.healthLocked(manager.lastRequestedMs), nil
 		}
 		manager.helperTarget = &helperTarget{path: result.Path, version: result.Artifact.Version, state: result.State, artifact: result.Artifact}
 		manager.helperVersion = result.Artifact.Version
@@ -329,7 +346,7 @@ func (manager *Manager) SetupHelper(ctx context.Context, consent Consent) Health
 		manager.helperTarget = nil
 		manager.helperProbe = helperProbeFallback
 	}
-	return manager.healthLocked(manager.lastRequestedMs)
+	return manager.healthLocked(manager.lastRequestedMs), nil
 }
 
 // ReleaseHelperOwnership explicitly forgets local ownership without modifying
@@ -448,28 +465,19 @@ func (manager *Manager) TestHelper(ctx context.Context) HelperTestResult {
 		reason := classifyHelperError(err)
 		return HelperTestResult{Health: manager.healthLocked(manager.lastRequestedMs), Reason: reasonPtr(reason)}
 	}
+	// This is deliberately a non-persisting probe. Do not alter state,
+	// completeness, or sessions: those describe the last durable snapshot and
+	// could otherwise make stale cached data aggregate-eligible. A successful
+	// probe may advertise its verified transport and bounded metrics.
 	manager.transport = TransportHelper
 	manager.metrics = metricsFor(result)
 	if reason := limitedResultReason(result); reason != nil {
-		manager.state = StateLimited
-		manager.complete = false
-		manager.reason = reasonPtr(*reason)
-		manager.errorCopy = genericErrorCopy(*reason)
-		// An empty host is a valid helper result: the executable completed the
-		// protocol and inspected every supported root, but there is simply no
-		// agent data yet. Keep that useful board state while reporting the setup
-		// operation itself as successful.
 		return HelperTestResult{
 			Health:    manager.healthLocked(manager.lastRequestedMs),
 			Succeeded: *reason == ReasonNoSupportedData,
 			Reason:    reasonPtr(*reason),
 		}
 	}
-	manager.state = StateOK
-	manager.complete = true
-	manager.reason = nil
-	manager.errorCopy = ""
-	manager.diagnostic = ""
 	return HelperTestResult{Health: manager.healthLocked(manager.lastRequestedMs), Succeeded: true}
 }
 

--- a/collector/internal/remote/lifecycle.go
+++ b/collector/internal/remote/lifecycle.go
@@ -446,6 +446,29 @@ type Lifecycle struct {
 	Trust  TrustStore
 }
 
+// VerifyExecution revalidates all executable-file invariants immediately
+// before a cached helper target is used. Discovery establishes which signed
+// artifact is allowed; this check ensures the pathname still names those exact
+// bytes with the expected owner and mode.
+func (lifecycle Lifecycle) VerifyExecution(ctx context.Context, path string, artifact Artifact) error {
+	if lifecycle.Remote == nil {
+		return ErrHelperVerification
+	}
+	platform, err := lifecycle.Remote.ProbePlatform(ctx)
+	if err != nil {
+		return err
+	}
+	normalized, err := normalizePlatform(platform.OS, platform.Arch)
+	if err != nil || normalized.OS != artifact.OS || normalized.Arch != artifact.Arch {
+		return ErrHelperVerification
+	}
+	file, err := lifecycle.Remote.Inspect(ctx, path)
+	if err != nil {
+		return err
+	}
+	return verifyRemoteFile(file, path, artifact, platform.UID)
+}
+
 // Setup authenticates metadata before platform lookup or any remote mutation.
 // Consent is per action: initial install and later upgrades are separate, so an
 // old consent cannot silently install fresh executable code.

--- a/collector/internal/remote/lifecycle.go
+++ b/collector/internal/remote/lifecycle.go
@@ -35,7 +35,7 @@ const (
 	// It is user-owned and versioned, so a failed update cannot replace a known
 	// working helper.  A noexec mount is a deliberate SFTP fallback, not a
 	// reason to try a privileged or alternate installation location.
-	HelperInstallBase            = "~/.local/lib/coslash/helpers"
+	HelperInstallBase            = "~/.coslash/helpers"
 	HelperFileName               = "coslash-helper"
 	MaxHelperArtifactBytes int64 = 128 << 20
 )
@@ -141,6 +141,10 @@ type SignedReleaseMetadata struct {
 	KeyID     string          `json:"key_id"`
 	Metadata  ReleaseMetadata `json:"metadata"`
 	Signature string          `json:"signature"`
+	// embedded is set only by the compile-time asset provider. It cannot be
+	// supplied by decoded metadata and makes the containing Coslash binary the
+	// authentication boundary instead of a second runtime signature service.
+	embedded bool
 }
 
 // TrustStore is compiled into the Mac application.  Shipping a replacement
@@ -153,6 +157,7 @@ type TrustStore struct {
 	MinimumSequence uint64
 	Now             func() time.Time
 	Sequences       MetadataSequenceStore
+	AllowEmbedded   bool
 }
 
 // MetadataSequenceStore durably remembers the newest authenticated release
@@ -180,6 +185,15 @@ func (store *MemoryMetadataSequenceStore) Accept(sequence uint64) error {
 }
 
 func (trust TrustStore) Verify(document SignedReleaseMetadata) (ReleaseMetadata, error) {
+	if document.embedded {
+		if !trust.AllowEmbedded || document.KeyID != "" || document.Signature != "" {
+			return ReleaseMetadata{}, ErrHelperMetadata
+		}
+		if err := document.Metadata.Validate(); err != nil {
+			return ReleaseMetadata{}, fmt.Errorf("%w: %v", ErrHelperMetadata, err)
+		}
+		return document.Metadata, nil
+	}
 	if !validMetadataID(document.KeyID) || trust.RevokedKeys[document.KeyID] {
 		return ReleaseMetadata{}, ErrHelperMetadata
 	}
@@ -392,6 +406,11 @@ type Consent struct {
 	Upgrade bool
 }
 
+// ArtifactLoader is invoked only after authenticated metadata, platform
+// selection, inspection, and the relevant user consent establish that an
+// install or upgrade is actually required.
+type ArtifactLoader func(context.Context, Artifact) ([]byte, error)
+
 type LifecycleState string
 
 const (
@@ -413,6 +432,7 @@ type LifecycleResult struct {
 	Artifact   Artifact
 	CanExecute bool
 	Fallback   bool
+	Reused     bool
 	Reason     error
 }
 
@@ -429,7 +449,16 @@ type Lifecycle struct {
 // Setup authenticates metadata before platform lookup or any remote mutation.
 // Consent is per action: initial install and later upgrades are separate, so an
 // old consent cannot silently install fresh executable code.
+// Setup is retained for focused lifecycle tests. Production callers must use
+// SetupWithLoader so an arm64 host never downloads amd64 bytes (or vice versa)
+// before its platform is known.
 func (lifecycle Lifecycle) Setup(ctx context.Context, document SignedReleaseMetadata, artifactBytes []byte, consent Consent) LifecycleResult {
+	return lifecycle.SetupWithLoader(ctx, document, consent, func(context.Context, Artifact) ([]byte, error) {
+		return artifactBytes, nil
+	})
+}
+
+func (lifecycle Lifecycle) SetupWithLoader(ctx context.Context, document SignedReleaseMetadata, consent Consent, load ArtifactLoader) LifecycleResult {
 	metadata, err := lifecycle.Trust.Verify(document)
 	if err != nil {
 		return lifecycleFailure(LifecycleVerificationError, err)
@@ -463,6 +492,7 @@ func (lifecycle Lifecycle) Setup(ctx context.Context, document SignedReleaseMeta
 	if currentErr == nil {
 		if err := verifyRemoteFile(current, target, artifact, platform.UID); err == nil {
 			result := lifecycle.capabilityResult(ctx, target, artifact, LifecycleReady)
+			result.Reused = result.CanExecute
 			if result.CanExecute || !errors.Is(result.Reason, ErrHelperIncompatible) {
 				return result
 			}
@@ -514,6 +544,13 @@ func (lifecycle Lifecycle) Setup(ctx context.Context, document SignedReleaseMeta
 	initialInstall := errors.Is(currentErr, fs.ErrNotExist) && previous == nil
 	if (initialInstall && !consent.Install) || (!initialInstall && !consent.Upgrade) {
 		return lifecycleFailure(LifecycleUpgradeRequired, ErrHelperConsentRequired)
+	}
+	if load == nil {
+		return lifecycleFailure(LifecycleVerificationError, ErrHelperArtifact)
+	}
+	artifactBytes, err := load(ctx, artifact)
+	if err != nil {
+		return lifecycleFailure(LifecycleVerificationError, fmt.Errorf("%w: download helper artifact", ErrHelperArtifact))
 	}
 	if err := verifyLocalArtifact(artifact, artifactBytes); err != nil {
 		return lifecycleFailure(LifecycleVerificationError, err)
@@ -579,7 +616,7 @@ func classifyLifecycleInstallError(err error) error {
 	case errors.Is(err, ErrHelperNoExec), errors.Is(err, ErrHelperRollback):
 		return err
 	default:
-		return fmt.Errorf("%w: %v", ErrHelperInstallation, err)
+		return fmt.Errorf("%w: %w", ErrHelperInstallation, err)
 	}
 }
 

--- a/collector/internal/remote/lifecycle_ssh.go
+++ b/collector/internal/remote/lifecycle_ssh.go
@@ -13,6 +13,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/centauri-ai/coslash/collector/internal/remoteinstall"
 	"github.com/centauri-ai/coslash/collector/internal/remoteprotocol"
@@ -55,11 +56,24 @@ func (remote *SSHLifecycleRemote) ProbePlatform(ctx context.Context) (Platform, 
 	runCtx, cancel := context.WithTimeout(ctx, limits.ConnectTimeout)
 	defer cancel()
 	cmd := command(runCtx, bin, args...)
+	configureProcessGroup(cmd)
 	stdout := &boundedCommandOutput{limit: 128, cancel: cancel}
 	stderr := &boundedCommandOutput{limit: limits.MaxStderrBytes, cancel: cancel}
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
-	if err := cmd.Run(); err != nil {
+	if err := cmd.Start(); err != nil {
+		return Platform{}, fmt.Errorf("start helper platform probe: %w", err)
+	}
+	waited := make(chan error, 1)
+	go func() { waited <- cmd.Wait() }()
+	var runErr error
+	select {
+	case runErr = <-waited:
+	case <-runCtx.Done():
+		terminateProcessGroup(cmd)
+		runErr = <-waited
+	}
+	if runErr != nil {
 		if stdout.overflow {
 			return Platform{}, fmt.Errorf("%w: platform probe output too long", ErrUnsupportedHelperPlatform)
 		}
@@ -260,13 +274,16 @@ func resolveLifecyclePath(home, requested string) (string, string, error) {
 	if !ok || fileName != HelperFileName || !helperVersionPattern.MatchString(version) {
 		return "", "", ErrUnknownHelperPath
 	}
-	return path.Join(home, ".local/lib/coslash/helpers", version, HelperFileName), version, nil
+	return path.Join(home, ".coslash/helpers", version, HelperFileName), version, nil
 }
 
 func validateLifecycleDirectories(client *sftp.Client, home, version string, uid uint32, create bool) error {
 	directories := []string{home}
 	current := home
-	for _, component := range []string{".local", "lib", "coslash", "helpers", version} {
+	// Keep the executable beneath a dedicated, mode-0700 tree. Common Linux
+	// homes may have a group-writable ~/.local; rejecting that ancestor is safe,
+	// but trying to chmod it would unexpectedly mutate unrelated user data.
+	for _, component := range []string{".coslash", "helpers", version} {
 		current = path.Join(current, component)
 		directories = append(directories, current)
 	}
@@ -377,7 +394,14 @@ func removeStaleLifecycleTemporary(client *sftp.Client, temporary string, uid ui
 	return client.Remove(temporary)
 }
 
-func writeLifecycleArtifact(file *sftp.File, content []byte) error {
+type lifecycleArtifactFile interface {
+	io.Writer
+	Chmod(os.FileMode) error
+	Sync() error
+	Close() error
+}
+
+func writeLifecycleArtifact(file lifecycleArtifactFile, content []byte) error {
 	if _, err := io.Copy(file, bytes.NewReader(content)); err != nil {
 		return err
 	}
@@ -390,7 +414,37 @@ func writeLifecycleArtifact(file *sftp.File, content []byte) error {
 	return nil
 }
 
+// writeAndCloseLifecycleArtifact is the failure-atomic temporary-file step of
+// installation. The callback makes cleanup testable independently from an SSH
+// server and ensures an interrupted write, sync, or close cannot leave a
+// candidate executable behind.
+func writeAndCloseLifecycleArtifact(
+	file lifecycleArtifactFile,
+	content []byte,
+	temporary string,
+	remove func(string) error,
+) error {
+	if err := errors.Join(writeLifecycleArtifact(file, content), file.Close()); err != nil {
+		return fmt.Errorf("write helper temporary: %w", errors.Join(err, remove(temporary)))
+	}
+	return nil
+}
+
+// activateLifecycleTemporary keeps a failed atomic rename from leaving a
+// verified-looking temporary executable behind for a later operation.
+func activateLifecycleTemporary(
+	rename func(string, string) error,
+	remove func(string) error,
+	temporary, destination string,
+) error {
+	if err := rename(temporary, destination); err != nil {
+		return fmt.Errorf("activate helper atomically: %w", errors.Join(err, remove(temporary)))
+	}
+	return nil
+}
+
 type boundedCommandOutput struct {
+	mu       sync.Mutex
 	buffer   bytes.Buffer
 	limit    int
 	overflow bool
@@ -398,6 +452,8 @@ type boundedCommandOutput struct {
 }
 
 func (output *boundedCommandOutput) Write(data []byte) (int, error) {
+	output.mu.Lock()
+	defer output.mu.Unlock()
 	if output.overflow {
 		return len(data), nil
 	}
@@ -414,4 +470,8 @@ func (output *boundedCommandOutput) Write(data []byte) (int, error) {
 	return len(data), nil
 }
 
-func (output *boundedCommandOutput) String() string { return output.buffer.String() }
+func (output *boundedCommandOutput) String() string {
+	output.mu.Lock()
+	defer output.mu.Unlock()
+	return output.buffer.String()
+}

--- a/collector/internal/remote/lifecycle_ssh.go
+++ b/collector/internal/remote/lifecycle_ssh.go
@@ -83,7 +83,7 @@ func (remote *SSHLifecycleRemote) ProbePlatform(ctx context.Context) (Platform, 
 		if runCtx.Err() != nil {
 			return Platform{}, runCtx.Err()
 		}
-		return Platform{}, wrapSSHError(fmt.Errorf("probe helper platform: %w", err), stderr.String())
+		return Platform{}, wrapSSHError(fmt.Errorf("probe helper platform: %w", runErr), stderr.String())
 	}
 	if stdout.overflow {
 		return Platform{}, fmt.Errorf("%w: platform probe output too long", ErrUnsupportedHelperPlatform)

--- a/collector/internal/remote/lifecycle_ssh_test.go
+++ b/collector/internal/remote/lifecycle_ssh_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"testing"
@@ -25,6 +26,21 @@ func TestSSHLifecycleRemoteUsesBoundedFixedPlatformProbe(t *testing.T) {
 	remote.Options = fakeOptions(bytes.Repeat([]byte("x"), 129), 0, "", false)
 	if _, err := remote.ProbePlatform(context.Background()); !errors.Is(err, ErrUnsupportedHelperPlatform) {
 		t.Fatalf("oversized probe error = %v", err)
+	}
+}
+
+func TestSSHLifecycleRemotePreservesPlatformProbeExitError(t *testing.T) {
+	remote, err := NewSSHLifecycleRemote("host", fakeOptions(nil, 23, "probe failed", false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = remote.ProbePlatform(context.Background())
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 23 {
+		t.Fatalf("platform probe error = %v, want exit code 23", err)
+	}
+	if got := sshErrorStderr(err); got != "probe failed" {
+		t.Fatalf("platform probe stderr = %q, want %q", got, "probe failed")
 	}
 }
 

--- a/collector/internal/remote/lifecycle_ssh_test.go
+++ b/collector/internal/remote/lifecycle_ssh_test.go
@@ -53,11 +53,27 @@ func TestLifecycleSFTPPrimitivesCreateVerifyAndRejectSymlink(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// A helper install must not depend on, or mutate, the permissions of the
+	// user's unrelated XDG-style directory tree.
+	local := filepath.Join(root, ".local")
+	if err := os.Mkdir(local, 0o775); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(local, 0o775); err != nil {
+		t.Fatal(err)
+	}
 	uid := uint32(os.Getuid())
 	if err := validateLifecycleDirectories(client, home, "v1", uid, true); err != nil {
 		t.Fatal(err)
 	}
-	absolute := path.Join(home, ".local/lib/coslash/helpers/v1/coslash-helper")
+	info, err := os.Stat(local)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o775 {
+		t.Fatalf("unrelated .local permissions = %v", info.Mode().Perm())
+	}
+	absolute := path.Join(home, ".coslash/helpers/v1/coslash-helper")
 	file, err := client.OpenFile(absolute, os.O_WRONLY|os.O_CREATE|os.O_EXCL)
 	if err != nil {
 		t.Fatal(err)
@@ -76,8 +92,8 @@ func TestLifecycleSFTPPrimitivesCreateVerifyAndRejectSymlink(t *testing.T) {
 	if err != nil || remoteFile.SHA256 != digest(content) || remoteFile.Mode.Perm() != 0o700 || remoteFile.UID != uid {
 		t.Fatalf("remote file = %#v, error = %v", remoteFile, err)
 	}
-	symlink := filepath.Join(root, ".local/lib/coslash/helpers/symlink")
-	if err := os.Symlink(filepath.Join(root, ".local/lib/coslash/helpers/v1"), symlink); err != nil {
+	symlink := filepath.Join(root, ".coslash/helpers/symlink")
+	if err := os.Symlink(filepath.Join(root, ".coslash/helpers/v1"), symlink); err != nil {
 		t.Fatal(err)
 	}
 	if err := validateLifecycleDirectories(client, home, "symlink", uid, false); !errors.Is(err, ErrHelperVerification) {
@@ -88,16 +104,81 @@ func TestLifecycleSFTPPrimitivesCreateVerifyAndRejectSymlink(t *testing.T) {
 func TestResolveLifecyclePathAcceptsOnlyExactKnownLayout(t *testing.T) {
 	want, _ := helperPath("v1")
 	absolute, version, err := resolveLifecyclePath("/home/user", want)
-	if err != nil || absolute != "/home/user/.local/lib/coslash/helpers/v1/coslash-helper" || version != "v1" {
+	if err != nil || absolute != "/home/user/.coslash/helpers/v1/coslash-helper" || version != "v1" {
 		t.Fatalf("path = %q, version = %q, error = %v", absolute, version, err)
 	}
 	for _, candidate := range []string{
-		"~/.local/lib/coslash/helpers/v1/other",
-		"~/.local/lib/coslash/helpers/v1/coslash-helper.new",
-		"~/.local/lib/coslash/helpers/../coslash-helper",
+		"~/.coslash/helpers/v1/other",
+		"~/.coslash/helpers/v1/coslash-helper.new",
+		"~/.coslash/helpers/../coslash-helper",
 	} {
 		if _, _, err := resolveLifecyclePath("/home/user", candidate); !errors.Is(err, ErrUnknownHelperPath) {
 			t.Fatalf("accepted lifecycle path %q: %v", candidate, err)
 		}
 	}
 }
+
+func TestLifecycleTemporaryWriteFailuresAreRemoved(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		file lifecycleTestFile
+	}{
+		{name: "write", file: lifecycleTestFile{writeErr: errors.New("write interrupted")}},
+		{name: "sync", file: lifecycleTestFile{syncErr: errors.New("sync interrupted")}},
+		{name: "close", file: lifecycleTestFile{closeErr: errors.New("close interrupted")}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			temporaryPresent := true
+			removed := ""
+			err := writeAndCloseLifecycleArtifact(&test.file, []byte("helper"), "temporary", func(path string) error {
+				removed, temporaryPresent = path, false
+				return nil
+			})
+			if err == nil || removed != "temporary" || temporaryPresent {
+				t.Fatalf("failure left temporary helper behind: err=%v removed=%q present=%v", err, removed, temporaryPresent)
+			}
+		})
+	}
+}
+
+func TestLifecycleFailedRenameRemovesTemporaryWithoutActivation(t *testing.T) {
+	temporaryPresent, activated := true, false
+	err := activateLifecycleTemporary(func(_, _ string) error {
+		return errors.New("rename interrupted")
+	}, func(path string) error {
+		if path != "temporary" {
+			t.Fatalf("removed %q, want temporary", path)
+		}
+		temporaryPresent = false
+		return nil
+	}, "temporary", "destination")
+	if err == nil || temporaryPresent || activated {
+		t.Fatalf("rename failure left unsafe state: err=%v temporary=%v activated=%v", err, temporaryPresent, activated)
+	}
+}
+
+func TestLifecycleTemporaryCleanupFailureIsNotHidden(t *testing.T) {
+	cleanupErr := errors.New("remove temporary failed")
+	err := activateLifecycleTemporary(func(_, _ string) error {
+		return errors.New("rename interrupted")
+	}, func(string) error { return cleanupErr }, "temporary", "destination")
+	if !errors.Is(err, cleanupErr) {
+		t.Fatalf("cleanup failure was hidden: %v", err)
+	}
+}
+
+type lifecycleTestFile struct {
+	writeErr error
+	syncErr  error
+	closeErr error
+}
+
+func (file *lifecycleTestFile) Write(data []byte) (int, error) {
+	if file.writeErr != nil {
+		return 0, file.writeErr
+	}
+	return len(data), nil
+}
+func (*lifecycleTestFile) Chmod(os.FileMode) error { return nil }
+func (file *lifecycleTestFile) Sync() error        { return file.syncErr }
+func (file *lifecycleTestFile) Close() error       { return file.closeErr }

--- a/collector/internal/remote/lifecycle_test.go
+++ b/collector/internal/remote/lifecycle_test.go
@@ -56,7 +56,7 @@ func TestLifecycleInstallsOnlyWithConsentAndVerifiesActivation(t *testing.T) {
 	if result.State != LifecycleReady || !result.CanExecute || remote.installs != 1 {
 		t.Fatalf("with consent = %#v, installs = %d", result, remote.installs)
 	}
-	if remote.lastRequest.Destination != "~/.local/lib/coslash/helpers/v1/coslash-helper" || remote.lastRequest.Temporary != remote.lastRequest.Destination+".new" {
+	if remote.lastRequest.Destination != "~/.coslash/helpers/v1/coslash-helper" || remote.lastRequest.Temporary != remote.lastRequest.Destination+".new" {
 		t.Fatalf("install request = %#v", remote.lastRequest)
 	}
 	if _, err := os.Stat(filepath.Join(remote.root, artifact.Version, HelperFileName)); err != nil {
@@ -110,6 +110,19 @@ func TestLifecycleNoExecAndRollbackStayOnSFTP(t *testing.T) {
 	result = lifecycleFor(remote).Setup(context.Background(), remote.document, content, Consent{Install: true})
 	if result.State != LifecycleSFTP || !errors.Is(result.Reason, ErrHelperRollback) {
 		t.Fatalf("rollback result = %#v", result)
+	}
+}
+
+func TestLifecycleInterruptedInstallFailsClosed(t *testing.T) {
+	remote, artifact, content := lifecycleFixture(t)
+	path, _ := helperPath(artifact.Version)
+	remote.installErr = context.DeadlineExceeded
+	result := lifecycleFor(remote).Setup(context.Background(), remote.document, content, Consent{Install: true})
+	if result.CanExecute || !result.Fallback || !errors.Is(result.Reason, context.DeadlineExceeded) {
+		t.Fatalf("interrupted install result = %#v", result)
+	}
+	if _, exists := remote.files[path]; exists {
+		t.Fatalf("interrupted install activated helper: %#v", remote.files)
 	}
 }
 
@@ -249,7 +262,7 @@ func TestClassifyLifecycleError(t *testing.T) {
 		{ErrHelperVerification, ReasonHelperVerification},
 		{ErrHelperNoExec, ReasonHelperBlocked},
 		{ErrHelperRevoked, ReasonHelperRevoked},
-		{ErrHelperConsentRequired, ReasonHelperUpgrade},
+		{ErrHelperConsentRequired, ReasonHelperConsent},
 		{ErrHelperRollback, ReasonHelperRollback},
 		{ErrHelperInstallation, ReasonHelperInstallation},
 	} {
@@ -323,6 +336,7 @@ type fakeLifecycleRemote struct {
 	capabilitiesCalls int
 	probeErr          error
 	capabilityErrors  map[string]error
+	removeErr         error
 	lastRequest       InstallRequest
 	removed           string
 }
@@ -364,6 +378,9 @@ func (remote *fakeLifecycleRemote) Install(_ context.Context, request InstallReq
 }
 func (remote *fakeLifecycleRemote) RemoveExact(_ context.Context, path string) error {
 	remote.removed = path
+	if remote.removeErr != nil {
+		return remote.removeErr
+	}
 	for _, artifact := range remote.document.Metadata.Artifacts {
 		known, _ := helperPath(artifact.Version)
 		if known == path {

--- a/collector/internal/remote/manager.go
+++ b/collector/internal/remote/manager.go
@@ -14,7 +14,10 @@ import (
 	"github.com/centauri-ai/coslash/collector/internal/vendors"
 )
 
-var ErrInvalidRemoteSettings = errors.New("invalid remote settings")
+var (
+	ErrInvalidRemoteSettings   = errors.New("invalid remote settings")
+	ErrHelperOwnershipConflict = errors.New("helper ownership must be explicitly released or uninstalled before changing SSH alias")
+)
 
 type SessionKey struct {
 	SourceID        string
@@ -31,6 +34,8 @@ type IndexedSession struct {
 	LastSeenStatus        *string
 }
 
+type remoteSessionKey struct{ Agent, ID string }
+
 type ListResult struct {
 	Sessions []IndexedSession
 	Health   Health
@@ -44,6 +49,8 @@ type refreshOutcome struct {
 	Failures  []error
 	Stderr    string
 	RoundTrip time.Duration
+	Metrics   CollectionMetrics
+	Reason    *Reason
 }
 
 type probeResult struct {
@@ -60,10 +67,15 @@ type openFunc func(context.Context, string, OpenOptions) (*Session, error)
 type Manager struct {
 	mu sync.Mutex
 
-	cache   *Cache
-	now     func() time.Time
-	refresh refreshFunc
-	test    probeFunc
+	cache                       *Cache
+	now                         func() time.Time
+	refresh                     refreshFunc
+	helperRefresh               helperRefreshFunc
+	test                        probeFunc
+	releaseProvider             HelperReleaseProvider
+	lifecycleFactory            lifecycleFactory
+	trust                       TrustStore
+	helperInstallationAvailable bool
 
 	cfg        *settings.RemoteSettings
 	lifeCtx    context.Context
@@ -73,27 +85,42 @@ type Manager struct {
 	// committed. legacyStale is true while snapshot only carries display fields
 	// inherited from a v1 cache: its Families stay empty so the next refresh
 	// starts from an empty baseline rather than reinterpreting v1 fingerprints.
-	snapshot        *CachedSnapshotV2
-	legacyStale     bool
-	sessions        []*session.Session
-	state           State
-	reason          *Reason
-	complete        bool
-	errorCopy       string
-	diagnostic      string
-	refreshing      bool
-	lastRequestedMs int64
-	failures        int
-	nextRetryAt     time.Time
-	lastSuccessAt   *int64
+	snapshot               *CachedSnapshotV2
+	legacyStale            bool
+	sessions               []*session.Session
+	familyStale            map[remoteSessionKey]bool
+	state                  State
+	reason                 *Reason
+	complete               bool
+	errorCopy              string
+	diagnostic             string
+	refreshing             bool
+	lastRequestedMs        int64
+	failures               int
+	nextRetryAt            time.Time
+	lastSuccessAt          *int64
+	transport              Transport
+	helper                 *HelperStatus
+	helperTarget           *helperTarget
+	helperVersion          string
+	helperOwnershipCorrupt bool
+	helperProbe            helperProbeState
+	metrics                CollectionMetrics
 }
 
 type Options struct {
 	Cache   *Cache
 	Now     func() time.Time
 	Refresh refreshFunc
-	Test    probeFunc
-	Open    openFunc
+	// HelperRefresh is only invoked after SetupHelper creates a verified target.
+	// Supplying it is useful for deterministic manager tests.
+	HelperRefresh               helperRefreshFunc
+	ReleaseProvider             HelperReleaseProvider
+	LifecycleFactory            lifecycleFactory
+	Trust                       TrustStore
+	HelperInstallationAvailable bool
+	Test                        probeFunc
+	Open                        openFunc
 }
 
 func NewManager(options Options) *Manager {
@@ -121,20 +148,62 @@ func NewManager(options Options) *Manager {
 			return probeSFTPWithOpen(ctx, alias, open)
 		}
 	}
+	helperRefresh := options.HelperRefresh
+	if helperRefresh == nil {
+		helperRefresh = func(ctx context.Context, alias string, since int64, now time.Time, baseline CachedSnapshotV2, target helperTarget) (refreshOutcome, error) {
+			return helperRefreshWithOpen(ctx, alias, since, now, baseline, target, OpenOptions{})
+		}
+	}
+	factory := options.LifecycleFactory
+	if factory == nil && options.ReleaseProvider != nil {
+		factory = defaultLifecycleFactory(options.Trust)
+	}
 	return &Manager{
-		cache: cache, now: now, refresh: refresh, test: test,
-		state: StateDisabled, complete: true,
+		cache: cache, now: now, refresh: refresh, helperRefresh: helperRefresh, test: test,
+		releaseProvider: options.ReleaseProvider, lifecycleFactory: factory,
+		trust:                       options.Trust,
+		helperInstallationAvailable: options.HelperInstallationAvailable,
+		state:                       StateDisabled, complete: true, transport: TransportSFTP,
+		helperProbe: helperProbeFallback,
 	}
 }
 
 func (manager *Manager) ApplySettings(remote *settings.RemoteSettings) error {
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
+	corruptOwnership := false
+	if remote != nil {
+		ownership, owned, err := manager.cache.LoadHelperOwnership(remote.ID)
+		if errors.Is(err, ErrHelperOwnershipLegacy) && owned {
+			// The old record was created while this was the only configured host.
+			// Bind it atomically to the persisted alias before any later alias
+			// comparison can be allowed.
+			if err := manager.cache.StoreHelperVersion(remote.ID, ownership.Version, remote.SSHAlias); err != nil {
+				return err
+			}
+		} else if errors.Is(err, ErrHelperOwnershipCorrupt) {
+			corruptOwnership = true
+		} else if err != nil {
+			return err
+		}
+	}
+	if corruptOwnership {
+		if !settings.ValidRemoteID(remote.ID) || !settings.ValidSSHAlias(remote.SSHAlias) {
+			return ErrInvalidRemoteSettings
+		}
+	} else if err := manager.validateSettingsLocked(remote); err != nil {
+		return err
+	}
 	if remote == nil {
 		return manager.removeLocked()
 	}
-	if !settings.ValidRemoteID(remote.ID) || !settings.ValidSSHAlias(remote.SSHAlias) {
-		return ErrInvalidRemoteSettings
+	ownership, owned, err := manager.cache.LoadHelperOwnership(remote.ID)
+	if errors.Is(err, ErrHelperOwnershipCorrupt) {
+		corruptOwnership = true
+		ownership = helperOwnership{}
+		owned = false
+	} else if err != nil {
+		return err
 	}
 	if manager.cfg != nil && manager.cfg.ID != remote.ID {
 		if err := manager.removeLocked(); err != nil {
@@ -148,9 +217,17 @@ func (manager *Manager) ApplySettings(remote *settings.RemoteSettings) error {
 		if err := manager.cache.RemoveSource(remote.ID); err != nil {
 			return err
 		}
+		manager.helper = nil
+		manager.helperTarget = nil
 	}
 	copyConfig := *remote
 	manager.cfg = &copyConfig
+	if owned {
+		manager.helperVersion = ownership.Version
+	} else {
+		manager.helperVersion = ""
+	}
+	manager.helperOwnershipCorrupt = corruptOwnership
 	if !remote.Enabled {
 		manager.cancelLifeLocked()
 		manager.refreshing = false
@@ -158,6 +235,7 @@ func (manager *Manager) ApplySettings(remote *settings.RemoteSettings) error {
 		manager.reason = reasonPtr(ReasonDisabled)
 		manager.complete = true
 		manager.errorCopy = ""
+		manager.transport = TransportSFTP
 		exitControlMasterBestEffort(remote.SSHAlias)
 		return nil
 	}
@@ -176,8 +254,53 @@ func (manager *Manager) ApplySettings(remote *settings.RemoteSettings) error {
 		manager.complete = false
 		manager.failures = 0
 		manager.nextRetryAt = time.Time{}
+		manager.helperTarget = nil
+		manager.helperProbe = helperProbeUnknown
 		// Initial collection waits for ListView's first requested window
 		// instead of starting eagerly with since=0.
+	}
+	if corruptOwnership {
+		manager.helperTarget = nil
+		manager.helperProbe = helperProbeFallback
+		manager.helper = &HelperStatus{
+			State: LifecycleVerificationError, Fallback: true,
+			Reason: reasonPtr(ReasonHelperVerification),
+		}
+	}
+	return nil
+}
+
+// ValidateSettingsChange checks remote-helper ownership before settings.json
+// is written, so a rejected alias replacement cannot persist an ambiguous
+// local/remote ownership state.
+func (manager *Manager) ValidateSettingsChange(remote *settings.RemoteSettings) error {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	return manager.validateSettingsLocked(remote)
+}
+
+func (manager *Manager) validateSettingsLocked(remote *settings.RemoteSettings) error {
+	if remote == nil {
+		if manager.helperVersion != "" || manager.helperOwnershipCorrupt {
+			return ErrHelperOwnershipConflict
+		}
+		return nil
+	}
+	if !settings.ValidRemoteID(remote.ID) || !settings.ValidSSHAlias(remote.SSHAlias) {
+		return ErrInvalidRemoteSettings
+	}
+	ownership, owned, err := manager.cache.LoadHelperOwnership(remote.ID)
+	if err != nil {
+		return err
+	}
+	if manager.helperOwnershipCorrupt {
+		return ErrHelperOwnershipCorrupt
+	}
+	if owned && ownership.Alias != remote.SSHAlias {
+		return ErrHelperOwnershipConflict
+	}
+	if manager.cfg != nil && manager.cfg.ID != remote.ID && manager.helperVersion != "" {
+		return ErrHelperOwnershipConflict
 	}
 	return nil
 }
@@ -192,6 +315,12 @@ func (manager *Manager) ListView(remoteSinceMs int64) ListResult {
 	}
 	if !manager.cfg.Enabled {
 		return ListResult{Health: manager.healthLocked(remoteSinceMs)}
+	}
+	if manager.helperProbe == helperProbeUnknown {
+		manager.startHelperDiscoveryLocked()
+	}
+	if manager.helperProbe == helperProbeProbing {
+		return ListResult{Sessions: manager.sessionsLocked(remoteSinceMs), Health: manager.healthLocked(remoteSinceMs)}
 	}
 	if manager.snapshot == nil || age(manager.snapshot.FetchedAtMs, manager.now()) >= FreshnessInterval ||
 		manager.snapshot.CoverageSinceMs > remoteSinceMs {
@@ -218,6 +347,7 @@ func (manager *Manager) TestAlias(ctx context.Context, alias string) (Health, er
 	health := Health{
 		Label: alias, Complete: true,
 		RoundTripMs: int64Ptr(result.RoundTrip.Milliseconds()),
+		Transport:   TransportSFTP,
 	}
 	if err != nil {
 		reason := classifyError(err)
@@ -225,11 +355,6 @@ func (manager *Manager) TestAlias(ctx context.Context, alias string) (Health, er
 		health.Complete = false
 		health.Reason = reasonPtr(reason)
 		health.Error = genericErrorCopy(reason)
-		diagnostic := result.Stderr
-		if diagnostic == "" {
-			diagnostic = sshErrorStderr(err)
-		}
-		health.DiagnosticStderr = redactDiagnostic(diagnostic)
 		return health, nil
 	}
 	health.State = StateOK
@@ -255,6 +380,9 @@ func (manager *Manager) Shutdown() {
 }
 
 func (manager *Manager) removeLocked() error {
+	if manager.helperVersion != "" {
+		return ErrHelperOwnershipConflict
+	}
 	manager.cancelLifeLocked()
 	var sourceID string
 	var alias string
@@ -266,6 +394,7 @@ func (manager *Manager) removeLocked() error {
 	manager.snapshot = nil
 	manager.legacyStale = false
 	manager.sessions = nil
+	manager.familyStale = nil
 	manager.state = StateDisabled
 	manager.reason = reasonPtr(ReasonDisabled)
 	manager.complete = true
@@ -275,6 +404,13 @@ func (manager *Manager) removeLocked() error {
 	manager.failures = 0
 	manager.nextRetryAt = time.Time{}
 	manager.lastSuccessAt = nil
+	manager.transport = TransportSFTP
+	manager.helper = nil
+	manager.helperTarget = nil
+	manager.helperVersion = ""
+	manager.helperOwnershipCorrupt = false
+	manager.helperProbe = helperProbeFallback
+	manager.metrics = CollectionMetrics{}
 	exitControlMasterBestEffort(alias)
 	if sourceID != "" {
 		return manager.cache.RemoveSource(sourceID)
@@ -291,6 +427,7 @@ func (manager *Manager) loadCacheLocked() error {
 		manager.snapshot = &v2
 		manager.legacyStale = false
 		manager.sessions = composeFromGeneration(toGeneration(v2), nullReadSource{}, nil, 0)
+		manager.familyStale = staleSessions(v2)
 		manager.lastSuccessAt = int64Ptr(v2.FetchedAtMs)
 		return nil
 	}
@@ -302,6 +439,7 @@ func (manager *Manager) loadCacheLocked() error {
 		manager.snapshot = nil
 		manager.legacyStale = false
 		manager.sessions = nil
+		manager.familyStale = nil
 		return nil
 	}
 	// A v1 card stays visible as stale display data only: Families and
@@ -314,6 +452,7 @@ func (manager *Manager) loadCacheLocked() error {
 	}
 	manager.legacyStale = true
 	manager.sessions = legacy.sessions()
+	manager.familyStale = nil
 	manager.lastSuccessAt = int64Ptr(legacy.FetchedAtMs)
 	return nil
 }
@@ -357,7 +496,12 @@ func (manager *Manager) kickRefreshLocked(remoteSinceMs int64) {
 	}
 	config := *manager.cfg
 	baseline := snapshotOrEmpty(manager.snapshot)
-	go manager.runRefresh(manager.lifeCtx, config, remoteSinceMs, baseline)
+	var helper *helperTarget
+	if manager.helperTarget != nil {
+		copy := *manager.helperTarget
+		helper = &copy
+	}
+	go manager.runRefresh(manager.lifeCtx, config, remoteSinceMs, baseline, helper)
 }
 
 func (manager *Manager) runRefresh(
@@ -365,8 +509,15 @@ func (manager *Manager) runRefresh(
 	config settings.RemoteSettings,
 	remoteSinceMs int64,
 	baseline CachedSnapshotV2,
+	helper *helperTarget,
 ) {
-	result, err := manager.refresh(ctx, config.SSHAlias, remoteSinceMs, manager.now(), baseline)
+	var result refreshOutcome
+	var err error
+	if helper != nil {
+		result, err = manager.helperRefresh(ctx, config.SSHAlias, remoteSinceMs, manager.now(), baseline, *helper)
+	} else {
+		result, err = manager.refresh(ctx, config.SSHAlias, remoteSinceMs, manager.now(), baseline)
+	}
 	fetchedAt := manager.now().UnixMilli()
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
@@ -379,10 +530,18 @@ func (manager *Manager) runRefresh(
 		if diagnostic == "" {
 			diagnostic = sshErrorStderr(err)
 		}
-		manager.applyFailureLocked(classifyError(err), diagnostic)
+		reason := classifyError(err)
+		if helper != nil {
+			reason = classifyHelperError(err)
+			manager.metrics = metricsFor(result)
+			manager.transport = TransportHelper
+		}
+		manager.applyFailureLocked(reason, diagnostic)
 		return
 	}
 	if reason := limitedResultReason(result); reason != nil {
+		manager.transport = transportFor(helper)
+		manager.metrics = metricsFor(result)
 		manager.applyLimitedLocked(result, *reason, fetchedAt)
 		return
 	}
@@ -396,6 +555,23 @@ func (manager *Manager) runRefresh(
 	manager.complete = true
 	manager.state = StateOK
 	manager.reason = nil
+	manager.transport = transportFor(helper)
+	manager.metrics = metricsFor(result)
+}
+
+func metricsFor(result refreshOutcome) CollectionMetrics {
+	metrics := result.Metrics
+	if metrics.RoundTripMs == 0 {
+		metrics.RoundTripMs = result.RoundTrip.Milliseconds()
+	}
+	return metrics
+}
+
+func transportFor(helper *helperTarget) Transport {
+	if helper != nil {
+		return TransportHelper
+	}
+	return TransportSFTP
 }
 
 func (manager *Manager) publishSnapshotLocked(result refreshOutcome, fetchedAt int64) bool {
@@ -409,6 +585,7 @@ func (manager *Manager) publishSnapshotLocked(result refreshOutcome, fetchedAt i
 	manager.snapshot = &snapshot
 	manager.legacyStale = false
 	manager.sessions = result.Sessions
+	manager.familyStale = staleSessions(snapshot)
 	manager.lastSuccessAt = int64Ptr(fetchedAt)
 	return true
 }
@@ -445,7 +622,7 @@ func (manager *Manager) sessionsLocked(remoteSinceMs int64) []IndexedSession {
 		return nil
 	}
 	eligible := manager.state == StateOK && manager.complete
-	displayStale := manager.state != StateOK && manager.state != StateLimited
+	globalStale := manager.state != StateOK && manager.state != StateLimited
 	result := []IndexedSession{}
 	for _, item := range manager.sessions {
 		if remoteSinceMs > 0 && item.Status == nil && item.LastActivityTime < remoteSinceMs {
@@ -454,7 +631,8 @@ func (manager *Manager) sessionsLocked(remoteSinceMs int64) []IndexedSession {
 		indexed := IndexedSession{
 			Key:         SessionKey{SourceID: manager.cfg.ID, Agent: item.Agent, SourceSessionID: item.ID},
 			SourceLabel: manager.cfg.SSHAlias, Session: item,
-			EligibleForAggregates: eligible, DisplayStale: displayStale,
+			EligibleForAggregates: eligible,
+			DisplayStale:          globalStale || manager.familyStale[remoteSessionKey{Agent: item.Agent, ID: item.ID}],
 		}
 		if indexed.DisplayStale {
 			indexed.LastSeenStatus = item.Status
@@ -471,8 +649,13 @@ func (manager *Manager) healthLocked(remoteSinceMs int64) Health {
 	health := Health{
 		SourceID: manager.cfg.ID, Label: manager.cfg.SSHAlias, State: manager.state,
 		Complete: manager.complete, Reason: manager.reason, Error: manager.errorCopy,
-		DiagnosticStderr: manager.diagnostic, Refreshing: manager.refreshing,
+		Refreshing:      manager.refreshing,
 		LastSuccessAtMs: manager.lastSuccessAt,
+		Transport:       manager.transport, Helper: manager.helper, Metrics: manager.metrics,
+		HelperInstallationAvailable: manager.helperInstallationAvailable,
+		HelperProbeState:            string(manager.helperProbe),
+		HelperOwnershipRecorded:     manager.helperVersion != "" || manager.helperOwnershipCorrupt,
+		HelperOwnershipCorrupt:      manager.helperOwnershipCorrupt,
 	}
 	if !manager.cfg.Enabled {
 		health.State = StateDisabled
@@ -555,6 +738,8 @@ func noSupportedData(coverage []AgentCoverage) bool {
 
 func limitedResultReason(result refreshOutcome) *Reason {
 	switch {
+	case result.Reason != nil:
+		return result.Reason
 	case len(result.Failures) > 0:
 		return reasonPtr(ReasonPartialAgentData)
 	case slices.ContainsFunc(result.Snapshot.Coverage, func(item AgentCoverage) bool { return item.Truncated }):

--- a/collector/internal/remote/manager.go
+++ b/collector/internal/remote/manager.go
@@ -18,6 +18,7 @@ var (
 	ErrInvalidRemoteSettings   = errors.New("invalid remote settings")
 	ErrHelperOwnershipConflict = errors.New("helper ownership must be explicitly released or uninstalled before changing SSH alias")
 	ErrHelperAliasMismatch     = errors.New("helper setup alias does not match configured SSH alias")
+	ErrHelperSetupInProgress   = errors.New("helper setup is running for the configured SSH alias")
 )
 
 type SessionKey struct {
@@ -104,6 +105,7 @@ type Manager struct {
 	helper                 *HelperStatus
 	helperTarget           *helperTarget
 	helperVerify           helperVerifyFunc
+	helperSetup            bool
 	helperVersion          string
 	helperOwnershipCorrupt bool
 	helperProbe            helperProbeState
@@ -188,6 +190,9 @@ func NewManager(options Options) *Manager {
 func (manager *Manager) ApplySettings(remote *settings.RemoteSettings) error {
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
+	if manager.helperSetup && remoteTargetChanged(manager.cfg, remote) {
+		return ErrHelperSetupInProgress
+	}
 	corruptOwnership := false
 	if remote != nil {
 		ownership, owned, err := manager.cache.LoadHelperOwnership(remote.ID)
@@ -297,6 +302,9 @@ func (manager *Manager) ValidateSettingsChange(remote *settings.RemoteSettings) 
 }
 
 func (manager *Manager) validateSettingsLocked(remote *settings.RemoteSettings) error {
+	if manager.helperSetup && remoteTargetChanged(manager.cfg, remote) {
+		return ErrHelperSetupInProgress
+	}
 	if remote == nil {
 		if manager.helperVersion != "" || manager.helperOwnershipCorrupt {
 			return ErrHelperOwnershipConflict
@@ -320,6 +328,13 @@ func (manager *Manager) validateSettingsLocked(remote *settings.RemoteSettings) 
 		return ErrHelperOwnershipConflict
 	}
 	return nil
+}
+
+func remoteTargetChanged(current, next *settings.RemoteSettings) bool {
+	if current == nil || next == nil {
+		return current != next
+	}
+	return current.ID != next.ID || current.SSHAlias != next.SSHAlias
 }
 
 func (manager *Manager) ListView(remoteSinceMs int64) ListResult {

--- a/collector/internal/remote/manager.go
+++ b/collector/internal/remote/manager.go
@@ -102,6 +102,7 @@ type Manager struct {
 	transport              Transport
 	helper                 *HelperStatus
 	helperTarget           *helperTarget
+	helperVerify           helperVerifyFunc
 	helperVersion          string
 	helperOwnershipCorrupt bool
 	helperProbe            helperProbeState
@@ -115,6 +116,7 @@ type Options struct {
 	// HelperRefresh is only invoked after SetupHelper creates a verified target.
 	// Supplying it is useful for deterministic manager tests.
 	HelperRefresh               helperRefreshFunc
+	HelperVerify                helperVerifyFunc
 	ReleaseProvider             HelperReleaseProvider
 	LifecycleFactory            lifecycleFactory
 	Trust                       TrustStore
@@ -158,8 +160,22 @@ func NewManager(options Options) *Manager {
 	if factory == nil && options.ReleaseProvider != nil {
 		factory = defaultLifecycleFactory(options.Trust)
 	}
+	helperVerify := options.HelperVerify
+	if helperVerify == nil {
+		helperVerify = func(ctx context.Context, alias string, target helperTarget) error {
+			if factory == nil {
+				return ErrHelperVerification
+			}
+			lifecycle, err := factory(alias)
+			if err != nil {
+				return err
+			}
+			return lifecycle.VerifyExecution(ctx, target.path, target.artifact)
+		}
+	}
 	return &Manager{
 		cache: cache, now: now, refresh: refresh, helperRefresh: helperRefresh, test: test,
+		helperVerify:    helperVerify,
 		releaseProvider: options.ReleaseProvider, lifecycleFactory: factory,
 		trust:                       options.Trust,
 		helperInstallationAvailable: options.HelperInstallationAvailable,
@@ -514,7 +530,9 @@ func (manager *Manager) runRefresh(
 	var result refreshOutcome
 	var err error
 	if helper != nil {
-		result, err = manager.helperRefresh(ctx, config.SSHAlias, remoteSinceMs, manager.now(), baseline, *helper)
+		if err = manager.helperVerify(ctx, config.SSHAlias, *helper); err == nil {
+			result, err = manager.helperRefresh(ctx, config.SSHAlias, remoteSinceMs, manager.now(), baseline, *helper)
+		}
 	} else {
 		result, err = manager.refresh(ctx, config.SSHAlias, remoteSinceMs, manager.now(), baseline)
 	}

--- a/collector/internal/remote/manager.go
+++ b/collector/internal/remote/manager.go
@@ -17,6 +17,7 @@ import (
 var (
 	ErrInvalidRemoteSettings   = errors.New("invalid remote settings")
 	ErrHelperOwnershipConflict = errors.New("helper ownership must be explicitly released or uninstalled before changing SSH alias")
+	ErrHelperAliasMismatch     = errors.New("helper setup alias does not match configured SSH alias")
 )
 
 type SessionKey struct {
@@ -381,6 +382,16 @@ func (manager *Manager) DiagnosticsHealth() Health {
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
 	return manager.healthLocked(manager.lastRequestedMs)
+}
+
+// SetupAliasMatches reports whether alias is the currently persisted remote
+// target. SetupHelperForAlias repeats this check while taking its immutable
+// configuration snapshot; this fast check lets the HTTP handler reject an
+// unsaved settings draft before starting any lifecycle work.
+func (manager *Manager) SetupAliasMatches(alias string) bool {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	return manager.cfg != nil && manager.cfg.Enabled && manager.cfg.SSHAlias == alias
 }
 
 func (manager *Manager) Shutdown() {

--- a/collector/internal/remote/manager_test.go
+++ b/collector/internal/remote/manager_test.go
@@ -222,6 +222,49 @@ func TestManagerUsesOnlyLifecycleVerifiedHelperAndDoesNotSilentlyFallback(t *tes
 	}
 }
 
+func TestManagerReverifiesHelperBeforeEveryRefresh(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("COSLASH_HOME", home)
+	remote, artifact, content := lifecycleFixture(t)
+	var helperCalls atomic.Int32
+	manager := NewManager(Options{
+		Cache: NewCache(filepath.Join(home, "remote-cache")), Now: time.Now,
+		HelperRefresh: func(context.Context, string, int64, time.Time, CachedSnapshotV2, helperTarget) (refreshOutcome, error) {
+			helperCalls.Add(1)
+			return refreshOutcome{}, nil
+		},
+		ReleaseProvider:             fixedHelperRelease{document: remote.document, content: content},
+		LifecycleFactory:            func(string) (Lifecycle, error) { return lifecycleFor(remote), nil },
+		HelperInstallationAvailable: true,
+	})
+	config := &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}
+	if err := manager.ApplySettings(config); err != nil {
+		t.Fatal(err)
+	}
+	if health := manager.SetupHelper(context.Background(), Consent{Install: true}); health.Helper == nil || !health.Helper.Compatible {
+		t.Fatalf("setup health = %#v", health)
+	}
+
+	targetPath, _ := helperPath(artifact.Version)
+	modified := remote.files[targetPath]
+	modified.SHA256 = "modified"
+	remote.files[targetPath] = modified
+	manager.ListView(time.Now().Add(-time.Hour).UnixMilli())
+	waitUntil(t, func() bool {
+		manager.mu.Lock()
+		defer manager.mu.Unlock()
+		return !manager.refreshing
+	})
+
+	if helperCalls.Load() != 0 {
+		t.Fatalf("modified helper executed %d times", helperCalls.Load())
+	}
+	health := manager.DiagnosticsHealth()
+	if health.Reason == nil || *health.Reason != ReasonHelperVerification {
+		t.Fatalf("modified helper health = %#v", health)
+	}
+}
+
 func TestPartialRefreshMarksOnlyRetainedFailedFamilyStale(t *testing.T) {
 	manager := NewManager(Options{})
 	manager.cfg = &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}

--- a/collector/internal/remote/manager_test.go
+++ b/collector/internal/remote/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -149,6 +150,24 @@ func TestHardFailureFallsBackToStaleWhenCacheExists(t *testing.T) {
 type fixedHelperRelease struct {
 	document SignedReleaseMetadata
 	content  []byte
+}
+
+type blockingHelperRelease struct {
+	document SignedReleaseMetadata
+	content  []byte
+	started  chan struct{}
+	release  chan struct{}
+	once     sync.Once
+}
+
+func (provider *blockingHelperRelease) LoadMetadata(context.Context) (SignedReleaseMetadata, error) {
+	return provider.document, nil
+}
+
+func (provider *blockingHelperRelease) LoadArtifact(context.Context, Artifact) ([]byte, error) {
+	provider.once.Do(func() { close(provider.started) })
+	<-provider.release
+	return provider.content, nil
 }
 
 type architectureRelease struct {
@@ -482,6 +501,51 @@ func TestHelperOwnershipBlocksAliasChangeUntilExplicitRelease(t *testing.T) {
 	}
 	if err := manager.ApplySettings(&changed); err != nil {
 		t.Fatalf("explicit release should allow alias replacement: %v", err)
+	}
+}
+
+func TestSetupBlocksAliasChangeUntilItRecordsOwnership(t *testing.T) {
+	remote, _, content := lifecycleFixture(t)
+	provider := &blockingHelperRelease{
+		document: remote.document, content: content,
+		started: make(chan struct{}), release: make(chan struct{}),
+	}
+	cache := NewCache(t.TempDir())
+	manager := NewManager(Options{
+		Cache: cache, ReleaseProvider: provider,
+		LifecycleFactory:            func(string) (Lifecycle, error) { return lifecycleFor(remote), nil },
+		HelperInstallationAvailable: true,
+	})
+	config := &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "old-host", Enabled: true}
+	if err := manager.ApplySettings(config); err != nil {
+		t.Fatal(err)
+	}
+	setupDone := make(chan error, 1)
+	go func() {
+		_, err := manager.SetupHelperForAlias(context.Background(), config.SSHAlias, Consent{Install: true})
+		setupDone <- err
+	}()
+	<-provider.started
+
+	changed := *config
+	changed.SSHAlias = "new-host"
+	if err := manager.ValidateSettingsChange(&changed); !errors.Is(err, ErrHelperSetupInProgress) {
+		t.Fatalf("validate alias change during setup = %v, want ErrHelperSetupInProgress", err)
+	}
+	if err := manager.ApplySettings(&changed); !errors.Is(err, ErrHelperSetupInProgress) {
+		t.Fatalf("apply alias change during setup = %v, want ErrHelperSetupInProgress", err)
+	}
+
+	close(provider.release)
+	if err := <-setupDone; err != nil {
+		t.Fatalf("SetupHelperForAlias: %v", err)
+	}
+	ownership, owned, err := cache.LoadHelperOwnership(config.ID)
+	if err != nil || !owned || ownership.Alias != config.SSHAlias {
+		t.Fatalf("ownership after setup = %#v, owned=%v, err=%v", ownership, owned, err)
+	}
+	if err := manager.ApplySettings(&changed); !errors.Is(err, ErrHelperOwnershipConflict) {
+		t.Fatalf("alias change after setup = %v, want ErrHelperOwnershipConflict", err)
 	}
 }
 

--- a/collector/internal/remote/manager_test.go
+++ b/collector/internal/remote/manager_test.go
@@ -317,6 +317,60 @@ func TestHelperTestAcceptsEmptySuccessfulCollection(t *testing.T) {
 	if result.Health.Complete || result.Health.Reason == nil || *result.Health.Reason != ReasonNoSupportedData {
 		t.Fatalf("empty-host board health = %#v", result.Health)
 	}
+	if result.Health.Transport != TransportHelper {
+		t.Fatalf("successful helper test transport = %q, want helper", result.Health.Transport)
+	}
+}
+
+func TestHelperTestFailureDoesNotPoisonRefreshOrTransport(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("COSLASH_HOME", home)
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	lifecycleRemote, _, content := lifecycleFixture(t)
+	manager := NewManager(Options{
+		Cache: NewCache(filepath.Join(home, "remote-cache")), Now: func() time.Time { return now },
+		ReleaseProvider:             fixedHelperRelease{document: lifecycleRemote.document, content: content},
+		LifecycleFactory:            func(string) (Lifecycle, error) { return lifecycleFor(lifecycleRemote), nil },
+		HelperInstallationAvailable: true,
+		HelperRefresh: func(context.Context, string, int64, time.Time, CachedSnapshotV2, helperTarget) (refreshOutcome, error) {
+			return refreshOutcome{Stderr: "probe failed"}, context.DeadlineExceeded
+		},
+	})
+	config := &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}
+	if err := manager.ApplySettings(config); err != nil {
+		t.Fatal(err)
+	}
+	if health := manager.SetupHelper(context.Background(), Consent{Install: true}); health.Helper == nil || !health.Helper.Compatible {
+		t.Fatalf("setup health = %#v", health)
+	}
+	manager.mu.Lock()
+	manager.snapshot = &CachedSnapshotV2{Version: cacheV2Version, CoverageSinceMs: now.UnixMilli()}
+	manager.state = StateOK
+	manager.complete = true
+	manager.transport = TransportSFTP
+	manager.failures = 0
+	manager.nextRetryAt = time.Time{}
+	manager.lastRequestedMs = 0
+	manager.mu.Unlock()
+
+	result := manager.TestHelper(context.Background())
+	if result.Succeeded || result.Reason == nil {
+		t.Fatalf("failed helper test = %#v", result)
+	}
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if manager.failures != 0 || !manager.nextRetryAt.IsZero() {
+		t.Fatalf("setup probe poisoned retry state: failures=%d nextRetryAt=%v", manager.failures, manager.nextRetryAt)
+	}
+	if manager.transport != TransportSFTP {
+		t.Fatalf("failed probe transport = %q, want prior sftp", manager.transport)
+	}
+	if manager.state != StateOK || !manager.complete {
+		t.Fatalf("failed probe rewrote board state: state=%s complete=%v", manager.state, manager.complete)
+	}
+	if result.Health.Transport != TransportSFTP || result.Health.State != StateOK {
+		t.Fatalf("failed probe health = %#v", result.Health)
+	}
 }
 
 func TestHelperOwnershipBlocksAliasChangeUntilExplicitRelease(t *testing.T) {

--- a/collector/internal/remote/manager_test.go
+++ b/collector/internal/remote/manager_test.go
@@ -328,7 +328,7 @@ func TestRestartDiscoversAndReusesVerifiedHelperWithoutInstall(t *testing.T) {
 	}
 }
 
-func TestHelperTestAcceptsEmptySuccessfulCollection(t *testing.T) {
+func TestHelperTestAcceptsEmptySuccessfulCollectionWithoutRewritingBoardState(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("COSLASH_HOME", home)
 	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
@@ -351,17 +351,63 @@ func TestHelperTestAcceptsEmptySuccessfulCollection(t *testing.T) {
 	}
 	manager.mu.Lock()
 	manager.snapshot = &CachedSnapshotV2{Version: cacheV2Version, CoverageSinceMs: now.UnixMilli()}
+	manager.sessions = []*session.Session{{Agent: vendors.AgentClaude, ID: "cached"}}
+	manager.state = StateStale
+	manager.reason = reasonPtr(ReasonInitialRefresh)
+	manager.complete = false
+	manager.errorCopy = "prior refresh is stale"
+	manager.transport = TransportSFTP
 	manager.lastRequestedMs = 0
 	manager.mu.Unlock()
 	result := manager.TestHelper(context.Background())
 	if !result.Succeeded {
 		t.Fatalf("empty helper test was not successful: %#v", result)
 	}
-	if result.Health.Complete || result.Health.Reason == nil || *result.Health.Reason != ReasonNoSupportedData {
-		t.Fatalf("empty-host board health = %#v", result.Health)
+	if result.Health.State != StateStale || result.Health.Complete || result.Health.Reason == nil || *result.Health.Reason != ReasonInitialRefresh {
+		t.Fatalf("helper test rewrote board health = %#v", result.Health)
 	}
 	if result.Health.Transport != TransportHelper {
 		t.Fatalf("successful helper test transport = %q, want helper", result.Health.Transport)
+	}
+	if view := manager.ListView(0); len(view.Sessions) != 1 || view.Sessions[0].EligibleForAggregates {
+		t.Fatalf("stale cached session became aggregate eligible: %#v", view.Sessions)
+	}
+}
+
+func TestDiscoveryClearsInMemoryOwnershipWhenOwnershipWriteFails(t *testing.T) {
+	home := t.TempDir()
+	remote, artifact, content := lifecycleFixture(t)
+	cache := NewCache(filepath.Join(home, "remote-cache"))
+	path, err := helperPath(artifact.Version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	remote.files[path] = remoteFile(path, artifact, remote.platform.UID)
+	manager := NewManager(Options{
+		Cache: cache, ReleaseProvider: fixedHelperRelease{document: remote.document, content: content},
+		LifecycleFactory:            func(string) (Lifecycle, error) { return lifecycleFor(remote), nil },
+		HelperInstallationAvailable: true,
+	})
+	config := &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}
+	if err := manager.ApplySettings(config); err != nil {
+		t.Fatal(err)
+	}
+	ownershipPath, err := cache.helperOwnershipPath(config.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(ownershipPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	manager.ListView(0)
+	waitUntil(t, func() bool {
+		manager.mu.Lock()
+		defer manager.mu.Unlock()
+		return manager.helperProbe == helperProbeFallback
+	})
+	health := manager.DiagnosticsHealth()
+	if health.HelperOwnershipRecorded || manager.helperVersion != "" || manager.helperTarget != nil {
+		t.Fatalf("failed ownership write left in-memory ownership: health=%#v version=%q target=%#v", health, manager.helperVersion, manager.helperTarget)
 	}
 }
 

--- a/collector/internal/remote/manager_test.go
+++ b/collector/internal/remote/manager_test.go
@@ -2,11 +2,14 @@ package remote
 
 import (
 	"context"
+	"errors"
+	"os"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/centauri-ai/coslash/collector/internal/remoteprotocol"
 	"github.com/centauri-ai/coslash/collector/internal/session"
 	"github.com/centauri-ai/coslash/collector/internal/settings"
 	"github.com/centauri-ai/coslash/collector/internal/vendors"
@@ -39,7 +42,12 @@ func TestApplySettingsWaitsForFirstListViewWindow(t *testing.T) {
 
 	manager.ListView(0)
 	waitUntil(t, func() bool {
-		return started.Load() > 0
+		if started.Load() == 0 {
+			return false
+		}
+		manager.mu.Lock()
+		defer manager.mu.Unlock()
+		return !manager.refreshing
 	})
 }
 
@@ -137,6 +145,377 @@ func TestHardFailureFallsBackToStaleWhenCacheExists(t *testing.T) {
 	}
 	manager.mu.Unlock()
 }
+
+type fixedHelperRelease struct {
+	document SignedReleaseMetadata
+	content  []byte
+}
+
+type architectureRelease struct {
+	document  SignedReleaseMetadata
+	content   map[string][]byte
+	requested string
+	loads     int
+}
+
+func (release *architectureRelease) LoadMetadata(context.Context) (SignedReleaseMetadata, error) {
+	return release.document, nil
+}
+
+func (release *architectureRelease) LoadArtifact(_ context.Context, artifact Artifact) ([]byte, error) {
+	release.loads++
+	release.requested = artifact.Arch
+	return release.content[artifact.Arch], nil
+}
+
+func (release fixedHelperRelease) LoadMetadata(context.Context) (SignedReleaseMetadata, error) {
+	return release.document, nil
+}
+
+func (release fixedHelperRelease) LoadArtifact(context.Context, Artifact) ([]byte, error) {
+	return release.content, nil
+}
+
+func TestManagerUsesOnlyLifecycleVerifiedHelperAndDoesNotSilentlyFallback(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("COSLASH_HOME", home)
+	remote, artifact, content := lifecycleFixture(t)
+	var sftpCalls atomic.Int32
+	var helperCalls atomic.Int32
+	manager := NewManager(Options{
+		Cache: NewCache(filepath.Join(home, "remote-cache")),
+		Now:   time.Now,
+		Refresh: func(context.Context, string, int64, time.Time, CachedSnapshotV2) (refreshOutcome, error) {
+			sftpCalls.Add(1)
+			return refreshOutcome{}, nil
+		},
+		HelperRefresh: func(_ context.Context, _ string, _ int64, _ time.Time, _ CachedSnapshotV2, target helperTarget) (refreshOutcome, error) {
+			helperCalls.Add(1)
+			if target.path == "" || target.version != artifact.Version {
+				t.Fatalf("unverified helper target = %#v", target)
+			}
+			return refreshOutcome{Metrics: CollectionMetrics{RequestBytes: 5, ResponseBytes: 9, Records: 2}}, ErrHelperFailed
+		},
+		ReleaseProvider:             fixedHelperRelease{document: remote.document, content: content},
+		LifecycleFactory:            func(string) (Lifecycle, error) { return lifecycleFor(remote), nil },
+		HelperInstallationAvailable: true,
+	})
+	if err := manager.ApplySettings(&settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	health := manager.SetupHelper(context.Background(), Consent{Install: true})
+	if health.Helper == nil || !health.Helper.Compatible || health.Helper.Version != artifact.Version {
+		t.Fatalf("setup health = %#v", health)
+	}
+	manager.ListView(time.Now().Add(-time.Hour).UnixMilli())
+	waitUntil(t, func() bool {
+		manager.mu.Lock()
+		defer manager.mu.Unlock()
+		return !manager.refreshing
+	})
+	health = manager.DiagnosticsHealth()
+	if helperCalls.Load() != 1 || sftpCalls.Load() != 0 {
+		t.Fatalf("helper calls=%d sftp calls=%d", helperCalls.Load(), sftpCalls.Load())
+	}
+	if health.Transport != TransportHelper || health.Reason == nil || *health.Reason != ReasonHelperFailed {
+		t.Fatalf("failure health = %#v", health)
+	}
+}
+
+func TestPartialRefreshMarksOnlyRetainedFailedFamilyStale(t *testing.T) {
+	manager := NewManager(Options{})
+	manager.cfg = &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}
+	manager.state = StateLimited
+	manager.complete = false
+	manager.sessions = []*session.Session{
+		{Agent: vendors.AgentClaude, ID: "fresh", Status: strPtr("working")},
+		{Agent: vendors.AgentClaude, ID: "retained", Status: strPtr("idle")},
+	}
+	manager.familyStale = map[remoteSessionKey]bool{{Agent: vendors.AgentClaude, ID: "retained"}: true}
+	view := manager.ListView(0)
+	if len(view.Sessions) != 2 || view.Sessions[0].DisplayStale || !view.Sessions[1].DisplayStale {
+		t.Fatalf("partial stale provenance = %#v", view.Sessions)
+	}
+	if view.Sessions[1].LastSeenStatus == nil || *view.Sessions[1].LastSeenStatus != "idle" {
+		t.Fatalf("retained status = %#v", view.Sessions[1].LastSeenStatus)
+	}
+}
+
+func TestRestartDiscoversAndReusesVerifiedHelperWithoutInstall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("COSLASH_HOME", home)
+	remote, artifact, content := lifecycleFixture(t)
+	cache := NewCache(filepath.Join(home, "remote-cache"))
+	options := Options{
+		Cache: cache, Now: time.Now,
+		ReleaseProvider:             fixedHelperRelease{document: remote.document, content: content},
+		LifecycleFactory:            func(string) (Lifecycle, error) { return lifecycleFor(remote), nil },
+		HelperInstallationAvailable: true,
+		HelperRefresh: func(context.Context, string, int64, time.Time, CachedSnapshotV2, helperTarget) (refreshOutcome, error) {
+			return refreshOutcome{Snapshot: CachedSnapshotV2{Version: cacheV2Version}}, nil
+		},
+	}
+	first := NewManager(options)
+	config := &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}
+	if err := first.ApplySettings(config); err != nil {
+		t.Fatal(err)
+	}
+	if health := first.SetupHelper(context.Background(), Consent{Install: true}); health.Helper == nil || !health.Helper.Compatible {
+		t.Fatalf("initial setup health = %#v", health)
+	}
+	if remote.installs != 1 {
+		t.Fatalf("initial installs = %d, want 1", remote.installs)
+	}
+
+	restarted := NewManager(options)
+	if err := restarted.ApplySettings(config); err != nil {
+		t.Fatal(err)
+	}
+	restarted.ListView(time.Now().Add(-time.Hour).UnixMilli())
+	waitUntil(t, func() bool {
+		restarted.mu.Lock()
+		defer restarted.mu.Unlock()
+		return restarted.helperProbe == helperProbeReady && !restarted.refreshing
+	})
+	if remote.installs != 1 {
+		t.Fatalf("restart installed again: installs=%d", remote.installs)
+	}
+	if health := restarted.DiagnosticsHealth(); health.Transport != TransportHelper || health.Helper == nil || !health.Helper.Compatible || health.Helper.Version != artifact.Version {
+		t.Fatalf("restart health = %#v", health)
+	}
+}
+
+func TestHelperTestAcceptsEmptySuccessfulCollection(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("COSLASH_HOME", home)
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	lifecycleRemote, _, content := lifecycleFixture(t)
+	manager := NewManager(Options{
+		Cache: NewCache(filepath.Join(home, "remote-cache")), Now: func() time.Time { return now },
+		ReleaseProvider:             fixedHelperRelease{document: lifecycleRemote.document, content: content},
+		LifecycleFactory:            func(string) (Lifecycle, error) { return lifecycleFor(lifecycleRemote), nil },
+		HelperInstallationAvailable: true,
+		HelperRefresh: func(context.Context, string, int64, time.Time, CachedSnapshotV2, helperTarget) (refreshOutcome, error) {
+			return refreshOutcome{Snapshot: CachedSnapshotV2{}}, nil
+		},
+	})
+	config := &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}
+	if err := manager.ApplySettings(config); err != nil {
+		t.Fatal(err)
+	}
+	if health := manager.SetupHelper(context.Background(), Consent{Install: true}); health.Helper == nil || !health.Helper.Compatible {
+		t.Fatalf("setup health = %#v", health)
+	}
+	manager.mu.Lock()
+	manager.snapshot = &CachedSnapshotV2{Version: cacheV2Version, CoverageSinceMs: now.UnixMilli()}
+	manager.lastRequestedMs = 0
+	manager.mu.Unlock()
+	result := manager.TestHelper(context.Background())
+	if !result.Succeeded {
+		t.Fatalf("empty helper test was not successful: %#v", result)
+	}
+	if result.Health.Complete || result.Health.Reason == nil || *result.Health.Reason != ReasonNoSupportedData {
+		t.Fatalf("empty-host board health = %#v", result.Health)
+	}
+}
+
+func TestHelperOwnershipBlocksAliasChangeUntilExplicitRelease(t *testing.T) {
+	cache := NewCache(t.TempDir())
+	manager := NewManager(Options{Cache: cache})
+	first := &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "old-host", Enabled: true}
+	if err := cache.StoreHelperVersion(first.ID, "v1", first.SSHAlias); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.ApplySettings(first); err != nil {
+		t.Fatal(err)
+	}
+	changed := *first
+	changed.SSHAlias = "new-host"
+	if err := manager.ApplySettings(&changed); !errors.Is(err, ErrHelperOwnershipConflict) {
+		t.Fatalf("alias replacement error = %v", err)
+	}
+	if err := manager.ReleaseHelperOwnership(); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.ApplySettings(&changed); err != nil {
+		t.Fatalf("explicit release should allow alias replacement: %v", err)
+	}
+}
+
+func TestHealthReportsRecordedOwnershipEvenWhenNoHelperVersionIsInspectable(t *testing.T) {
+	cache := NewCache(t.TempDir())
+	manager := NewManager(Options{Cache: cache})
+	config := &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}
+	if err := cache.StoreHelperVersion(config.ID, "v1", config.SSHAlias); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.ApplySettings(config); err != nil {
+		t.Fatal(err)
+	}
+	health := manager.DiagnosticsHealth()
+	if !health.HelperOwnershipRecorded || health.Helper != nil {
+		t.Fatalf("ownership must not be inferred from an inspectable helper version: %#v", health)
+	}
+}
+
+func TestCorruptOwnershipBlocksAliasReplacement(t *testing.T) {
+	cache := NewCache(t.TempDir())
+	config := &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}
+	path, err := cache.helperOwnershipPath(config.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{"version":"?"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	manager := NewManager(Options{Cache: cache})
+	changed := *config
+	changed.SSHAlias = "new-host"
+	if err := manager.ValidateSettingsChange(&changed); !errors.Is(err, ErrHelperOwnershipCorrupt) {
+		t.Fatalf("corrupt ownership replacement error = %v", err)
+	}
+}
+
+func TestFailedUninstallRetainsHostAndOwnership(t *testing.T) {
+	cache := NewCache(t.TempDir())
+	manager := NewManager(Options{Cache: cache})
+	config := &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}
+	if err := cache.StoreHelperVersion(config.ID, "v1", config.SSHAlias); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.ApplySettings(config); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.UninstallHelper(context.Background()); err == nil {
+		t.Fatal("uninstall without a release provider unexpectedly succeeded")
+	}
+	if manager.cfg == nil || manager.cfg.SSHAlias != config.SSHAlias || manager.helperVersion != "v1" {
+		t.Fatalf("failed uninstall lost ownership: cfg=%#v version=%q", manager.cfg, manager.helperVersion)
+	}
+}
+
+func TestInterruptedUninstallRetainsHostOwnershipAndHelper(t *testing.T) {
+	home := t.TempDir()
+	remote, artifact, content := lifecycleFixture(t)
+	cache := NewCache(home)
+	manager := NewManager(Options{
+		Cache: cache, ReleaseProvider: fixedHelperRelease{document: remote.document, content: content},
+		LifecycleFactory:            func(string) (Lifecycle, error) { return lifecycleFor(remote), nil },
+		HelperInstallationAvailable: true,
+	})
+	config := &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}
+	if err := manager.ApplySettings(config); err != nil {
+		t.Fatal(err)
+	}
+	if health := manager.SetupHelper(context.Background(), Consent{Install: true}); health.Helper == nil || !health.Helper.Compatible {
+		t.Fatalf("setup health = %#v", health)
+	}
+	remote.removeErr = context.DeadlineExceeded
+	if err := manager.UninstallHelper(context.Background()); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("UninstallHelper error = %v, want deadline", err)
+	}
+	path, _ := helperPath(artifact.Version)
+	if manager.cfg == nil || manager.helperVersion != artifact.Version || remote.files[path].Path == "" {
+		t.Fatalf("interrupted uninstall lost recovery state: cfg=%#v version=%q files=%#v", manager.cfg, manager.helperVersion, remote.files)
+	}
+	if ownership, ok, err := cache.LoadHelperOwnership(config.ID); err != nil || !ok || ownership.Version != artifact.Version {
+		t.Fatalf("interrupted uninstall lost ownership: %#v, ok=%v, err=%v", ownership, ok, err)
+	}
+}
+
+func TestProductionManagerHasPrivateSequenceStoreAndFeatureGatedProvider(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("COSLASH_HOME", home)
+	manager, err := NewProductionManager()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manager.releaseProvider == nil || manager.lifecycleFactory == nil || manager.helperInstallationAvailable {
+		t.Fatalf("production manager is not safely feature gated: %#v", manager)
+	}
+	store, ok := manager.trust.Sequences.(*FileMetadataSequenceStore)
+	if !ok || store.Path != filepath.Join(home, "helper-release", "sequence") {
+		t.Fatalf("sequence store = %#v", manager.trust.Sequences)
+	}
+}
+
+func TestSetupFetchesOnlyTheSelectedArchitectureArtifact(t *testing.T) {
+	for _, arch := range []string{"amd64", "arm64"} {
+		t.Run(arch, func(t *testing.T) {
+			remote, _, _ := lifecycleFixture(t)
+			remote.platform.Arch = arch
+			remote.capabilities.Arch = arch
+			content := syntheticELF(arch)
+			artifact := Artifact{Version: "v1", OS: "linux", Arch: arch, Size: int64(len(content)), SHA256: digest(content), Protocol: remoteprotocol.VersionRange{Min: 1, Max: 1}, Schema: remoteprotocol.VersionRange{Min: 1, Max: 1}, Current: true}
+			remote.document = signDocument(t, ReleaseMetadata{Sequence: 1, ExpiresAtUnix: time.Now().Add(time.Hour).Unix(), Artifacts: []Artifact{artifact}})
+			provider := &architectureRelease{document: remote.document, content: map[string][]byte{arch: content}}
+			manager := NewManager(Options{
+				Cache: NewCache(t.TempDir()), ReleaseProvider: provider,
+				LifecycleFactory:            func(string) (Lifecycle, error) { return lifecycleFor(remote), nil },
+				HelperInstallationAvailable: true,
+			})
+			if err := manager.ApplySettings(&settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}); err != nil {
+				t.Fatal(err)
+			}
+			if health := manager.SetupHelper(context.Background(), Consent{Install: true}); health.Helper == nil || !health.Helper.Compatible {
+				t.Fatalf("setup health = %#v", health)
+			}
+			if provider.requested != arch {
+				t.Fatalf("requested artifact = %q, want %q", provider.requested, arch)
+			}
+		})
+	}
+}
+
+func TestHelperFallbackPolicy(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		result LifecycleResult
+		want   bool
+	}{
+		{"missing", LifecycleResult{State: LifecycleSFTP}, true},
+		{"unsupported", LifecycleResult{State: LifecycleUnsupported}, true},
+		{"blocked", LifecycleResult{State: LifecycleSFTP, Reason: ErrHelperNoExec}, true},
+		{"incompatible", LifecycleResult{State: LifecycleUpgradeRequired, Reason: ErrHelperIncompatible}, true},
+		{"revoked", LifecycleResult{State: LifecycleRevoked, Reason: ErrHelperRevoked}, true},
+		{"verification", LifecycleResult{State: LifecycleVerificationError, Reason: ErrHelperVerification}, true},
+		{"installation", LifecycleResult{State: LifecycleSFTP, Reason: ErrHelperInstallation}, true},
+		{"verified", LifecycleResult{State: LifecycleReady, CanExecute: true}, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := useSFTPFallbackAfterDiscovery(test.result); got != test.want {
+				t.Fatalf("useSFTPFallbackAfterDiscovery(%#v) = %v, want %v", test.result, got, test.want)
+			}
+		})
+	}
+}
+
+func TestReadOnlyDiscoveryDoesNotFetchAnArtifact(t *testing.T) {
+	remote, artifact, content := lifecycleFixture(t)
+	provider := &architectureRelease{document: remote.document, content: map[string][]byte{artifact.Arch: content}}
+	manager := NewManager(Options{
+		Cache: NewCache(t.TempDir()), ReleaseProvider: provider,
+		LifecycleFactory:            func(string) (Lifecycle, error) { return lifecycleFor(remote), nil },
+		HelperInstallationAvailable: true,
+	})
+	if err := manager.ApplySettings(&settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	manager.ListView(time.Now().Add(-time.Hour).UnixMilli())
+	waitUntil(t, func() bool {
+		manager.mu.Lock()
+		defer manager.mu.Unlock()
+		return manager.helperProbe == helperProbeFallback
+	})
+	if provider.loads != 0 {
+		t.Fatalf("read-only discovery downloaded %d artifacts", provider.loads)
+	}
+}
+
+func strPtr(value string) *string { return &value }
 
 func waitUntil(t *testing.T, ready func() bool) {
 	t.Helper()

--- a/collector/internal/remote/sftp.go
+++ b/collector/internal/remote/sftp.go
@@ -33,6 +33,16 @@ func ensureSSHControlDir() error {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("create SSH control directory: %w", err)
 	}
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return fmt.Errorf("inspect SSH control directory: %w", err)
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return errors.New("SSH control directory is not a real directory")
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		return fmt.Errorf("secure SSH control directory: %w", err)
+	}
 	return nil
 }
 
@@ -106,10 +116,33 @@ func runSSHCommand(ctx context.Context, options OpenOptions, args []string) erro
 	if command == nil {
 		command = exec.CommandContext
 	}
-	cmd := command(ctx, bin, args...)
-	output, err := cmd.CombinedOutput()
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	cmd := command(runCtx, bin, args...)
+	configureProcessGroup(cmd)
+	output := &cappedStderr{limit: options.Limits.withDefaults().MaxStderrBytes, cancel: cancel}
+	cmd.Stdout = output
+	cmd.Stderr = output
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start SSH command: %w", err)
+	}
+	waited := make(chan error, 1)
+	go func() { waited <- cmd.Wait() }()
+	var err error
+	select {
+	case err = <-waited:
+	case <-runCtx.Done():
+		terminateProcessGroup(cmd)
+		err = <-waited
+	}
+	if output.overflow {
+		return ErrStderrLimit
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
 	if err != nil {
-		return fmt.Errorf("%w: %s", err, bytes.TrimSpace(output))
+		return wrapSSHError(err, output.String())
 	}
 	return nil
 }
@@ -124,6 +157,8 @@ func ensureControlMaster(ctx context.Context, alias string, options OpenOptions)
 	}
 	if err := runSSHCommand(ctx, options, checkArgs); err == nil {
 		return nil
+	} else if errors.Is(err, ErrStderrLimit) || ctx.Err() != nil {
+		return err
 	}
 	limits := options.Limits.withDefaults()
 	startArgs, err := controlMasterStartArgs(alias, int(limits.ConnectTimeout.Seconds()))

--- a/collector/internal/remote/source.go
+++ b/collector/internal/remote/source.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"unicode/utf8"
 )
 
 type sftpOperations struct {
@@ -193,6 +194,9 @@ func (source *Source) ReadDir(name string) ([]fs.DirEntry, error) {
 	clean := path.Clean(name)
 	result := make([]fs.DirEntry, 0, len(entries))
 	for _, entry := range entries {
+		if !validRemoteDirEntryName(entry.Name()) {
+			return nil, ErrPathDenied
+		}
 		result = append(result, fs.FileInfoToDirEntry(entry))
 		if allowedIndex >= 0 && entry.Mode()&fs.ModeSymlink == 0 {
 			childLexical := path.Join(clean, entry.Name())
@@ -204,6 +208,15 @@ func (source *Source) ReadDir(name string) ([]fs.DirEntry, error) {
 	}
 	sort.Slice(result, func(i, j int) bool { return result[i].Name() < result[j].Name() })
 	return result, nil
+}
+
+// validRemoteDirEntryName rejects malformed names from an untrusted SFTP
+// server before they are used to build a cached child path. POSIX servers do
+// not normally return separators here, but this boundary must not rely on a
+// compromised server obeying that convention.
+func validRemoteDirEntryName(name string) bool {
+	return utf8.ValidString(name) && name != "" && name != "." && name != ".." && path.Base(name) == name &&
+		!strings.ContainsAny(name, "/\\\x00")
 }
 
 func (source *Source) Stat(name string) (fs.FileInfo, error) {

--- a/collector/internal/remote/source_test.go
+++ b/collector/internal/remote/source_test.go
@@ -2,6 +2,7 @@ package remote
 
 import (
 	"io"
+	"os"
 	"path"
 	"testing"
 	"time"
@@ -70,6 +71,23 @@ func TestReadDirCacheStillRejectsSymlinkEntries(t *testing.T) {
 	}
 	if _, err := source.Stat(path.Join(dir, "evil.jsonl")); err == nil {
 		t.Fatal("a symlink entry discovered via ReadDir must still be rejected")
+	}
+}
+
+func TestReadDirRejectsMalformedServerEntryNames(t *testing.T) {
+	fs := newFakeFS()
+	dir := path.Join(fakeHome, ".claude/projects/proj")
+	fs.mkdirAll(dir)
+	ops := fs.ops()
+	ops.readDir = func(string) ([]os.FileInfo, error) {
+		return []os.FileInfo{fakeFileInfo{name: "../outside", mode: 0o644}}, nil
+	}
+	source, err := newSource(ops, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := source.ReadDir(dir); err == nil {
+		t.Fatal("ReadDir accepted an entry name with traversal")
 	}
 }
 

--- a/collector/internal/remote/staleness.go
+++ b/collector/internal/remote/staleness.go
@@ -1,0 +1,23 @@
+package remote
+
+// staleSessions derives display provenance from normalized cached families.
+// A partial refresh can therefore retain one failed family as stale without
+// making unrelated, freshly replaced families look stale.
+func staleSessions(snapshot CachedSnapshotV2) map[remoteSessionKey]bool {
+	result := map[remoteSessionKey]bool{}
+	for _, family := range snapshot.Families {
+		if family.StaleReason == "" {
+			continue
+		}
+		parsed, _, err := family.Facts.Parsed()
+		if err != nil {
+			continue
+		}
+		for _, item := range parsed {
+			if item != nil && item.Session != nil {
+				result[remoteSessionKey{Agent: item.Session.Agent, ID: item.Session.ID}] = true
+			}
+		}
+	}
+	return result
+}

--- a/collector/internal/remote/t07_realhost_test.go
+++ b/collector/internal/remote/t07_realhost_test.go
@@ -1,0 +1,162 @@
+package remote
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/centauri-ai/coslash/collector/internal/remotefacts"
+)
+
+// TestT07RealHostSFTPAndHelperParity is deliberately opt-in: it reads the
+// caller's existing remote agent data over SSH. It emits only aggregate counts
+// and comparison results, never family IDs, paths, or transcript-derived facts.
+//
+// Run with:
+//
+//	COSLASH_T07_REAL_HOST=1 COSLASH_T07_SSH_ALIAS=<alias> \
+//	  COSLASH_T07_HELPER_PATH='~/.coslash/helpers/<version>/coslash-helper' \
+//	  go test -count=1 -run '^TestT07RealHostSFTPAndHelperParity$' ./internal/remote
+func TestT07RealHostSFTPAndHelperParity(t *testing.T) {
+	if os.Getenv("COSLASH_T07_REAL_HOST") != "1" {
+		t.Skip("set COSLASH_T07_REAL_HOST=1 to run against an authorized SSH host")
+	}
+	alias, helperPath := os.Getenv("COSLASH_T07_SSH_ALIAS"), os.Getenv("COSLASH_T07_HELPER_PATH")
+	if alias == "" || helperPath == "" {
+		t.Fatal("COSLASH_T07_SSH_ALIAS and COSLASH_T07_HELPER_PATH are required")
+	}
+
+	now := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	sftp, err := refreshIncrementalWithOpen(ctx, alias, now.Add(-7*24*time.Hour).UnixMilli(), now, CachedSnapshotV2{}, OpenSession)
+	if err != nil {
+		t.Fatal("SFTP collection failed")
+	}
+	helper, err := helperRefreshWithOpen(ctx, alias, now.Add(-7*24*time.Hour).UnixMilli(), now, CachedSnapshotV2{}, helperTarget{path: helperPath}, OpenOptions{})
+	if err != nil {
+		t.Fatal("helper collection failed")
+	}
+	if len(sftp.Failures) != 0 || len(helper.Failures) != 0 {
+		t.Fatal("collection reported partial vendor coverage")
+	}
+
+	sftpFamilies := familyFactsByKey(sftp.Snapshot)
+	helperFamilies := familyFactsByKey(helper.Snapshot)
+	if !reflect.DeepEqual(sftpFamilies, helperFamilies) {
+		t.Fatalf(
+			"SFTP/helper normalized facts differ (sftp_families=%d helper_families=%d sftp_by_vendor=%v helper_by_vendor=%v sftp_only=%v helper_only=%v field_differences=%v)",
+			len(sftpFamilies), len(helperFamilies), familyCountsByVendor(sftpFamilies), familyCountsByVendor(helperFamilies),
+			familyDifferenceCounts(sftpFamilies, helperFamilies), familyDifferenceCounts(helperFamilies, sftpFamilies),
+			familyFieldDifferenceCounts(sftpFamilies, helperFamilies),
+		)
+	}
+	warm, err := helperRefreshWithOpen(ctx, alias, now.Add(-7*24*time.Hour).UnixMilli(), now, helper.Snapshot, helperTarget{path: helperPath}, OpenOptions{})
+	if err != nil {
+		t.Fatal("warm helper collection failed")
+	}
+	if len(warm.Failures) != 0 {
+		t.Fatal("warm helper collection reported partial vendor coverage")
+	}
+	if !reflect.DeepEqual(helperFamilies, familyFactsByKey(warm.Snapshot)) {
+		t.Fatal("warm helper collection changed normalized facts")
+	}
+	// An empty host has no family bodies to elide, and the known-baseline
+	// envelope can be a few bytes larger than the baseline-free request. Only
+	// require byte reduction when the initial response contained family facts.
+	if len(helperFamilies) > 0 && warm.Metrics.ResponseBytes >= helper.Metrics.ResponseBytes {
+		t.Fatalf("warm helper response was not smaller (initial_bytes=%d warm_bytes=%d)", helper.Metrics.ResponseBytes, warm.Metrics.ResponseBytes)
+	}
+	t.Logf("parity passed: families=%d sftp_round_trip_ms=%d helper_round_trip_ms=%d helper_response_bytes=%d warm_round_trip_ms=%d warm_response_bytes=%d",
+		len(sftpFamilies), sftp.RoundTrip.Milliseconds(), helper.RoundTrip.Milliseconds(), helper.Metrics.ResponseBytes,
+		warm.RoundTrip.Milliseconds(), warm.Metrics.ResponseBytes)
+}
+
+func familyFactsByKey(snapshot CachedSnapshotV2) map[string]remotefacts.Family {
+	result := make(map[string]remotefacts.Family, len(snapshot.Families))
+	for _, family := range snapshot.Families {
+		result[family.Vendor+"\x00"+family.FamilyID] = family.Facts
+	}
+	return result
+}
+
+func familyCountsByVendor(families map[string]remotefacts.Family) map[string]int {
+	counts := map[string]int{}
+	for _, family := range families {
+		counts[family.Vendor]++
+	}
+	return counts
+}
+
+func familyDifferenceCounts(left, right map[string]remotefacts.Family) map[string]int {
+	counts := map[string]int{}
+	for key, family := range left {
+		if _, ok := right[key]; !ok {
+			counts[family.Vendor]++
+		}
+	}
+	return counts
+}
+
+// familyFieldDifferenceCounts deliberately reports only field classes and
+// counts. It is used by the opt-in real-host test to diagnose parity without
+// logging identifiers, paths, timestamps, or transcript-derived values.
+func familyFieldDifferenceCounts(left, right map[string]remotefacts.Family) map[string]int {
+	counts := map[string]int{}
+	for key, l := range left {
+		r, ok := right[key]
+		if !ok {
+			continue
+		}
+		for _, field := range []struct {
+			name  string
+			left  any
+			right any
+		}{
+			{"schema_version", l.SchemaVersion, r.SchemaVersion},
+			{"parser_version", l.ParserVersion, r.ParserVersion},
+			{"state", l.State, r.State},
+			{"stale_reason", l.StaleReason, r.StaleReason},
+			{"sessions", l.Sessions, r.Sessions},
+			{"metadata", l.Metadata, r.Metadata},
+			{"fingerprints", l.Fingerprints, r.Fingerprints},
+			{"header_mappings", l.HeaderMappings, r.HeaderMappings},
+		} {
+			if !reflect.DeepEqual(field.left, field.right) {
+				counts[field.name]++
+			}
+		}
+		for field, count := range fingerprintFieldDifferenceCounts(l.Fingerprints, r.Fingerprints) {
+			counts["fingerprints."+field] += count
+		}
+	}
+	return counts
+}
+
+func fingerprintFieldDifferenceCounts(left, right []remotefacts.Fingerprint) map[string]int {
+	counts := map[string]int{}
+	if len(left) != len(right) {
+		counts["length"]++
+	}
+	byKey := make(map[string]remotefacts.Fingerprint, len(right))
+	for _, item := range right {
+		byKey[item.Key] = item
+	}
+	for _, item := range left {
+		other, ok := byKey[item.Key]
+		if !ok {
+			counts["key_set"]++
+			continue
+		}
+		if item.Size != other.Size {
+			counts["size"]++
+		}
+		if item.ModifiedAtMs != other.ModifiedAtMs {
+			counts["modified_at"]++
+		}
+	}
+	return counts
+}

--- a/collector/internal/remotefacts/facts.go
+++ b/collector/internal/remotefacts/facts.go
@@ -39,6 +39,19 @@ const (
 	StateStale    = "stale"
 )
 
+// Stale reasons are codes rather than helper- or filesystem-supplied prose.
+// They are persisted with a last-good family, so accepting arbitrary text here
+// would let hostile protocol output turn the cache into a transcript sink.
+const (
+	StaleReasonOversizedFile        = "oversized_file"
+	StaleReasonVendorBudgetExceeded = "vendor_budget_exceeded"
+	StaleReasonPathDenied           = "path_denied"
+	StaleReasonInvalidData          = "invalid_data"
+	StaleReasonReadFailed           = "read_failed"
+	StaleReasonNoData               = "no_data"
+	StaleReasonUnstableFile         = "unstable_file"
+)
+
 // Family is the complete normalized replacement unit. Paths and raw transcript
 // content deliberately have no representation in this type.
 type Family struct {
@@ -147,8 +160,11 @@ func Validate(f Family) error {
 	if f.State != StateComplete && f.State != StatePartial && f.State != StateStale {
 		return fmt.Errorf("invalid family state %q", f.State)
 	}
-	if f.State == StateStale && (f.StaleReason == "" || !bounded(f.StaleReason, MaxDisplayBytes)) {
-		return errors.New("stale family requires a bounded reason")
+	if f.State == StateStale && !ValidStaleReason(f.StaleReason) {
+		return errors.New("stale family requires a fixed reason code")
+	}
+	if f.State != StateStale && f.StaleReason != "" {
+		return errors.New("non-stale family cannot carry a stale reason")
 	}
 	if len(f.Sessions) == 0 || len(f.Sessions) > MaxSessions {
 		return errors.New("invalid session count")
@@ -325,6 +341,19 @@ func identifier(value string) bool {
 		}
 	}
 	return true
+}
+
+// ValidStaleReason reports whether value is one of the fixed, content-free
+// reasons that may be kept beside a cached family.
+func ValidStaleReason(value string) bool {
+	switch value {
+	case StaleReasonOversizedFile, StaleReasonVendorBudgetExceeded,
+		StaleReasonPathDenied, StaleReasonInvalidData, StaleReasonReadFailed,
+		StaleReasonNoData, StaleReasonUnstableFile:
+		return true
+	default:
+		return false
+	}
 }
 func bounded(value string, limit int) bool { return utf8.ValidString(value) && len(value) <= limit }
 func validateOptionalCount(value *int) error {

--- a/collector/internal/remotefacts/facts_test.go
+++ b/collector/internal/remotefacts/facts_test.go
@@ -32,6 +32,15 @@ func TestValidateRejectsUnsortedAndUnboundedFacts(t *testing.T) {
 			f.Sessions = append(f.Sessions, Session{ID: "orphan", StartedAtMs: 1, LastActivityAtMs: 2, Usage: []ModelUsage{}, Spawns: []Spawn{}, CommandLabels: []string{}})
 		}},
 		{"negative count", func(f *Family) { f.Sessions[0].Counts.Errors = -1 }},
+		{"unstructured stale reason", func(f *Family) {
+			f.State, f.StaleReason = StateStale, "a transcript-derived failure"
+		}},
+		{"complete family carrying stale reason", func(f *Family) {
+			f.StaleReason = StaleReasonReadFailed
+		}},
+		{"partial family carrying stale reason", func(f *Family) {
+			f.State, f.StaleReason = StatePartial, StaleReasonReadFailed
+		}},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/collector/internal/remotehelper/collect.go
+++ b/collector/internal/remotehelper/collect.go
@@ -266,7 +266,7 @@ func publishChanged(
 			if singleErr != nil {
 				if skipErr := emitSkipped(
 					emitter, scanned.vendor, item.id,
-					boundedReason("transcript could not be parsed", singleErr),
+					boundedReason(singleErr),
 				); skipErr != nil {
 					return parser, skipErr
 				}
@@ -297,7 +297,7 @@ func publishFamily(
 	for attempt := 0; ; attempt++ {
 		if len(sessions) == 0 {
 			return parser, skipFamily(
-				emitter, scanned, item, counts, "no sessions could be parsed for this family",
+				emitter, scanned, item, counts, remotefacts.StaleReasonNoData,
 			)
 		}
 		if stable, reason := restabilize(scanned, item); !stable {
@@ -310,7 +310,7 @@ func publishFamily(
 			if err != nil {
 				return parser, skipFamily(
 					emitter, scanned, item, counts,
-					boundedReason("transcript could not be parsed", err),
+					boundedReason(err),
 				)
 			}
 			sessions = groupByFamily(reparsed, []*family{item})[item.id]
@@ -320,7 +320,7 @@ func publishFamily(
 		if err != nil {
 			return parser, skipFamily(
 				emitter, scanned, item, counts,
-				boundedReason("family facts failed validation", err),
+				boundedReason(err),
 			)
 		}
 		// A baseline-free response carries no prior fingerprint: the helper was
@@ -384,23 +384,23 @@ func familyFacts(
 // parser invalidates the facts just produced.
 func restabilize(scanned *vendorScan, item *family) (bool, string) {
 	if item.identityUnstable {
-		return false, "transcript family header changed while it was read"
+		return false, remotefacts.StaleReasonUnstableFile
 	}
 	stable := true
 	for _, file := range item.files {
 		before, ok := scanned.fileFacts[file]
 		if !ok {
-			return false, "transcript disappeared while it was read"
+			return false, remotefacts.StaleReasonUnstableFile
 		}
 		info, err := scanned.statFile(file)
 		if err != nil {
-			return false, "transcript disappeared while it was read"
+			return false, remotefacts.StaleReasonUnstableFile
 		}
-		if info.Size() != before.Size || info.ModTime().UnixMilli() != before.ModifiedAtMs {
+		refreshed := sftpCompatibleFingerprint(vendors.FileFingerprint{
+			Key: before.Key, Size: info.Size(), ModifiedAtMs: info.ModTime().UnixMilli(),
+		})
+		if refreshed.Size != before.Size || refreshed.ModifiedAtMs != before.ModifiedAtMs {
 			stable = false
-			refreshed := before
-			refreshed.Size = info.Size()
-			refreshed.ModifiedAtMs = info.ModTime().UnixMilli()
 			scanned.fileFacts[file] = refreshed
 			for index := range item.fingerprints {
 				if item.fingerprints[index].Key == refreshed.Key {
@@ -414,10 +414,10 @@ func restabilize(scanned *vendorScan, item *family) (bool, string) {
 	}
 	if scanned.vendor == vendors.AgentCodex && !codexHeadersStillMatch(scanned, item) {
 		item.identityUnstable = true
-		return false, "transcript family header changed while it was read"
+		return false, remotefacts.StaleReasonUnstableFile
 	}
 	item.fingerprint = aggregateFingerprint(item, scanned.metadata)
-	return false, "transcript changed while it was read"
+	return false, remotefacts.StaleReasonUnstableFile
 }
 
 func codexHeadersStillMatch(scanned *vendorScan, item *family) bool {
@@ -549,28 +549,26 @@ func outcomeOf(emitter *emitter, completed []string, requestComplete bool) Outco
 	}
 }
 
-// boundedReason keeps a structured skip reason inside the schema's display bound
-// and never repeats a path or transcript content back to the Mac.
-func boundedReason(reason string, err error) string {
-	if err == nil {
-		return reason
-	}
+// boundedReason converts filesystem and parser failures to fixed codes. Skip
+// reasons are persisted in the Mac cache, so even bounded remote error prose
+// must never cross the helper boundary.
+func boundedReason(err error) string {
 	switch {
 	case errors.Is(err, ErrFileLimit):
-		return reason + ": file exceeds the size limit"
+		return remotefacts.StaleReasonOversizedFile
 	case errors.Is(err, ErrEntryLimit), errors.Is(err, ErrDepthLimit):
-		return reason + ": safety limit reached"
+		return remotefacts.StaleReasonVendorBudgetExceeded
 	case errors.Is(err, ErrSymlink):
-		return reason + ": symlinks are not followed"
+		return remotefacts.StaleReasonPathDenied
 	case errors.Is(err, ErrPathDenied):
-		return reason + ": path is outside the read allowlist"
+		return remotefacts.StaleReasonPathDenied
 	case errors.Is(err, vendors.ErrInvalidData):
-		return reason + ": transcript data is invalid"
+		return remotefacts.StaleReasonInvalidData
 	case errors.Is(err, os.ErrNotExist):
-		return reason + ": file no longer exists"
+		return remotefacts.StaleReasonUnstableFile
 	case errors.Is(err, os.ErrPermission):
-		return reason + ": file is not readable"
+		return remotefacts.StaleReasonReadFailed
 	default:
-		return reason
+		return remotefacts.StaleReasonReadFailed
 	}
 }

--- a/collector/internal/remotehelper/remotehelper_test.go
+++ b/collector/internal/remotehelper/remotehelper_test.go
@@ -62,6 +62,23 @@ func TestSourceReadsFileAtExactByteLimit(t *testing.T) {
 	}
 }
 
+func TestSelectionSinceMatchesSFTPLookback(t *testing.T) {
+	since := (48 * time.Hour).Milliseconds()
+	if got, want := selectionSince(since), (24 * time.Hour).Milliseconds(); got != want {
+		t.Fatalf("selection since = %d, want %d", got, want)
+	}
+	if got := selectionSince((12 * time.Hour).Milliseconds()); got != 0 {
+		t.Fatalf("selection since before epoch = %d, want 0", got)
+	}
+}
+
+func TestSFTPCompatibleFingerprintUsesWholeSecondMtime(t *testing.T) {
+	fingerprint := sftpCompatibleFingerprint(vendors.FileFingerprint{Key: "file", Size: 9, ModifiedAtMs: 1_729_123_456_789})
+	if got, want := fingerprint.ModifiedAtMs, int64(1_729_123_456_000); got != want {
+		t.Fatalf("fingerprint mtime = %d, want %d", got, want)
+	}
+}
+
 func TestCodexScanReusesUnchangedCachedHeader(t *testing.T) {
 	home := t.TempDir()
 	root := filepath.Join(home, ".codex", "sessions")
@@ -84,7 +101,7 @@ func TestCodexScanReusesUnchangedCachedHeader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	fp := fingerprints[0]
+	fp := sftpCompatibleFingerprint(fingerprints[0])
 	request := validRequest()
 	request.Known = []remoteprotocol.KnownFamily{{
 		Vendor: "codex", FamilyID: id, Fingerprint: "family-fingerprint",

--- a/collector/internal/remotehelper/vendorscan.go
+++ b/collector/internal/remotehelper/vendorscan.go
@@ -32,6 +32,24 @@ func (v *vendorScan) statFile(file string) (fs.FileInfo, error) {
 	return v.source.Stat(file)
 }
 
+// selectionSince matches SFTP collection's one-day lookback. The requested
+// protocol window stays unchanged for coverage reporting; this only retains
+// near-boundary families so local, SFTP, and helper collection produce the
+// same normalized facts.
+func selectionSince(since int64) int64 {
+	return max(0, since-(24*time.Hour).Milliseconds())
+}
+
+// sftpCompatibleFingerprint uses the precision available to the fallback
+// transport. SFTP v3 reports mtimes in whole seconds, while a native helper
+// can see nanoseconds. Keeping the helper's protocol facts at second precision
+// lets a host move between SFTP and helper collection without spurious changed
+// families or a permanently mismatched Codex header baseline.
+func sftpCompatibleFingerprint(fingerprint vendors.FileFingerprint) vendors.FileFingerprint {
+	fingerprint.ModifiedAtMs = fingerprint.ModifiedAtMs / 1000 * 1000
+	return fingerprint
+}
+
 func scanClaude(
 	source *Source,
 	home string,
@@ -58,7 +76,7 @@ func scanClaude(
 	root := claude.ProjectsRoot(home)
 	found, err := claude.ScanSource(source, root)
 	if err != nil {
-		result.scan.incompleteWhy = boundedReason("directory scan failed", err)
+		result.scan.incompleteWhy = boundedReason(err)
 		return result
 	}
 	result.scan.complete = found.SkippedTotal == 0
@@ -68,7 +86,7 @@ func scanClaude(
 	result.scan.candidateFiles = len(found.Files)
 	selected := found.Files
 	if since > 0 {
-		selected = claude.FilesSinceSource(source, found.Files, metadata.Live, since)
+		selected = claude.FilesSinceSource(source, found.Files, metadata.Live, selectionSince(since))
 	}
 	selected, _ = vendors.LimitNewestSourceFileFamilies(
 		source, selected, vendors.MaxCandidateFilesPerAgent, claude.FamilyIDFromPath,
@@ -101,7 +119,7 @@ func scanCodex(source *Source, home string, request remoteprotocol.Request) *ven
 	root := codex.SessionsRoot(home)
 	found, err := codex.ScanSource(source, root)
 	if err != nil {
-		result.scan.incompleteWhy = boundedReason("directory scan failed", err)
+		result.scan.incompleteWhy = boundedReason(err)
 		return result
 	}
 	result.scan.complete = found.SkippedTotal == 0
@@ -116,9 +134,9 @@ func scanCodex(source *Source, home string, request remoteprotocol.Request) *ven
 	for _, file := range found.Files {
 		items, fingerprintErr := vendors.FingerprintSourceFiles(source, root, []string{file})
 		if fingerprintErr == nil && len(items) == 1 {
-			fingerprints[file] = items[0]
+			fingerprints[file] = sftpCompatibleFingerprint(items[0])
 			if cached, ok := known[items[0].Key]; ok && cached.Size == items[0].Size &&
-				cached.ModifiedAtMs == items[0].ModifiedAtMs &&
+				cached.ModifiedAtMs == fingerprints[file].ModifiedAtMs &&
 				cached.SessionID == codex.SessionIDFromRollout(file) {
 				headers[file] = codex.FileHeader{SessionID: cached.SessionID, ParentID: cached.ParentID}
 				continue
@@ -132,7 +150,7 @@ func scanCodex(source *Source, home string, request remoteprotocol.Request) *ven
 	roots := codex.FamilyRoots(headers)
 	selected := found.Files
 	if request.SinceMs > 0 {
-		selected = codex.FilesSinceSource(source, found.Files, metadata.Live, request.SinceMs)
+		selected = codex.FilesSinceSource(source, found.Files, metadata.Live, selectionSince(request.SinceMs))
 	}
 	selected, _ = vendors.LimitNewestSourceFileFamilies(
 		source, selected, vendors.MaxCandidateFilesPerAgent,
@@ -172,7 +190,7 @@ func scanCodex(source *Source, home string, request remoteprotocol.Request) *ven
 			})
 		}
 		if header.Err != nil {
-			result.scan.family(familyID).skipReason = boundedReason("header unreadable", header.Err)
+			result.scan.family(familyID).skipReason = boundedReason(header.Err)
 		}
 	}
 	result.scan.finish(metadata)
@@ -189,10 +207,10 @@ func (v *vendorScan) record(
 ) {
 	fingerprints, err := vendors.FingerprintSourceFiles(source, root, []string{file})
 	if err != nil || len(fingerprints) != 1 {
-		v.scan.family(familyID).skipReason = boundedReason("file became unreadable", err)
+		v.scan.family(familyID).skipReason = boundedReason(err)
 		return
 	}
-	v.recordFingerprint(familyID, sessionID, file, fingerprints[0], selected)
+	v.recordFingerprint(familyID, sessionID, file, sftpCompatibleFingerprint(fingerprints[0]), selected)
 }
 
 func (v *vendorScan) recordFingerprint(

--- a/collector/internal/remoteprotocol/protocol.go
+++ b/collector/internal/remoteprotocol/protocol.go
@@ -243,6 +243,9 @@ func Decode(reader io.Reader, request Request) ([]Record, error) {
 	if limited.N <= 0 {
 		return nil, errors.New("response exceeds byte limit")
 	}
+	if !complete {
+		return nil, errors.New("response ended before request_complete")
+	}
 	return records, nil
 }
 
@@ -289,7 +292,7 @@ func validateRecord(r Record, request Request, sequence int) error {
 			return errors.New("invalid unchanged family record")
 		}
 	case RecordSkipped:
-		if !requestedVendor(request, r.Vendor) || !validID(r.FamilyID) || r.Reason == "" || len(r.Reason) > remotefacts.MaxDisplayBytes {
+		if !requestedVendor(request, r.Vendor) || !validID(r.FamilyID) || !remotefacts.ValidStaleReason(r.Reason) {
 			return errors.New("invalid skipped family record")
 		}
 	case RecordTombstone:

--- a/collector/internal/remoteprotocol/protocol_fuzz_test.go
+++ b/collector/internal/remoteprotocol/protocol_fuzz_test.go
@@ -1,0 +1,26 @@
+package remoteprotocol
+
+import (
+	"bytes"
+	"testing"
+)
+
+// FuzzDecode exercises the strict, bounded NDJSON decoder with hostile wire
+// bytes. The fixed request keeps every iteration inside the protocol ceilings.
+func FuzzDecode(f *testing.F) {
+	f.Add([]byte(""))
+	f.Add([]byte("{}\n"))
+	f.Add([]byte(`{"type":"handshake","protocol_version":1,"request_id":"req-1","sequence":1}` + "\n"))
+	request := request()
+	f.Fuzz(func(t *testing.T, input []byte) {
+		_, _ = Decode(bytes.NewReader(input), request)
+	})
+}
+
+func FuzzDecodeCapabilities(f *testing.F) {
+	f.Add([]byte("{}"))
+	f.Add([]byte(`{"protocol":{"min":1,"max":1},"schema":{"min":1,"max":1},"parser_version":"parser-v1"}`))
+	f.Fuzz(func(t *testing.T, input []byte) {
+		_, _ = DecodeCapabilities(bytes.NewReader(input))
+	})
+}

--- a/collector/internal/remoteprotocol/protocol_test.go
+++ b/collector/internal/remoteprotocol/protocol_test.go
@@ -78,6 +78,7 @@ func TestDecodeRejectsUnknownFieldsAndTrailingContent(t *testing.T) {
 	for _, input := range []string{
 		`{"type":"handshake","protocol_version":1,"request_id":"req-1","sequence":1,"baseline_id":"base-1","schema_version":1,"parser_version":"parser-v1","secret":"x"}` + "\n",
 		`{"type":"request_complete","protocol_version":1,"request_id":"req-1","sequence":1}` + "\n{}\n",
+		`{"type":"handshake","protocol_version":1,"request_id":"req-1","sequence":1,"baseline_id":"base-1","schema_version":1,"parser_version":"parser-v1"}` + "\n",
 	} {
 		if _, err := Decode(strings.NewReader(input), r); err == nil {
 			t.Fatalf("accepted %q", input)
@@ -130,7 +131,7 @@ func TestChangedFamilyPublishesBeforeRequestCompletionAndFailedReplacementStaysG
 	if _, ok := a.Proposal().Families[FamilyKey{"codex", "root"}]; !ok {
 		t.Fatal("validated changed family not publishable")
 	}
-	if err := a.Apply(Record{Type: RecordSkipped, ProtocolVersion: 1, RequestID: r.RequestID, Sequence: 3, Vendor: "codex", FamilyID: "old", Reason: "unstable_file"}); err != nil {
+	if err := a.Apply(Record{Type: RecordSkipped, ProtocolVersion: 1, RequestID: r.RequestID, Sequence: 3, Vendor: "codex", FamilyID: "old", Reason: remotefacts.StaleReasonUnstableFile}); err != nil {
 		t.Fatal(err)
 	}
 	if got := a.Proposal().Families[FamilyKey{"codex", "old"}]; got.Fingerprint != "old" || got.StaleReason != "unstable_file" {
@@ -228,12 +229,44 @@ func TestDecodeRoundTrip(t *testing.T) {
 	}
 }
 
+func TestSkippedFamilyRejectsUnstructuredReason(t *testing.T) {
+	r := request()
+	a, err := NewAccumulator(r, Generation{BaselineID: "base-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := a.Apply(handshake(r)); err != nil {
+		t.Fatal(err)
+	}
+	err = a.Apply(Record{Type: RecordSkipped, ProtocolVersion: 1, RequestID: r.RequestID, Sequence: 2, Vendor: "codex", FamilyID: "root", Reason: "raw stderr or transcript text"})
+	if err == nil {
+		t.Fatal("accepted an unstructured skip reason")
+	}
+}
+
+func TestChangedFamilyRejectsStaleReasonOutsideStaleState(t *testing.T) {
+	r := request()
+	a, err := NewAccumulator(r, Generation{BaselineID: "base-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := a.Apply(handshake(r)); err != nil {
+		t.Fatal(err)
+	}
+	changed := family()
+	changed.StaleReason = "hostile transcript text"
+	err = a.Apply(Record{Type: RecordChanged, ProtocolVersion: 1, RequestID: r.RequestID, Sequence: 2, Vendor: "codex", FamilyID: "root", Fingerprint: "new", Family: &changed})
+	if err == nil {
+		t.Fatal("accepted a non-stale family carrying arbitrary stale reason text")
+	}
+}
+
 func TestAccumulatorEnforcesRequestedVendorLifecycle(t *testing.T) {
 	t.Run("unrequested vendor", func(t *testing.T) {
 		r := request()
 		a, _ := NewAccumulator(r, Generation{BaselineID: "base-1"})
 		_ = a.Apply(handshake(r))
-		record := Record{Type: RecordSkipped, ProtocolVersion: 1, RequestID: r.RequestID, Sequence: 2, Vendor: "claude", FamilyID: "root", Reason: "parse_failed"}
+		record := Record{Type: RecordSkipped, ProtocolVersion: 1, RequestID: r.RequestID, Sequence: 2, Vendor: "claude", FamilyID: "root", Reason: remotefacts.StaleReasonInvalidData}
 		if err := a.Apply(record); err == nil {
 			t.Fatal("accepted record for unrequested vendor")
 		}
@@ -244,7 +277,7 @@ func TestAccumulatorEnforcesRequestedVendorLifecycle(t *testing.T) {
 		a, _ := NewAccumulator(r, Generation{BaselineID: "base-1"})
 		_ = a.Apply(handshake(r))
 		_ = a.Apply(Record{Type: RecordVendorComplete, ProtocolVersion: 1, RequestID: r.RequestID, Sequence: 2, Vendor: "codex", EnumerationComplete: true, InventoryComplete: true, Inventory: []string{}})
-		record := Record{Type: RecordSkipped, ProtocolVersion: 1, RequestID: r.RequestID, Sequence: 3, Vendor: "codex", FamilyID: "root", Reason: "parse_failed"}
+		record := Record{Type: RecordSkipped, ProtocolVersion: 1, RequestID: r.RequestID, Sequence: 3, Vendor: "codex", FamilyID: "root", Reason: remotefacts.StaleReasonInvalidData}
 		if err := a.Apply(record); err == nil {
 			t.Fatal("accepted family action after vendor completion")
 		}

--- a/collector/internal/vendors/claude/source.go
+++ b/collector/internal/vendors/claude/source.go
@@ -70,7 +70,8 @@ type RemoteFamily struct {
 // result by FamilyIDFromPath. allFamilyIDs names every family found by a
 // complete, unfiltered scan of the tree, independent of the requested window
 // or the per-refresh family-count cap, so a caller can use it as
-// deletion-authority inventory even when since narrows what gets selected.
+// deletion-authority inventory when skippedTotal is zero, even when since
+// narrows what gets selected.
 func BuildRemoteFamilies(
 	source vendors.ReadSource,
 	home string,
@@ -80,14 +81,17 @@ func BuildRemoteFamilies(
 	selected map[string]RemoteFamily,
 	allFamilyIDs []string,
 	candidateFiles int,
+	skippedTotal int,
 	truncated bool,
 	err error,
 ) {
 	root := ProjectsRoot(home)
-	allFiles, err := FilesSource(source, root)
+	scan, err := ScanSource(source, root)
 	if err != nil {
-		return nil, nil, 0, false, err
+		return nil, nil, 0, 0, false, err
 	}
+	allFiles := scan.Files
+	skippedTotal = scan.SkippedTotal
 	candidateFiles = len(allFiles)
 	allFamilySet := map[string]struct{}{}
 	for _, file := range allFiles {
@@ -108,7 +112,7 @@ func BuildRemoteFamilies(
 	)
 	fingerprints, err := vendors.FingerprintSourceFiles(source, root, files)
 	if err != nil {
-		return nil, nil, candidateFiles, truncated, err
+		return nil, nil, candidateFiles, skippedTotal, truncated, err
 	}
 	selected = map[string]RemoteFamily{}
 	for index, file := range files {
@@ -118,7 +122,7 @@ func BuildRemoteFamilies(
 		entry.Fingerprints = append(entry.Fingerprints, fingerprints[index])
 		selected[id] = entry
 	}
-	return selected, allFamilyIDs, candidateFiles, truncated, nil
+	return selected, allFamilyIDs, candidateFiles, skippedTotal, truncated, nil
 }
 
 // ParseRemoteFiles parses exactly the given files (already selected as one or

--- a/collector/internal/vendors/codex/family.go
+++ b/collector/internal/vendors/codex/family.go
@@ -83,13 +83,6 @@ func ParseFamilyFilesSource(
 	if err != nil {
 		return nil, err
 	}
-	// Codex currently derives ParsedSession.Name from the first user prompt.
-	// Prompts are outside remote schema v1, so do not let that fallback cross the
-	// helper boundary. Approved session-index metadata remains available.
-	for _, item := range parsed {
-		if item != nil {
-			item.Name = ""
-		}
-	}
+	clearPromptDerivedNames(parsed)
 	return parsed, nil
 }

--- a/collector/internal/vendors/codex/source.go
+++ b/collector/internal/vendors/codex/source.go
@@ -265,7 +265,20 @@ func ParseRemoteFiles(
 	home string,
 	files []string,
 ) ([]*vendors.ParsedSession, []vendors.FileFailure, error) {
-	return parseFilesSourceStrict(source, ArchivedDir(home), files, func(string, string) bool { return true })
+	parsed, failures, err := parseFilesSourceStrict(source, ArchivedDir(home), files, func(string, string) bool { return true })
+	clearPromptDerivedNames(parsed)
+	return parsed, failures, err
+}
+
+// clearPromptDerivedNames prevents the parser's first-user-prompt fallback
+// from crossing either remote collection boundary. Approved session-index
+// metadata names remain available separately.
+func clearPromptDerivedNames(parsed []*vendors.ParsedSession) {
+	for _, item := range parsed {
+		if item != nil {
+			item.Name = ""
+		}
+	}
 }
 
 func GetSessionFamily(id string) ([]*vendors.ParsedSession, *vendors.SessionMetadata, error) {

--- a/collector/internal/vendors/codex/source.go
+++ b/collector/internal/vendors/codex/source.go
@@ -113,7 +113,8 @@ type RemoteFamily struct {
 // parent-less session. allFamilyIDs names every family found by a complete,
 // unfiltered scan of the tree, independent of the requested window or the
 // per-refresh family-count cap, so a caller can use it as deletion-authority
-// inventory even when since narrows what gets selected for parsing. selected
+// inventory when skippedTotal is zero, even when since narrows what gets
+// selected for parsing. selected
 // applies the since/live window and then caps the result to the newest
 // MaxCandidateFilesPerAgent files by whole family. A file whose header could
 // not be resolved becomes its own singleton family, keyed by its filename
@@ -131,18 +132,21 @@ func BuildRemoteFamilies(
 	updatedHeaders map[string]CachedHeader,
 	headerFailed map[string]error,
 	candidateFiles int,
+	skippedTotal int,
 	truncated bool,
 	err error,
 ) {
 	root := SessionsRoot(home)
-	files, err := FilesSource(source, root)
+	scan, err := ScanSource(source, root)
 	if err != nil {
-		return nil, nil, nil, nil, 0, false, err
+		return nil, nil, nil, nil, 0, 0, false, err
 	}
+	files := scan.Files
+	skippedTotal = scan.SkippedTotal
 	candidateFiles = len(files)
 	fingerprints, err := vendors.FingerprintSourceFiles(source, root, files)
 	if err != nil {
-		return nil, nil, nil, nil, candidateFiles, false, err
+		return nil, nil, nil, nil, candidateFiles, skippedTotal, false, err
 	}
 	headers, updatedHeaders, headerFailed := ResolveHeaders(source, files, fingerprints, cachedHeaders)
 
@@ -217,7 +221,7 @@ func BuildRemoteFamilies(
 		windowed[familyOf[file]] = append(windowed[familyOf[file]], file)
 	}
 	if len(windowed) == 0 {
-		return map[string]RemoteFamily{}, allFamilyIDs, updatedHeaders, headerFailed, candidateFiles, false, nil
+		return map[string]RemoteFamily{}, allFamilyIDs, updatedHeaders, headerFailed, candidateFiles, skippedTotal, false, nil
 	}
 	newest := map[string]int64{}
 	for id, familyFiles := range windowed {
@@ -244,7 +248,7 @@ func BuildRemoteFamilies(
 		selected[id] = entry
 		total += len(familyFiles)
 	}
-	return selected, allFamilyIDs, updatedHeaders, headerFailed, candidateFiles, len(selected) < len(windowed), nil
+	return selected, allFamilyIDs, updatedHeaders, headerFailed, candidateFiles, skippedTotal, len(selected) < len(windowed), nil
 }
 
 func sortFamiliesByNewest(ids []string, newest map[string]int64) {

--- a/collector/scripts/smoke.sh
+++ b/collector/scripts/smoke.sh
@@ -140,6 +140,23 @@ if [[ "$mode" == "embedded" ]]; then
     exit 1
   fi
 
+  # Exercise the provider compiled into the packaged executable, not only the
+  # tagged unit test. The alias need not resolve: availability is determined
+  # entirely by the authenticated embedded release and both helper assets.
+  settings='{"$schema":"https://raw.githubusercontent.com/centauri-ai/coslash/main/settings.schema.json","version":1,"synthesis":{"enabled":false,"backend":"claude-cli","model":"claude-haiku-4-5"},"appearance":{"theme":"light"},"launch":{"terminal":"terminal"},"remote":{"id":"r_0123456789abcdef","sshAlias":"coslash-smoke-invalid","enabled":true}}'
+  actual=$(
+    printf 'header = "X-Coslash-Token: %s"\n' "$token" |
+      curl --config - -sS -o "$response_body" -w '%{http_code}' \
+        -X PUT -H 'Content-Type: application/json' --data "$settings" "$base_url/api/settings"
+  )
+  if [[ "$actual" != 200 ]]; then
+    echo "error: could not configure isolated helper smoke host (HTTP $actual)" >&2
+    cat "$response_body" >&2
+    exit 1
+  fi
+  expect_status /api/remote/status 200
+  assert_contains '"helperInstallationAvailable":true' 'the embedded helper provider'
+
   version=$("$binary" --version)
   echo "version -> $version"
   if [[ -z "$version" || "$version" == "dev" ]]; then

--- a/docs/data-and-privacy.md
+++ b/docs/data-and-privacy.md
@@ -23,12 +23,24 @@ coSlash reads, but does not modify:
 
 coSlash creates the storage directory with mode `0700` and persistent files with mode `0600`. Programs running as your macOS user can still read them.
 
-## Optional SSH/SFTP access
+## Optional SSH/SFTP access and helper installation
 
 When one remote machine is enabled, the Mac's system `ssh` client uses the saved
-OpenSSH alias and requests SFTP. Linux runs no coSlash code and receives no
-coSlash package, cache, handoff, or parser. coSlash may read these paths beneath
-the SSH user's home:
+OpenSSH alias and requests SFTP. SFTP collection runs no coSlash code on Linux.
+After a connection test, the user may explicitly consent to install the optional
+collector helper. Preview releases authenticate the embedded helper through the
+containing coSlash archive checksum, then verify its exact digest and platform
+before uploading a versioned executable to
+`~/.coslash/helpers/<version>/coslash-helper`, owned by the SSH user with mode
+`0700`. The helper has no root access or network access, reads only the same
+fixed allowlist below, and streams bounded normalized facts back to the Mac.
+No path, command, prompt, transcript row, cache, or handoff supplied by the Mac
+can choose files the helper opens.
+
+Builds without authenticated embedded helper assets disable the install action
+explicitly. They continue using SFTP and never upload an unverified helper.
+
+Both collection paths may read these paths beneath the SSH user's home:
 
 - `.claude/projects`, `.claude/sessions`, and `.claude/jobs`;
 - `.codex/sessions`, `.codex/archived_sessions`, and
@@ -97,7 +109,12 @@ coSlash listens on IPv4 loopback and protects API requests with a new access tok
 Synthesis is off until you enable and save it in Settings. Disable it there to stop new requests, then delete `~/.coslash/summaries` to remove cached results.
 
 Disabling a remote machine stops refreshes and hides its cards but retains its
-normalized last-good cache. Confirming **Remove host** deletes only that source's
-`~/.coslash/remotes/<source-id>` directory. It does not change files on Linux.
+normalized last-good cache and any optional helper; it does not change Linux.
+**Remove host only** deletes the source's `~/.coslash/remotes/<source-id>`
+directory and deliberately leaves a previously installed helper in place.
+**Uninstall helper and remove** first removes only the exact verified helper
+version, then deletes local host settings and cache. If the remote uninstall
+fails, coSlash keeps the local host configuration so you can retry or explicitly
+choose remove-only; it never silently forgets helper ownership.
 
 To remove all coSlash data, quit coSlash and delete `~/.coslash` (or your `COSLASH_HOME`). `coslash doctor --json` and **Copy diagnostics** exclude transcript contents, prompts, and session names.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,15 +11,31 @@ uses the Mac's existing OpenSSH configuration, so first run `ssh <alias>` in
 Terminal if the host key or authentication still needs confirmation. The Linux
 SSH server must enable an SFTP subsystem and the SSH user must be able to read
 the Claude/Codex paths listed in [Data and privacy](data-and-privacy.md). No
-coSlash installation or agent CLI is required on Linux. The test performs a
-bounded inspection of both agent roots, so a successful result also confirms
-that supported data is readable.
+coSlash installation or agent CLI is required on Linux for SFTP collection. The
+test verifies that SSH authentication and the SFTP subsystem can open and close
+successfully. Readability of the allowed Claude/Codex roots is checked during
+the subsequent collection refresh.
+
+The optional **Install helper** action needs explicit consent and installs the
+digest-verified collector embedded in the coSlash release, owned by the SSH
+user under `~/.coslash/helpers`. If it is unavailable, blocked
+by a `noexec` mount, unsupported, incompatible, revoked, or fails verification,
+coSlash does not execute it and continues with visibly labeled SFTP collection.
+Use **Upgrade helper** or **Install helper** only after reviewing the consent
+copy. Never paste remote stderr into a bug report; **Copy diagnostics** includes
+only bounded structured transport, version, timing, byte-count, and coverage
+facts.
 
 `SFTP subsystem unavailable` means ordinary SSH may work while SFTP is disabled
 by `sshd_config` or account policy. `Agent data is not readable` means the SSH
 account connected but lacks file permissions. `No Claude or Codex data found`
 means the allowed roots are absent or empty. A stale banner keeps the last-good
 cards visible; **Retry** starts an immediate bounded refresh.
+
+To remove a remote host, choose **Remove host only** to leave the optional
+helper installed, or **Uninstall helper and remove**. The latter completes its
+exact remote uninstall before coSlash removes local settings. If it fails, use
+Retry or choose remove-only explicitly.
 
 ## coSlash will not start
 

--- a/frontend/src/pages/coslash/CoslashPage.tsx
+++ b/frontend/src/pages/coslash/CoslashPage.tsx
@@ -423,8 +423,8 @@ export function CoslashPage() {
       });
   };
 
-  const saveSettings = async (settings: Parameters<typeof settingsState.save>[0]) => {
-    const ok = await settingsState.save(settings);
+  const saveSettings = async (...args: Parameters<typeof settingsState.save>) => {
+    const ok = await settingsState.save(...args);
     if (ok) retrySessions();
     return ok;
   };

--- a/frontend/src/pages/coslash/components/MachinesSettingsSection.tsx
+++ b/frontend/src/pages/coslash/components/MachinesSettingsSection.tsx
@@ -105,10 +105,17 @@ export function MachinesSettingsSection({
   };
 
   const setupHelper = async (consent: 'install' | 'upgrade') => {
+    const alias = draft.sshAlias.trim();
+    if (!alias) {
+      setTestError('Enter an SSH alias first');
+      return;
+    }
     setHelperAction(consent);
     setTestError(null);
     try {
-      const result = await setupRemoteHelper(consent);
+      // The backend binds this request to the persisted alias. It rejects a
+      // tested-but-unsaved draft rather than installing on the saved host.
+      const result = await setupRemoteHelper(alias, consent);
       setSetupResult(result);
       setTestResult(result.machine);
       setHostStatus(result.machine);

--- a/frontend/src/pages/coslash/components/MachinesSettingsSection.tsx
+++ b/frontend/src/pages/coslash/components/MachinesSettingsSection.tsx
@@ -1,34 +1,81 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { firstTimeSshHint, formatTestConnectionResult } from '@/pages/coslash/lib/host-strip';
 import type { MachineFact } from '@/pages/coslash/lib/machines';
-import { testRemoteAlias } from '@/pages/coslash/lib/remote-api';
-import type { RemoteHostSettings } from '@/pages/coslash/lib/settings';
+import {
+  remoteStatus,
+  setupRemoteHelper,
+  testRemoteAlias,
+  type HelperSetupResult,
+} from '@/pages/coslash/lib/remote-api';
+import type { RemoteHostSettings, RemoteOwnershipAction } from '@/pages/coslash/lib/settings';
 
 export function MachinesSettingsSection({
   remote,
   onChange,
+  onOwnershipActionChange,
 }: {
   remote: RemoteHostSettings | null | undefined;
   onChange: (remote: RemoteHostSettings | null) => void;
+  onOwnershipActionChange: (action: RemoteOwnershipAction | null) => void;
 }) {
   const draft = remote ?? { sshAlias: '', enabled: true };
   const hasHost = remote != null;
   const [testResult, setTestResult] = useState<MachineFact | null>(null);
+  const [hostStatus, setHostStatus] = useState<MachineFact | null>(null);
+  const [setupResult, setSetupResult] = useState<HelperSetupResult | null>(null);
   const [testError, setTestError] = useState<string | null>(null);
   const [testing, setTesting] = useState(false);
-  const [confirmRemove, setConfirmRemove] = useState(false);
+  const [helperAction, setHelperAction] = useState<'install' | 'upgrade' | null>(null);
+  const [removeAction, setRemoveAction] = useState<'only' | 'uninstall' | null>(null);
+  const [pendingAlias, setPendingAlias] = useState<string | null>(null);
+  const displayedAlias = pendingAlias ?? draft.sshAlias;
+  const helperOwned = hostStatus?.helperOwnershipRecorded === true;
+  const helperOwnershipCorrupt = hostStatus?.helperOwnershipCorrupt === true;
+  const setupFailed = setupResult?.error != null;
+
+  useEffect(() => {
+    if (!remote?.id) {
+      setHostStatus(null);
+      return;
+    }
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const load = async () => {
+      try {
+        const status = await remoteStatus();
+        if (cancelled) return;
+        setHostStatus(status);
+        if (status.helperProbeState === 'probing') timer = setTimeout(() => void load(), 400);
+      } catch {
+        if (!cancelled) setHostStatus(null);
+      }
+    };
+    void load();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [remote?.id]);
 
   const setAlias = (sshAlias: string) => {
     setTestResult(null);
+    setSetupResult(null);
     setTestError(null);
-    setConfirmRemove(false);
+    setRemoveAction(null);
+    onOwnershipActionChange(null);
+    if (hasHost && helperOwned && sshAlias !== draft.sshAlias) {
+      setPendingAlias(sshAlias);
+      return;
+    }
+    setPendingAlias(null);
     onChange({ ...draft, sshAlias });
   };
 
   const setEnabled = (enabled: boolean) => {
-    setConfirmRemove(false);
+    setRemoveAction(null);
+    onOwnershipActionChange(null);
     onChange({ ...draft, enabled });
   };
 
@@ -41,8 +88,15 @@ export function MachinesSettingsSection({
     setTesting(true);
     setTestError(null);
     setTestResult(null);
+    setSetupResult(null);
     try {
       setTestResult(await testRemoteAlias(alias));
+      try {
+        setHostStatus(await remoteStatus());
+      } catch {
+        // SFTP test success remains useful if the optional helper inspection
+        // endpoint is temporarily unavailable.
+      }
     } catch (error: unknown) {
       setTestError(error instanceof Error ? error.message : String(error));
     } finally {
@@ -50,15 +104,45 @@ export function MachinesSettingsSection({
     }
   };
 
-  const removeHost = () => {
-    if (!confirmRemove) {
-      setConfirmRemove(true);
+  const setupHelper = async (consent: 'install' | 'upgrade') => {
+    setHelperAction(consent);
+    setTestError(null);
+    try {
+      const result = await setupRemoteHelper(consent);
+      setSetupResult(result);
+      setTestResult(result.machine);
+      setHostStatus(result.machine);
+    } catch (error: unknown) {
+      setTestError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setHelperAction(null);
+    }
+  };
+
+  const removeHost = async (action: 'only' | 'uninstall') => {
+    if (removeAction !== action) {
+      setRemoveAction(action);
       return;
     }
-    setConfirmRemove(false);
+    // Do not mutate helper ownership from an unsaved dialog draft. The action
+    // travels with the next Settings save and is committed by the backend only
+    // for that exact settings replacement.
+    onOwnershipActionChange(action === 'uninstall' ? 'uninstall' : 'release');
+    setRemoveAction(null);
     setTestResult(null);
     setTestError(null);
     onChange(null);
+  };
+
+  const resolveAliasChange = (action: 'uninstall' | 'leave' | 'cancel') => {
+    if (pendingAlias == null) return;
+    if (action === 'cancel') {
+      setPendingAlias(null);
+      return;
+    }
+    onOwnershipActionChange(action === 'uninstall' ? 'uninstall' : 'release');
+    onChange({ ...draft, sshAlias: pendingAlias });
+    setPendingAlias(null);
   };
 
   const showFirstTimeHint = testResult?.state === 'error' && testResult.reason === 'connection_failed';
@@ -75,8 +159,8 @@ export function MachinesSettingsSection({
         <div className="flex flex-col gap-1 p-4">
           <div className="text-sm font-semibold">Remote host</div>
           <div className="text-muted-foreground text-xs text-pretty">
-            Monitor Claude Code and Codex through your existing SSH config. Linux only needs SSH/SFTP and
-            readable agent files; do not install coSlash there.
+            Monitor Claude Code and Codex through your existing SSH config. SFTP works without Linux code; you
+            can explicitly install the optional, verified collection helper for faster refreshes.
           </div>
         </div>
 
@@ -87,12 +171,47 @@ export function MachinesSettingsSection({
           <input
             id="remote-ssh-alias"
             aria-label="SSH alias"
-            value={draft.sshAlias}
+            value={displayedAlias}
             onChange={(event) => setAlias(event.target.value)}
             placeholder="gpu-server"
             className="border-border bg-background text-foreground focus-visible:border-ring focus-visible:ring-ring h-8 w-full rounded-lg border px-2.5 font-mono text-xs outline-none focus-visible:ring-3 sm:max-w-72"
           />
         </div>
+
+        {pendingAlias != null && (
+          <div className="border-warning-fg/30 bg-warning-bg text-warning-fg flex flex-col gap-2 border-t p-4 text-xs">
+            A helper is owned by {draft.sshAlias}. Choose how to change this host before saving the new alias.
+            <div className="flex flex-wrap gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={testing || helperOwnershipCorrupt}
+                onClick={() => void resolveAliasChange('uninstall')}
+              >
+                Uninstall helper and change host
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={testing}
+                onClick={() => void resolveAliasChange('leave')}
+              >
+                Leave helper installed and change host
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                disabled={testing}
+                onClick={() => void resolveAliasChange('cancel')}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        )}
 
         <div className="border-border flex items-center justify-between gap-4 border-t p-4">
           <div className="flex min-w-0 flex-col gap-1">
@@ -100,7 +219,7 @@ export function MachinesSettingsSection({
             <div className="text-muted-foreground text-[11px]">
               {draft.enabled
                 ? 'Monitor this host on the board'
-                : 'Disabled — no remote cards or strip; cache retained'}
+                : 'Disabled — no remote cards or strip; cache and any installed helper are retained'}
             </div>
           </div>
           <button
@@ -136,23 +255,97 @@ export function MachinesSettingsSection({
               {testing ? 'Testing…' : 'Test connection'}
             </Button>
             {hasHost && (
-              <Button type="button" variant="outline" size="sm" onClick={removeHost}>
-                {confirmRemove ? 'Confirm remove' : 'Remove host'}
-              </Button>
+              <>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={
+                    testing ||
+                    helperAction != null ||
+                    testResult?.state !== 'ok' ||
+                    hostStatus?.helperInstallationAvailable !== true ||
+                    hostStatus?.helperProbeState === 'probing'
+                  }
+                  onClick={() =>
+                    void setupHelper(hostStatus?.helper?.state === 'deprecated' ? 'upgrade' : 'install')
+                  }
+                >
+                  {helperAction != null
+                    ? 'Setting up helper…'
+                    : hostStatus?.helper?.state === 'deprecated'
+                      ? 'Upgrade helper'
+                      : 'Install helper'}
+                </Button>
+                <Button type="button" variant="outline" size="sm" onClick={() => void removeHost('only')}>
+                  {removeAction === 'only' ? 'Confirm remove only' : 'Remove host only'}
+                </Button>
+                <Button
+                  type="button"
+                  variant="destructive"
+                  size="sm"
+                  disabled={testing || helperAction != null || helperOwnershipCorrupt}
+                  onClick={() => void removeHost('uninstall')}
+                >
+                  {removeAction === 'uninstall'
+                    ? 'Confirm uninstall and remove'
+                    : 'Uninstall helper and remove'}
+                </Button>
+              </>
             )}
           </div>
         </div>
 
+        {hasHost && (
+          <div className="border-border text-muted-foreground flex flex-col gap-1 border-t p-4 text-xs">
+            <div>
+              Active transport: {hostStatus?.transport === 'helper' ? 'Verified helper' : 'SFTP fallback'}
+            </div>
+            <div>
+              Helper:{' '}
+              {hostStatus?.helperProbeState === 'probing'
+                ? 'Checking installed helper…'
+                : (hostStatus?.helper?.state ?? 'Not checked')}
+              {hostStatus?.helper?.version ? ` · ${hostStatus.helper.version}` : ''}
+              {hostStatus?.helper?.reason ? ` · ${hostStatus.helper.reason.replaceAll('_', ' ')}` : ''}
+            </div>
+            {helperOwned && <div>Helper ownership is recorded for this SSH alias.</div>}
+            {helperOwnershipCorrupt && (
+              <div>
+                Helper ownership is corrupt. You can only leave the helper installed while removing or
+                changing this host.
+              </div>
+            )}
+            {hostStatus?.helperInstallationAvailable === false && (
+              <div>Helper installation is unavailable in this build.</div>
+            )}
+            {testResult?.state !== 'ok' && hostStatus?.helperInstallationAvailable !== false && (
+              <div>Test SSH/SFTP before installing or upgrading the helper.</div>
+            )}
+          </div>
+        )}
+
         {(testResult != null || testError != null) && (
           <div
-            role={testResult?.state === 'ok' ? 'status' : 'alert'}
+            role={testResult?.state === 'ok' && !setupFailed ? 'status' : 'alert'}
             className={cn('border-t px-4 py-3 text-xs', {
-              'bg-success-bg text-success-fg': testResult?.state === 'ok',
-              'bg-warning-bg text-warning-fg': testResult != null && testResult.state !== 'ok',
+              'bg-success-bg text-success-fg': testResult?.state === 'ok' && !setupFailed,
+              'bg-warning-bg text-warning-fg':
+                (testResult != null && testResult.state !== 'ok') || setupFailed,
               'bg-destructive/10 text-destructive': testError != null,
             })}
           >
-            {testError ?? (testResult ? formatTestConnectionResult(testResult) : null)}
+            {testError ?? setupResult?.error ?? (testResult ? formatTestConnectionResult(testResult) : null)}
+            {testResult?.helper && (
+              <div className="pt-1">
+                Helper: {testResult.helper.version ? `${testResult.helper.version} · ` : ''}
+                {testResult.helper.state.replaceAll('_', ' ')} ·{' '}
+                {testResult.helper.compatible ? 'compatible' : 'unavailable'}
+                {testResult.helper.reused ? ' · reused after verification' : ''}
+                {testResult.helper.reason ? ` · ${testResult.helper.reason.replaceAll('_', ' ')}` : ''}
+                {testResult.helper.fallback ? ' · using SFTP fallback' : ''}
+              </div>
+            )}
             {showFirstTimeHint && <div className="pt-1">{firstTimeSshHint(draft.sshAlias.trim())}</div>}
           </div>
         )}

--- a/frontend/src/pages/coslash/components/SettingsDialog.tsx
+++ b/frontend/src/pages/coslash/components/SettingsDialog.tsx
@@ -12,6 +12,7 @@ import {
   requiresFirstRunConsent,
   type BackendOption,
   type CoslashSettings,
+  type RemoteOwnershipAction,
   type SettingsResponse,
 } from '@/pages/coslash/lib/settings';
 
@@ -192,12 +193,13 @@ export function SettingsDialog({
   loadError: string | null;
   saveError: string | null;
   isSaving: boolean;
-  onSave: (settings: CoslashSettings) => Promise<boolean>;
+  onSave: (settings: CoslashSettings, remoteOwnershipAction?: RemoteOwnershipAction) => Promise<boolean>;
 }) {
   const [draft, setDraft] = useState<CoslashSettings | null>(
     response ? initialSettingsDraft(response) : null,
   );
   const [disclosureOpen, setDisclosureOpen] = useState(false);
+  const [remoteOwnershipAction, setRemoteOwnershipAction] = useState<RemoteOwnershipAction | null>(null);
   const isFirstRun = requiresFirstRunConsent(response);
   const requiresConsent = mode === 'synthesis-consent' && isFirstRun;
   const showFullSettings = mode === 'full-settings';
@@ -206,6 +208,7 @@ export function SettingsDialog({
     if (!open || !response) return;
     setDraft(initialSettingsDraft(response));
     setDisclosureOpen(false);
+    setRemoteOwnershipAction(null);
   }, [open, response]);
 
   const initialDraft = response ? initialSettingsDraft(response) : null;
@@ -221,7 +224,7 @@ export function SettingsDialog({
 
   const save = async () => {
     if (!draft || !synthesisBackendAvailable) return;
-    if (await onSave(draft)) {
+    if (await onSave(draft, remoteOwnershipAction ?? undefined)) {
       setTheme(draft.appearance.theme);
       onOpenChange(false);
     }
@@ -489,6 +492,7 @@ export function SettingsDialog({
                     }
                     setDraft({ ...draft, remote: { ...remote, sshAlias: remote.sshAlias.trim() } });
                   }}
+                  onOwnershipActionChange={setRemoteOwnershipAction}
                 />
               )}
 

--- a/frontend/src/pages/coslash/hooks/use-sessions.test.ts
+++ b/frontend/src/pages/coslash/hooks/use-sessions.test.ts
@@ -73,6 +73,31 @@ describe('decodeSessionsResponse', () => {
     expect(decodeSessionsResponse({ sessions, machines })).toEqual({ sessions, machines });
   });
 
+  it('normalizes null remote collections so sparse facts cannot crash the board', () => {
+    const sparse = {
+      ...sampleSession('remote', 'r_0123456789abcdef'),
+      tokens: null,
+      unpricedModels: null,
+      subagents: null,
+      commands: null,
+      commits: null,
+      todos: null,
+      digest: null,
+      fileEdits: null,
+    };
+    const decoded = decodeSessionsResponse({ sessions: [sparse], machines: [] }).sessions[0];
+    expect(decoded).toMatchObject({
+      tokens: {},
+      unpricedModels: [],
+      subagents: [],
+      commands: [],
+      commits: [],
+      todos: [],
+      digest: [],
+      fileEdits: [],
+    });
+  });
+
   it('treats a null or missing sessions list as empty', () => {
     const machines = [{ sourceId: 'local', label: 'This Mac', state: 'ok', complete: true }];
     expect(decodeSessionsResponse({ sessions: null, machines })).toEqual({ sessions: [], machines });

--- a/frontend/src/pages/coslash/hooks/use-sessions.ts
+++ b/frontend/src/pages/coslash/hooks/use-sessions.ts
@@ -41,7 +41,7 @@ export type SessionsQuery = {
 export function decodeSessionsResponse(body: unknown): SessionsPayload {
   if (Array.isArray(body)) {
     return {
-      sessions: body.map((session) => withLocalSourceDefaults(session as Session)),
+      sessions: body.map(decodeSession),
       machines: [],
     };
   }
@@ -59,8 +59,42 @@ export function decodeSessionsResponse(body: unknown): SessionsPayload {
     throw new Error('Invalid sessions response');
   }
   return {
-    sessions: sessions.map((session) => withLocalSourceDefaults(session as Session)),
+    sessions: sessions.map(decodeSession),
     machines: machinesFromBody(body),
+  };
+}
+
+function arrayOrEmpty<T>(value: T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+// Older caches and sparse remote facts can contain null collection fields.
+// Normalize at the API boundary so one incomplete session cannot crash the
+// whole board while the backend is being upgraded or refreshed.
+function decodeSession(value: unknown): Session {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Invalid session response');
+  }
+  const raw = value as Session;
+  const synthesis =
+    raw.synthesis == null
+      ? null
+      : {
+          ...raw.synthesis,
+          goals: arrayOrEmpty(raw.synthesis.goals),
+          keyDecisions: arrayOrEmpty(raw.synthesis.keyDecisions),
+        };
+  return {
+    ...withLocalSourceDefaults(raw),
+    tokens: raw.tokens != null && typeof raw.tokens === 'object' ? raw.tokens : {},
+    unpricedModels: arrayOrEmpty(raw.unpricedModels),
+    subagents: arrayOrEmpty(raw.subagents),
+    commands: arrayOrEmpty(raw.commands),
+    commits: arrayOrEmpty(raw.commits),
+    todos: arrayOrEmpty(raw.todos),
+    digest: arrayOrEmpty(raw.digest),
+    fileEdits: arrayOrEmpty(raw.fileEdits),
+    synthesis,
   };
 }
 

--- a/frontend/src/pages/coslash/hooks/use-settings.ts
+++ b/frontend/src/pages/coslash/hooks/use-settings.ts
@@ -4,6 +4,7 @@ import {
   decodeSettingsResponse,
   settingsForSave,
   type CoslashSettings,
+  type RemoteOwnershipAction,
   type SettingsResponse,
 } from '@/pages/coslash/lib/settings';
 
@@ -39,14 +40,17 @@ export function useSettings() {
     return () => controller.abort();
   }, []);
 
-  const save = async (settings: CoslashSettings): Promise<boolean> => {
+  const save = async (
+    settings: CoslashSettings,
+    remoteOwnershipAction?: RemoteOwnershipAction,
+  ): Promise<boolean> => {
     setIsSaving(true);
     setSaveError(null);
     try {
       const result = await apiFetch('/api/settings', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(settingsForSave(settings)),
+        body: JSON.stringify({ settings: settingsForSave(settings), remoteOwnershipAction }),
       });
       if (!result.ok) throw new Error(await readError(result));
       setResponse(decodeSettingsResponse(await result.json()));

--- a/frontend/src/pages/coslash/lib/diagnostics.ts
+++ b/frontend/src/pages/coslash/lib/diagnostics.ts
@@ -33,7 +33,15 @@ export type RemoteDiagnostics = {
   roundTripMs?: number;
   nextRetryAtMs?: number;
   error?: string;
-  diagnosticStderr?: string;
+  transport?: string;
+  helperState?: string;
+  helperVersion?: string;
+  helperCompatible?: boolean;
+  helperFallback?: boolean;
+  helperReason?: string;
+  requestBytes?: number;
+  responseBytes?: number;
+  records?: number;
 };
 
 export type Diagnostics = {

--- a/frontend/src/pages/coslash/lib/handoff.test.ts
+++ b/frontend/src/pages/coslash/lib/handoff.test.ts
@@ -159,8 +159,12 @@ describe('settings and remote API decoders', () => {
   });
 
   it('sends one explicit install or upgrade consent', () => {
-    expect(helperSetupRequestInit('install').body).toBe(JSON.stringify({ install: true, upgrade: false }));
-    expect(helperSetupRequestInit('upgrade').body).toBe(JSON.stringify({ install: false, upgrade: true }));
+    expect(helperSetupRequestInit('gpu-server', 'install').body).toBe(
+      JSON.stringify({ sshAlias: 'gpu-server', install: true, upgrade: false }),
+    );
+    expect(helperSetupRequestInit('gpu-server', 'upgrade').body).toBe(
+      JSON.stringify({ sshAlias: 'gpu-server', install: false, upgrade: true }),
+    );
   });
 
   it('exhaustively decodes setup outcomes and recorded helper ownership', () => {

--- a/frontend/src/pages/coslash/lib/handoff.test.ts
+++ b/frontend/src/pages/coslash/lib/handoff.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it } from 'vitest';
 import { launchRequestPath } from '@/pages/coslash/hooks/use-launch-terminal';
 import { decodeApiError } from '@/pages/coslash/lib/api';
 import { handoffBrief } from '@/pages/coslash/lib/handoff';
-import { remoteTestRequestInit } from '@/pages/coslash/lib/remote-api';
+import { decodeMachineFact, HELPER_STATES, MACHINE_REASONS } from '@/pages/coslash/lib/machines';
+import {
+  decodeHelperSetup,
+  HELPER_SETUP_OUTCOMES,
+  helperSetupRequestInit,
+  remoteTestRequestInit,
+} from '@/pages/coslash/lib/remote-api';
 import { LOCAL_SOURCE_ID, type SessionDetail } from '@/pages/coslash/lib/session';
 import { decodeRemoteHostSettings, decodeSettingsResponse } from '@/pages/coslash/lib/settings';
 
@@ -108,5 +114,76 @@ describe('settings and remote API decoders', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ sshAlias: 'gpu-server' }),
     });
+  });
+
+  it('decodes helper transport, lifecycle, and safe metrics', () => {
+    expect(
+      decodeMachineFact({
+        sourceId: 'r_0123456789abcdef',
+        label: 'gpu-server',
+        state: 'limited',
+        complete: false,
+        reason: 'output_limit',
+        transport: 'helper',
+        helper: {
+          state: 'deprecated',
+          version: 'v1',
+          compatible: true,
+          fallback: false,
+          reason: 'helper_upgrade_required',
+        },
+        metrics: { requestBytes: 120, responseBytes: 456, records: 3, roundTripMs: 40 },
+      }),
+    ).toMatchObject({
+      transport: 'helper',
+      helper: { state: 'deprecated', version: 'v1', compatible: true },
+      metrics: { responseBytes: 456, records: 3 },
+    });
+  });
+
+  it('exhaustively decodes helper lifecycle states and reasons', () => {
+    for (const state of HELPER_STATES) {
+      for (const reason of MACHINE_REASONS) {
+        expect(
+          decodeMachineFact({
+            sourceId: 'r_0123456789abcdef',
+            label: 'gpu-server',
+            state: 'limited',
+            complete: false,
+            transport: 'sftp',
+            helper: { state, compatible: false, fallback: true, reason },
+          }).helper,
+        ).toMatchObject({ state, reason });
+      }
+    }
+  });
+
+  it('sends one explicit install or upgrade consent', () => {
+    expect(helperSetupRequestInit('install').body).toBe(JSON.stringify({ install: true, upgrade: false }));
+    expect(helperSetupRequestInit('upgrade').body).toBe(JSON.stringify({ install: false, upgrade: true }));
+  });
+
+  it('exhaustively decodes setup outcomes and recorded helper ownership', () => {
+    for (const outcome of HELPER_SETUP_OUTCOMES) {
+      expect(
+        decodeHelperSetup({
+          outcome,
+          machine: {
+            sourceId: 'r_0123456789abcdef',
+            label: 'gpu-server',
+            state: 'limited',
+            complete: false,
+            helperOwnershipRecorded: true,
+            helper: { state: 'sftp', compatible: false, fallback: true, reason: 'helper_missing' },
+          },
+        }),
+      ).toMatchObject({ outcome, machine: { helperOwnershipRecorded: true } });
+    }
+    expect(() =>
+      decodeHelperSetup({
+        outcome: 'green',
+        machine: { sourceId: 'r_0123456789abcdef', label: 'gpu-server', state: 'limited', complete: false },
+      }),
+    ).toThrow('Expected one of');
   });
 });

--- a/frontend/src/pages/coslash/lib/host-strip.test.ts
+++ b/frontend/src/pages/coslash/lib/host-strip.test.ts
@@ -30,9 +30,9 @@ describe('Mac-only remote health copy', () => {
     ['error', 'permission_denied'],
     ['limited', 'no_supported_data'],
     ['error', 'invalid_remote_data'],
-  ] as const)('renders %s / %s without Linux installation guidance', (state, reason) => {
+  ] as const)('renders %s / %s without helper-only guidance', (state, reason) => {
     const model = hostStripModel(machine(state, reason), { nowMs: 10_000 });
-    expect(model.message).not.toMatch(/collector|install|upgrade/i);
+    expect(model.message).not.toMatch(/collector|helper/i);
     expect(model.actions).not.toContain('installation');
   });
 
@@ -42,8 +42,8 @@ describe('Mac-only remote health copy', () => {
     expect(hostStripVisible(machine('limited', 'partial_agent_data'))).toBe(true);
   });
 
-  it('describes SFTP-only setup and first-use SSH guidance', () => {
-    expect(formatTestConnectionResult(machine('ok'))).toContain('no Linux coSlash installation needed');
+  it('describes optional-helper setup and first-use SSH guidance', () => {
+    expect(formatTestConnectionResult(machine('ok'))).toContain('optional helper');
     expect(firstTimeSshHint('gpu-server')).toContain('ssh gpu-server');
   });
 });

--- a/frontend/src/pages/coslash/lib/host-strip.ts
+++ b/frontend/src/pages/coslash/lib/host-strip.ts
@@ -52,6 +52,28 @@ function reasonMessage(reason: MachineReason | undefined): string {
       return 'agent data could not be parsed';
     case 'local_cache_failed':
       return 'the Mac cache could not be updated';
+    case 'helper_missing':
+      return 'the optional helper is not installed; using SFTP';
+    case 'helper_not_executable':
+      return 'the helper cannot run; using SFTP';
+    case 'helper_incompatible':
+    case 'helper_upgrade_required':
+      return 'the helper needs an approved upgrade; using SFTP';
+    case 'helper_consent_required':
+      return 'the optional helper needs your consent; using SFTP';
+    case 'helper_platform_unsupported':
+      return 'this platform uses SFTP only';
+    case 'helper_verification_failed':
+    case 'helper_revoked':
+      return 'the helper was not trusted and will not run';
+    case 'helper_installation_failed':
+      return 'the helper could not be installed; using SFTP';
+    case 'helper_rolled_back':
+      return 'the helper update was rolled back';
+    case 'output_limit':
+      return 'helper output reached a safety limit';
+    case 'helper_failed':
+      return 'the helper collection failed';
     default:
       return 'the SFTP refresh failed';
   }
@@ -62,7 +84,7 @@ function stripMessage(machine: MachineFact, nowMs: number): string {
     case 'connecting':
       return machine.reason === 'broader_history'
         ? `${machine.label} · refreshing older history · showing the previous view`
-        : `${machine.label} · connecting over SFTP…`;
+        : `${machine.label} · connecting over ${machine.transport === 'helper' ? 'the helper' : 'SFTP'}…`;
     case 'limited':
       return `${machine.label} · ${reasonMessage(machine.reason)}`;
     case 'stale':
@@ -93,7 +115,8 @@ export function hostStripModel(
 }
 
 export function formatTestConnectionResult(machine: MachineFact): string {
-  if (machine.state === 'ok') return 'Connected · SFTP is ready · no Linux coSlash installation needed';
+  if (machine.state === 'ok')
+    return 'Connected · SFTP is ready · optional helper available with your consent';
   return `${machine.label} · ${machine.error || reasonMessage(machine.reason)}`;
 }
 

--- a/frontend/src/pages/coslash/lib/machines.ts
+++ b/frontend/src/pages/coslash/lib/machines.ts
@@ -2,6 +2,18 @@ import { assertOneOf } from '@/pages/coslash/lib/narrow';
 
 export const MACHINE_STATES = ['ok', 'connecting', 'limited', 'stale', 'error', 'disabled'] as const;
 export type MachineState = (typeof MACHINE_STATES)[number];
+export const MACHINE_TRANSPORTS = ['sftp', 'helper'] as const;
+export type MachineTransport = (typeof MACHINE_TRANSPORTS)[number];
+export const HELPER_STATES = [
+  'sftp',
+  'ready',
+  'deprecated',
+  'upgrade_required',
+  'unsupported',
+  'revoked',
+  'verification_failed',
+] as const;
+export type HelperState = (typeof HELPER_STATES)[number];
 
 export const MACHINE_REASONS = [
   'initial_refresh',
@@ -17,6 +29,18 @@ export const MACHINE_REASONS = [
   'partial_agent_data',
   'invalid_remote_data',
   'local_cache_failed',
+  'helper_missing',
+  'helper_not_executable',
+  'helper_incompatible',
+  'helper_failed',
+  'output_limit',
+  'helper_platform_unsupported',
+  'helper_verification_failed',
+  'helper_installation_failed',
+  'helper_revoked',
+  'helper_upgrade_required',
+  'helper_rolled_back',
+  'helper_consent_required',
   'disabled',
 ] as const;
 export type MachineReason = (typeof MACHINE_REASONS)[number];
@@ -40,6 +64,29 @@ export type MachineFact = {
   roundTripMs?: number;
   coverage?: AgentCoverage[];
   error?: string;
+  transport?: MachineTransport;
+  helper?: HelperFact;
+  metrics?: CollectionMetrics;
+  helperInstallationAvailable?: boolean;
+  helperProbeState?: 'unknown' | 'probing' | 'ready' | 'fallback';
+  helperOwnershipRecorded?: boolean;
+  helperOwnershipCorrupt?: boolean;
+};
+
+export type HelperFact = {
+  state: HelperState;
+  version?: string;
+  compatible: boolean;
+  fallback: boolean;
+  reused?: boolean;
+  reason?: MachineReason;
+};
+
+export type CollectionMetrics = {
+  requestBytes?: number;
+  responseBytes?: number;
+  records?: number;
+  roundTripMs?: number;
 };
 
 function optionalString(value: unknown): string | undefined {
@@ -78,6 +125,49 @@ function decodeCoverage(value: unknown): AgentCoverage[] | undefined {
   });
 }
 
+function decodeHelper(value: unknown): HelperFact | undefined {
+  if (value === undefined) return undefined;
+  if (value == null || typeof value !== 'object' || Array.isArray(value))
+    throw new Error('Invalid helper state');
+  const raw = value as Record<string, unknown>;
+  if (
+    typeof raw.state !== 'string' ||
+    typeof raw.compatible !== 'boolean' ||
+    typeof raw.fallback !== 'boolean'
+  ) {
+    throw new Error('Invalid helper state');
+  }
+  const helper: HelperFact = {
+    state: assertOneOf(raw.state, HELPER_STATES),
+    compatible: raw.compatible,
+    fallback: raw.fallback,
+  };
+  const version = optionalString(raw.version);
+  if (version != null) helper.version = version;
+  if (raw.reused != null) {
+    if (typeof raw.reused !== 'boolean') throw new Error('Invalid helper state');
+    helper.reused = raw.reused;
+  }
+  if (raw.reason != null) {
+    if (typeof raw.reason !== 'string') throw new Error('Invalid helper state');
+    helper.reason = assertOneOf(raw.reason, MACHINE_REASONS);
+  }
+  return helper;
+}
+
+function decodeMetrics(value: unknown): CollectionMetrics | undefined {
+  if (value === undefined) return undefined;
+  if (value == null || typeof value !== 'object' || Array.isArray(value))
+    throw new Error('Invalid collection metrics');
+  const raw = value as Record<string, unknown>;
+  const metrics: CollectionMetrics = {};
+  for (const key of ['requestBytes', 'responseBytes', 'records', 'roundTripMs'] as const) {
+    const number = optionalNumber(raw[key]);
+    if (number != null) metrics[key] = number;
+  }
+  return metrics;
+}
+
 export function decodeMachineFact(value: unknown): MachineFact {
   if (value == null || typeof value !== 'object' || Array.isArray(value)) {
     throw new Error('Invalid machine fact');
@@ -109,6 +199,32 @@ export function decodeMachineFact(value: unknown): MachineFact {
   if (coverage != null) fact.coverage = coverage;
   const error = optionalString(raw.error);
   if (error != null) fact.error = error;
+  if (raw.transport != null) {
+    if (typeof raw.transport !== 'string') throw new Error('Invalid machine fact');
+    fact.transport = assertOneOf(raw.transport, MACHINE_TRANSPORTS);
+  }
+  const helper = decodeHelper(raw.helper);
+  if (helper != null) fact.helper = helper;
+  const metrics = decodeMetrics(raw.metrics);
+  if (metrics != null) fact.metrics = metrics;
+  if (raw.helperInstallationAvailable != null) {
+    if (typeof raw.helperInstallationAvailable !== 'boolean') throw new Error('Invalid machine fact');
+    fact.helperInstallationAvailable = raw.helperInstallationAvailable;
+  }
+  if (raw.helperProbeState != null) {
+    if (!['unknown', 'probing', 'ready', 'fallback'].includes(String(raw.helperProbeState))) {
+      throw new Error('Invalid machine fact');
+    }
+    fact.helperProbeState = raw.helperProbeState as MachineFact['helperProbeState'];
+  }
+  if (raw.helperOwnershipRecorded != null) {
+    if (typeof raw.helperOwnershipRecorded !== 'boolean') throw new Error('Invalid machine fact');
+    fact.helperOwnershipRecorded = raw.helperOwnershipRecorded;
+  }
+  if (raw.helperOwnershipCorrupt != null) {
+    if (typeof raw.helperOwnershipCorrupt !== 'boolean') throw new Error('Invalid machine fact');
+    fact.helperOwnershipCorrupt = raw.helperOwnershipCorrupt;
+  }
   return fact;
 }
 

--- a/frontend/src/pages/coslash/lib/remote-api.ts
+++ b/frontend/src/pages/coslash/lib/remote-api.ts
@@ -1,5 +1,23 @@
 import { apiFetch, decodeApiError, readApiError } from '@/pages/coslash/lib/api';
 import { decodeMachineFact, type MachineFact } from '@/pages/coslash/lib/machines';
+import { assertOneOf } from '@/pages/coslash/lib/narrow';
+
+export const HELPER_SETUP_OUTCOMES = [
+  'installed_and_tested',
+  'reused_and_tested',
+  'deprecated_helper_active',
+  'consent_required',
+  'unsupported',
+  'blocked',
+  'incompatible',
+  'revoked',
+  'verification_failed',
+  'installation_failed',
+  'rolled_back',
+  'helper_test_failed',
+  'sftp_fallback',
+] as const;
+export type HelperSetupOutcome = (typeof HELPER_SETUP_OUTCOMES)[number];
 
 export function remoteTestRequestInit(sshAlias: string): RequestInit {
   return {
@@ -26,4 +44,51 @@ export async function retryRemoteRefresh(): Promise<{ status: number; machine: M
     throw Object.assign(new Error(apiError.error), { code: apiError.code, status: response.status });
   }
   return { status: response.status, machine: decodeMachineFact(body) };
+}
+
+export async function setupRemoteHelper(consent: 'install' | 'upgrade'): Promise<HelperSetupResult> {
+  const response = await apiFetch('/api/remote/helper/setup', helperSetupRequestInit(consent));
+  return decodeHelperSetup(await response.json());
+}
+
+export function helperSetupRequestInit(consent: 'install' | 'upgrade'): RequestInit {
+  return {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ install: consent === 'install', upgrade: consent === 'upgrade' }),
+  };
+}
+
+export type HelperSetupResult = { machine: MachineFact; outcome: HelperSetupOutcome; error?: string };
+
+export function decodeHelperSetup(value: unknown): HelperSetupResult {
+  if (value == null || typeof value !== 'object' || Array.isArray(value))
+    throw new Error('Invalid helper setup result');
+  const raw = value as Record<string, unknown>;
+  if (typeof raw.outcome !== 'string') throw new Error('Invalid helper setup result');
+  const result: HelperSetupResult = {
+    machine: decodeMachineFact(raw.machine),
+    outcome: assertOneOf(raw.outcome, HELPER_SETUP_OUTCOMES),
+  };
+  if (raw.error != null) {
+    if (typeof raw.error !== 'string') throw new Error('Invalid helper setup result');
+    result.error = raw.error;
+  }
+  return result;
+}
+
+export async function remoteStatus(): Promise<MachineFact> {
+  const response = await apiFetch('/api/remote/status');
+  if (!response.ok) {
+    const apiError = await readApiError(response);
+    throw new Error(apiError?.error || `Remote status failed (${response.status})`);
+  }
+  return decodeMachineFact(await response.json());
+}
+
+export async function uninstallRemoteHelper(): Promise<void> {
+  const response = await apiFetch('/api/remote/helper/uninstall', { method: 'POST' });
+  if (response.ok) return;
+  const apiError = await readApiError(response);
+  throw new Error(apiError?.error || `Helper uninstall failed (${response.status})`);
 }

--- a/frontend/src/pages/coslash/lib/remote-api.ts
+++ b/frontend/src/pages/coslash/lib/remote-api.ts
@@ -46,16 +46,25 @@ export async function retryRemoteRefresh(): Promise<{ status: number; machine: M
   return { status: response.status, machine: decodeMachineFact(body) };
 }
 
-export async function setupRemoteHelper(consent: 'install' | 'upgrade'): Promise<HelperSetupResult> {
-  const response = await apiFetch('/api/remote/helper/setup', helperSetupRequestInit(consent));
-  return decodeHelperSetup(await response.json());
+export async function setupRemoteHelper(
+  sshAlias: string,
+  consent: 'install' | 'upgrade',
+): Promise<HelperSetupResult> {
+  const response = await apiFetch('/api/remote/helper/setup', helperSetupRequestInit(sshAlias, consent));
+  const body: unknown = await response.json();
+  try {
+    return decodeHelperSetup(body);
+  } catch (error) {
+    if (!response.ok) throw new Error(decodeApiError(body).error);
+    throw error;
+  }
 }
 
-export function helperSetupRequestInit(consent: 'install' | 'upgrade'): RequestInit {
+export function helperSetupRequestInit(sshAlias: string, consent: 'install' | 'upgrade'): RequestInit {
   return {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ install: consent === 'install', upgrade: consent === 'upgrade' }),
+    body: JSON.stringify({ sshAlias, install: consent === 'install', upgrade: consent === 'upgrade' }),
   };
 }
 

--- a/frontend/src/pages/coslash/lib/remote-diagnostics.ts
+++ b/frontend/src/pages/coslash/lib/remote-diagnostics.ts
@@ -15,6 +15,7 @@ export function formatRemoteDiagnosticsFacts(
   const nowMs = options.nowMs ?? Date.now();
   const lines: string[] = [];
   const head = [remote.label ?? 'Remote host', remote.state];
+  if (remote.transport) head.push(remote.transport);
   lines.push(head.join(' · '));
 
   const counts: string[] = [];
@@ -33,7 +34,19 @@ export function formatRemoteDiagnosticsFacts(
     timing.push(`next automatic retry ${formatNextRetry(remote.nextRetryAtMs, nowMs)}`);
   if (timing.length > 0) lines.push(timing.join(' · '));
 
+  if (remote.helperState) {
+    const helper = [`helper ${remote.helperState}`];
+    if (remote.helperVersion) helper.push(remote.helperVersion);
+    helper.push(remote.helperCompatible ? 'compatible' : 'not executable');
+    if (remote.helperFallback) helper.push('SFTP fallback');
+    lines.push(helper.join(' · '));
+  }
+  const metrics: string[] = [];
+  if (remote.requestBytes != null) metrics.push(`${remote.requestBytes} request bytes`);
+  if (remote.responseBytes != null) metrics.push(`${remote.responseBytes} response bytes`);
+  if (remote.records != null) metrics.push(`${remote.records} records`);
+  if (metrics.length > 0) lines.push(metrics.join(' · '));
+
   if (remote.error) lines.push(`error: ${remote.error}`);
-  if (remote.diagnosticStderr) lines.push(`stderr: ${remote.diagnosticStderr}`);
   return lines;
 }

--- a/frontend/src/pages/coslash/lib/session.test.ts
+++ b/frontend/src/pages/coslash/lib/session.test.ts
@@ -82,6 +82,15 @@ describe('boardStatusKey', () => {
 });
 
 describe('decodeMachineFact', () => {
+  it('accepts the exact local-machine JSON shape without remote-only fields', () => {
+    expect(decodeMachineFact({ sourceId: 'local', label: 'This Mac', state: 'ok', complete: true })).toEqual({
+      sourceId: 'local',
+      label: 'This Mac',
+      state: 'ok',
+      complete: true,
+    });
+  });
+
   it('accepts a healthy remote machine fact', () => {
     expect(
       decodeMachineFact({

--- a/frontend/src/pages/coslash/lib/settings.ts
+++ b/frontend/src/pages/coslash/lib/settings.ts
@@ -12,6 +12,10 @@ export type RemoteHostSettings = {
   enabled: boolean;
 };
 
+// Request-only intent sent beside a proposed settings replacement. It is not
+// serialized into settings.json.
+export type RemoteOwnershipAction = 'release' | 'uninstall';
+
 export type CoslashSettings = {
   $schema: string;
   version: number;

--- a/settings.schema.json
+++ b/settings.schema.json
@@ -49,6 +49,7 @@
       }
     },
     "remote": {
+      "description": "One optional Linux host monitored through an existing OpenSSH alias. SFTP is always available when permitted; the optional Linux collection helper requires explicit in-app consent before installation.",
       "type": "object",
       "additionalProperties": false,
       "required": ["id", "sshAlias", "enabled"],


### PR DESCRIPTION
## Summary

- Add remote setup, helper lifecycle, and ownership APIs.
- Add Machines controls, diagnostics, fallback, and recovery states.
- Embed AMD64 and ARM64 helpers in release binaries.
- Add packaged smoke coverage and user documentation.
- Include follow-up fixes for freshness, setup probes, and reverification.

## Validation

- Full Go, vet, and targeted race suites pass.
- Frontend tests, lint, formatting, and build pass.
- Embedded-helper and packaged release smoke tests pass.
- Real-host lifecycle passed on Linux AMD64 and ARM64.

## Stack

- 3 of 3.
- Depends on #136, which depends on #135.
- Merge in stack order.