### PR TITLE
Add a verified SSH collection helper

### DIFF
--- a/collector/Makefile
+++ b/collector/Makefile
@@ -1,5 +1,9 @@
 BINARY := coslash
 PKG := ./cmd/coslash
+HELPER := coslash-helper
+HELPER_PKG := ./cmd/coslash-helper
+HELPER_PLATFORMS := linux/amd64 linux/arm64
+HELPER_DIST := dist/helper
 FRONTEND := ../frontend
 STAGED := internal/web/dist
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
@@ -11,7 +15,8 @@ MODELS := internal/session/models.json
 LITELLM_URL := https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json
 OPENCODE_MODELS_URL := https://models.opencode.ai/api.json
 
-.PHONY: build run test check tidy clean release stage unstage smoke smoke-dev dist models
+.PHONY: build run test check tidy clean release stage unstage smoke smoke-dev dist models \
+	helper helper-dist
 
 release: stage
 	go build -ldflags "$(LDFLAGS)" -o bin/$(BINARY) $(PKG)
@@ -48,6 +53,29 @@ dist: stage
 		echo "packaged $(DIST)/$$stem.tar.gz"; \
 	done
 	cd $(DIST) && shasum -a 256 *.tar.gz > checksums.txt
+
+# The Linux collection helper, for local iteration on the host platform.
+helper:
+	CGO_ENABLED=0 go build -ldflags '-X main.build=$(VERSION)' -o bin/$(HELPER) $(HELPER_PKG)
+
+# Cross-compiles the shipped helper targets. Reproducible on purpose: -trimpath
+# and no CGO, so rebuilding one commit yields identical binaries and therefore
+# the digests release metadata is signed over. Digests cover the binaries
+# themselves rather than an archive, because installation verifies the exact
+# executable it is about to place and run.
+helper-dist:
+	rm -rf $(HELPER_DIST)
+	mkdir -p $(HELPER_DIST)
+	@for platform in $(HELPER_PLATFORMS); do \
+		goos=$${platform%/*}; goarch=$${platform#*/}; \
+		stem=$(HELPER)_$(VERSION)_$${goos}_$${goarch}; \
+		CGO_ENABLED=0 GOOS=$$goos GOARCH=$$goarch \
+			go build -trimpath -ldflags '-s -w -X main.build=$(VERSION)' \
+			-o $(HELPER_DIST)/$$stem $(HELPER_PKG) || exit 1; \
+		echo "built $(HELPER_DIST)/$$stem"; \
+	done
+	cd $(HELPER_DIST) && shasum -a 256 $(HELPER)_* > checksums.txt
+	@cat $(HELPER_DIST)/checksums.txt
 
 # Without this a build after `make release` would embed that release's frontend.
 unstage:

--- a/collector/cmd/coslash-helper/main.go
+++ b/collector/cmd/coslash-helper/main.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/centauri-ai/coslash/collector/internal/remotefacts"
 	"github.com/centauri-ai/coslash/collector/internal/remotehelper"
+	"github.com/centauri-ai/coslash/collector/internal/remoteinstall"
 	"github.com/centauri-ai/coslash/collector/internal/remoteprotocol"
 	"github.com/centauri-ai/coslash/collector/internal/vendors"
 )
@@ -39,15 +40,33 @@ const (
 var build = "dev"
 
 func main() {
-	if len(os.Args) != 2 {
+	if len(os.Args) < 2 {
 		usage()
 		os.Exit(exitUsage)
 	}
 	switch os.Args[1] {
 	case "version", "capabilities":
+		if len(os.Args) != 2 {
+			usage()
+			os.Exit(exitUsage)
+		}
 		os.Exit(runCapabilities(os.Stdout))
 	case "collect":
+		if len(os.Args) != 2 {
+			usage()
+			os.Exit(exitUsage)
+		}
 		os.Exit(runCollect(context.Background(), os.Stdin, os.Stdout))
+	case "install":
+		if len(os.Args) != 5 {
+			usage()
+			os.Exit(exitUsage)
+		}
+		if err := remoteinstall.Install(os.Args[2], os.Args[3], os.Args[4]); err != nil {
+			fmt.Fprintf(os.Stderr, "coslash-helper: secure install: %v\n", err)
+			os.Exit(exitInternal)
+		}
+		os.Exit(exitOK)
 	default:
 		usage()
 		os.Exit(exitUsage)
@@ -55,7 +74,7 @@ func main() {
 }
 
 func usage() {
-	fmt.Fprintln(os.Stderr, "usage: coslash-helper version|collect")
+	fmt.Fprintln(os.Stderr, "usage: coslash-helper version|collect|install <home> <version> <sha256>")
 	fmt.Fprintln(os.Stderr, "collect reads one JSON request line on stdin.")
 }
 

--- a/collector/cmd/coslash-helper/main.go
+++ b/collector/cmd/coslash-helper/main.go
@@ -1,0 +1,155 @@
+// Command coslash-helper answers one bounded collection request from a Mac
+// coSlash instance driving it over SSH. It reads the SSH user's own Claude and
+// Codex data, writes protocol records to stdout, and keeps no state: no daemon,
+// no listener, no cache, and no transcript ever leaves the machine.
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"runtime/debug"
+
+	"github.com/centauri-ai/coslash/collector/internal/remotefacts"
+	"github.com/centauri-ai/coslash/collector/internal/remotehelper"
+	"github.com/centauri-ai/coslash/collector/internal/remoteprotocol"
+	"github.com/centauri-ai/coslash/collector/internal/vendors"
+)
+
+// Exit codes are part of the transport contract: the Mac separates a helper that
+// is missing or blocked (shell codes 126/127) from one that ran and reported
+// what it could.
+const (
+	exitOK       = 0
+	exitUsage    = 2
+	exitPartial  = 3
+	exitRequest  = 4
+	exitInternal = 5
+	exitResource = 6
+)
+
+// build is stamped at release time; it is diagnostic identity only, never a
+// compatibility gate.
+var build = "dev"
+
+func main() {
+	if len(os.Args) != 2 {
+		usage()
+		os.Exit(exitUsage)
+	}
+	switch os.Args[1] {
+	case "version", "capabilities":
+		os.Exit(runCapabilities(os.Stdout))
+	case "collect":
+		os.Exit(runCollect(context.Background(), os.Stdin, os.Stdout))
+	default:
+		usage()
+		os.Exit(exitUsage)
+	}
+}
+
+func usage() {
+	fmt.Fprintln(os.Stderr, "usage: coslash-helper version|collect")
+	fmt.Fprintln(os.Stderr, "collect reads one JSON request line on stdin.")
+}
+
+func runCapabilities(output io.Writer) int {
+	document := remoteprotocol.Capabilities{
+		Protocol:      remoteprotocol.VersionRange{Min: 1, Max: remoteprotocol.ProtocolVersion},
+		Schema:        remoteprotocol.VersionRange{Min: 1, Max: remotefacts.SchemaVersion},
+		ParserVersion: vendors.ParserVersion,
+		Capabilities:  remotehelper.Capabilities,
+		Build:         buildIdentity(),
+		OS:            runtime.GOOS,
+		Arch:          runtime.GOARCH,
+	}
+	encoder := json.NewEncoder(output)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(document); err != nil {
+		fmt.Fprintln(os.Stderr, "coslash-helper: capabilities could not be written")
+		return exitInternal
+	}
+	return exitOK
+}
+
+func runCollect(ctx context.Context, input io.Reader, output io.Writer) int {
+	request, err := readRequest(input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "coslash-helper: %v\n", err)
+		return exitRequest
+	}
+	outcome, err := remotehelper.Collect(ctx, request, remotehelper.Options{}, output)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "coslash-helper: collection stopped: %v\n", err)
+		if errors.Is(err, remotehelper.ErrRecordLimit) {
+			return exitResource
+		}
+		if outcome.Records > 0 {
+			return exitPartial
+		}
+		return exitInternal
+	}
+	if !outcome.RequestComplete {
+		fmt.Fprintln(os.Stderr, "coslash-helper: coverage is partial for this request")
+		return exitPartial
+	}
+	return exitOK
+}
+
+// readRequest reads exactly one bounded request line. Nothing in the request is
+// ever treated as a path, a command, or a filesystem name.
+func readRequest(input io.Reader) (remoteprotocol.Request, error) {
+	reader := bufio.NewReaderSize(
+		io.LimitReader(input, remoteprotocol.MaxRequestBytes+1), 64<<10,
+	)
+	line, err := reader.ReadBytes('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return remoteprotocol.Request{}, fmt.Errorf("read request: %w", err)
+	}
+	if len(line) == 0 {
+		return remoteprotocol.Request{}, errors.New("request is empty")
+	}
+	if len(line) > remoteprotocol.MaxRequestBytes {
+		return remoteprotocol.Request{}, errors.New("request exceeds byte limit")
+	}
+	if _, trailingErr := reader.ReadByte(); trailingErr == nil {
+		return remoteprotocol.Request{}, errors.New("trailing content after request line")
+	} else if !errors.Is(trailingErr, io.EOF) {
+		return remoteprotocol.Request{}, fmt.Errorf("read request trailer: %w", trailingErr)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(line))
+	decoder.DisallowUnknownFields()
+	var request remoteprotocol.Request
+	if err := decoder.Decode(&request); err != nil {
+		return remoteprotocol.Request{}, fmt.Errorf("decode request: %w", err)
+	}
+	if decoder.Decode(&struct{}{}) != io.EOF {
+		return remoteprotocol.Request{}, errors.New("trailing content after request")
+	}
+	if err := remoteprotocol.ValidateRequest(request); err != nil {
+		return remoteprotocol.Request{}, fmt.Errorf("invalid request: %w", err)
+	}
+	return request, nil
+}
+
+func buildIdentity() string {
+	if build != "dev" {
+		return build
+	}
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return build
+	}
+	for _, setting := range info.Settings {
+		if setting.Key == "vcs.revision" && setting.Value != "" {
+			return setting.Value
+		}
+	}
+	return build
+}

--- a/collector/cmd/coslash-helper/main_test.go
+++ b/collector/cmd/coslash-helper/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/centauri-ai/coslash/collector/internal/remoteprotocol"
+	"github.com/centauri-ai/coslash/collector/internal/vendors"
+)
+
+func TestReadRequestRejectsSecondLine(t *testing.T) {
+	request := remoteprotocol.Request{
+		RequestID: "req-1", Protocol: remoteprotocol.VersionRange{Min: 1, Max: 1},
+		Schema: remoteprotocol.VersionRange{Min: 1, Max: 1}, ParserVersion: vendors.ParserVersion,
+		BaselineMode: remoteprotocol.BaselineKnown, BaselineID: "base-1",
+		CollectedAtMs: 1, Vendors: []string{"codex"}, Limits: remoteprotocol.Limits{
+			MaxRecordBytes: 1024, MaxResponseBytes: 4096, MaxRecords: 10, MaxInventoryFamilies: 10,
+		},
+	}
+	payload, err := json.Marshal(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readRequest(strings.NewReader(string(payload) + "\n{}\n")); err == nil {
+		t.Fatal("accepted a second request line")
+	}
+}

--- a/collector/go.mod
+++ b/collector/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	golang.org/x/crypto v0.41.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
+	golang.org/x/sys v0.47.0
 	modernc.org/libc v1.74.4 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/collector/internal/remote/helperexec.go
+++ b/collector/internal/remote/helperexec.go
@@ -1,0 +1,490 @@
+package remote
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/centauri-ai/coslash/collector/internal/remoteprotocol"
+)
+
+const (
+	HelperCommandCapabilities = "version"
+	HelperCommandCollect      = "collect"
+
+	// MaxHelperPathBytes bounds the installed helper path the Mac selects.
+	MaxHelperPathBytes = 256
+	// DefaultCapabilityTimeout bounds the handshake, which reads a few hundred
+	// bytes and must not inherit the collection deadline.
+	DefaultCapabilityTimeout = 20 * time.Second
+)
+
+// helperExitGrace bounds waiting for a helper that stopped writing but has not
+// exited. Past it the process group is terminated. It is a variable so tests can
+// shorten it.
+var helperExitGrace = 5 * time.Second
+
+// helperPathPattern is deliberately narrow: the installed path is chosen by the
+// Mac, never by a request or by remote output, and only these characters can
+// appear in a versioned install directory.
+var helperPathPattern = regexp.MustCompile(`^(/|~/)[A-Za-z0-9._][A-Za-z0-9._/-]*$`)
+
+var (
+	ErrInvalidHelperPath   = errors.New("invalid helper path")
+	ErrInvalidHelperArgs   = errors.New("invalid helper command")
+	ErrHelperOutputLimit   = errors.New("helper output exceeds the response limit")
+	ErrHelperMissing       = errors.New("helper is not installed")
+	ErrHelperBlocked       = errors.New("helper is not executable")
+	ErrHelperIncompatible  = errors.New("helper protocol is incompatible")
+	ErrHelperFailed        = errors.New("helper failed")
+	ErrHelperPartial       = errors.New("helper reported partial coverage")
+	ErrHelperRequestBounds = errors.New("collect request exceeds the byte limit")
+)
+
+// HelperArgs builds the exec argv for one fixed helper subcommand. Request data
+// never appears here: the request travels on stdin, so the remote command line
+// is a validated path plus one word from a closed set.
+func HelperArgs(alias, helperPath, subcommand string, connectTimeoutSeconds int) ([]string, error) {
+	if !aliasPattern.MatchString(alias) {
+		return nil, ErrInvalidAlias
+	}
+	if subcommand != HelperCommandCapabilities && subcommand != HelperCommandCollect {
+		return nil, fmt.Errorf("%w: %q", ErrInvalidHelperArgs, subcommand)
+	}
+	command, err := helperCommand(helperPath, subcommand)
+	if err != nil {
+		return nil, err
+	}
+	if connectTimeoutSeconds <= 0 {
+		connectTimeoutSeconds = int(DefaultConnectTimeout.Seconds())
+	}
+	return []string{
+		"-T",
+		"-o", "BatchMode=yes",
+		"-o", "ConnectTimeout=" + strconv.Itoa(connectTimeoutSeconds),
+		"-o", "ControlMaster=auto",
+		"-o", "ControlPath=" + controlSocketPath(),
+		"-o", "ControlPersist=" + defaultControlPersist,
+		alias,
+		command,
+	}, nil
+}
+
+// helperCommand renders the remote command. OpenSSH hands the command to the
+// remote shell, so the path is quoted and a home-relative install expands only
+// the fixed $HOME name.
+func helperCommand(helperPath, subcommand string) (string, error) {
+	if helperPath == "" || len(helperPath) > MaxHelperPathBytes {
+		return "", fmt.Errorf("%w: length", ErrInvalidHelperPath)
+	}
+	if !helperPathPattern.MatchString(helperPath) {
+		return "", fmt.Errorf("%w: unsupported characters", ErrInvalidHelperPath)
+	}
+	if strings.Contains(helperPath, "..") {
+		return "", fmt.Errorf("%w: relative traversal", ErrInvalidHelperPath)
+	}
+	if relative, ok := strings.CutPrefix(helperPath, "~/"); ok {
+		if relative == "" {
+			return "", fmt.Errorf("%w: empty home-relative path", ErrInvalidHelperPath)
+		}
+		return `"$HOME"/` + shellQuote(relative) + " " + subcommand, nil
+	}
+	// The pattern already required an absolute path here.
+	return shellQuote(helperPath) + " " + subcommand, nil
+}
+
+// shellQuote wraps a value so the remote shell treats it as one literal word.
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
+}
+
+// HelperResult reports one collect exchange. The proposal holds every record
+// that applied cleanly, even when the response was cut short, so a partial
+// refresh keeps the families that did arrive.
+type HelperResult struct {
+	Capabilities    remoteprotocol.Capabilities
+	Proposal        remoteprotocol.Generation
+	Records         int
+	ResponseBytes   int
+	RequestBytes    int
+	RequestComplete bool
+	ExitCode        int
+	Stderr          string
+	RoundTrip       time.Duration
+}
+
+// HelperCapabilities runs the handshake subcommand and returns the helper's
+// supported ranges. Compatibility is decided from overlapping ranges, so a
+// helper built from a different commit than this Mac is still usable.
+func HelperCapabilities(
+	ctx context.Context,
+	alias, helperPath string,
+	options OpenOptions,
+) (remoteprotocol.Capabilities, string, error) {
+	limits := options.Limits.withDefaults()
+	args, err := HelperArgs(
+		alias, helperPath, HelperCommandCapabilities, int(limits.ConnectTimeout.Seconds()),
+	)
+	if err != nil {
+		return remoteprotocol.Capabilities{}, "", err
+	}
+	runCtx, cancel := context.WithTimeout(ctx, DefaultCapabilityTimeout)
+	defer cancel()
+	process, err := startHelper(runCtx, alias, args, cancel, options)
+	if err != nil {
+		return remoteprotocol.Capabilities{}, "", err
+	}
+	_ = process.stdin.Close()
+	capabilities, decodeErr := remoteprotocol.DecodeCapabilities(process.stdout)
+	exitCode, waitErr := process.finish(decodeErr != nil)
+	stderr := process.stderr.String()
+	if reason := helperProcessError(runCtx, exitCode, waitErr, process); reason != nil {
+		return remoteprotocol.Capabilities{}, stderr, reason
+	}
+	if decodeErr != nil {
+		return remoteprotocol.Capabilities{}, stderr, fmt.Errorf(
+			"%w: %w", ErrHelperIncompatible, decodeErr,
+		)
+	}
+	if !capabilities.Compatible() {
+		return capabilities, stderr, fmt.Errorf(
+			"%w: helper offers protocol %d-%d, schema %d-%d",
+			ErrHelperIncompatible, capabilities.Protocol.Min, capabilities.Protocol.Max,
+			capabilities.Schema.Min, capabilities.Schema.Max,
+		)
+	}
+	return capabilities, stderr, nil
+}
+
+// HelperCollect runs one collect exchange against the accumulator. It returns
+// the proposed generation and a reason; the caller decides whether a partial
+// proposal is worth committing.
+func HelperCollect(
+	ctx context.Context,
+	alias, helperPath string,
+	request remoteprotocol.Request,
+	baseline remoteprotocol.Generation,
+	options OpenOptions,
+) (HelperResult, error) {
+	started := time.Now()
+	accumulator, err := remoteprotocol.NewAccumulator(request, baseline)
+	if err != nil {
+		return HelperResult{}, err
+	}
+	payload, err := marshalRequestLine(request)
+	if err != nil {
+		return HelperResult{}, err
+	}
+	limits := options.Limits.withDefaults()
+	args, err := HelperArgs(
+		alias, helperPath, HelperCommandCollect, int(limits.ConnectTimeout.Seconds()),
+	)
+	if err != nil {
+		return HelperResult{}, err
+	}
+	runCtx, cancel := context.WithTimeout(ctx, limits.Deadline)
+	defer cancel()
+	process, err := startHelper(runCtx, alias, args, cancel, options)
+	if err != nil {
+		return HelperResult{}, err
+	}
+	written := process.writeStdin(payload)
+
+	requestCompleted := make(chan struct{})
+	streamed := make(chan streamOutcome, 1)
+	go func() {
+		streamed <- streamRecords(process.stdout, request, accumulator, requestCompleted)
+	}()
+	var stream streamOutcome
+	var exitCode int
+	var waitErr error
+	select {
+	case stream = <-streamed:
+		// Reap before collecting the write result: a helper that answered without
+		// draining stdin would otherwise leave the writer blocked on a full pipe.
+		exitCode, waitErr = process.finish(stream.err != nil || !stream.complete)
+	case <-requestCompleted:
+		// Keep draining through EOF so trailing output is rejected. Wait and drain
+		// concurrently: Wait closes stdout on exit, while finish's grace timer kills
+		// a child that emitted completion and then hung.
+		finished := make(chan struct{}, 1)
+		go func() {
+			exitCode, waitErr = process.finish(false)
+			finished <- struct{}{}
+		}()
+		stream = <-streamed
+		<-finished
+	}
+	writeErr := <-written
+	result := HelperResult{
+		Proposal: accumulator.Proposal(), Records: stream.records,
+		ResponseBytes: stream.bytes, RequestBytes: len(payload),
+		RequestComplete: stream.complete, ExitCode: exitCode,
+		Stderr: process.stderr.String(), RoundTrip: time.Since(started),
+	}
+	if reason := helperProcessError(runCtx, exitCode, waitErr, process); reason != nil {
+		return result, reason
+	}
+	if stream.err != nil {
+		return result, stream.err
+	}
+	if writeErr != nil {
+		return result, fmt.Errorf("send collect request: %w", writeErr)
+	}
+	if !stream.complete {
+		// A helper that ran and could not finish enumerating is partial coverage,
+		// not a failure: the families it did publish stay in the proposal.
+		if exitCode == helperExitPartial {
+			return result, ErrHelperPartial
+		}
+		return result, fmt.Errorf("%w: response ended before completion", ErrHelperFailed)
+	}
+	return result, nil
+}
+
+func marshalRequestLine(request remoteprotocol.Request) ([]byte, error) {
+	if err := remoteprotocol.ValidateRequest(request); err != nil {
+		return nil, err
+	}
+	payload, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("encode collect request: %w", err)
+	}
+	if len(payload)+1 > remoteprotocol.MaxRequestBytes {
+		return nil, ErrHelperRequestBounds
+	}
+	return append(payload, '\n'), nil
+}
+
+type streamOutcome struct {
+	records  int
+	bytes    int
+	complete bool
+	err      error
+}
+
+// streamRecords applies each whole record as it arrives. Records are applied
+// incrementally on purpose: a response that stops early still leaves the records
+// it completed in the proposal, and no partial record ever reaches it.
+func streamRecords(
+	reader io.Reader,
+	request remoteprotocol.Request,
+	accumulator *remoteprotocol.Accumulator,
+	requestCompleted chan<- struct{},
+) streamOutcome {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 4096), request.Limits.MaxRecordBytes+1)
+	outcome := streamOutcome{}
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		outcome.bytes += len(line) + 1
+		if outcome.bytes > request.Limits.MaxResponseBytes {
+			outcome.err = ErrHelperOutputLimit
+			return outcome
+		}
+		if len(line) > request.Limits.MaxRecordBytes {
+			outcome.err = ErrHelperOutputLimit
+			return outcome
+		}
+		record, err := decodeRecordLine(line)
+		if err != nil {
+			outcome.err = err
+			return outcome
+		}
+		if err := accumulator.Apply(record); err != nil {
+			outcome.err = fmt.Errorf("%w: %w", ErrHelperFailed, err)
+			return outcome
+		}
+		outcome.records++
+		if record.Type == remoteprotocol.RecordRequestComplete {
+			outcome.complete = true
+			close(requestCompleted)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		if errors.Is(err, bufio.ErrTooLong) {
+			outcome.err = ErrHelperOutputLimit
+			return outcome
+		}
+		outcome.err = fmt.Errorf("read helper response: %w", err)
+	}
+	return outcome
+}
+
+func decodeRecordLine(line []byte) (remoteprotocol.Record, error) {
+	if len(bytes.TrimSpace(line)) == 0 {
+		return remoteprotocol.Record{}, fmt.Errorf("%w: blank record", ErrHelperFailed)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(line))
+	decoder.DisallowUnknownFields()
+	var record remoteprotocol.Record
+	if err := decoder.Decode(&record); err != nil {
+		return remoteprotocol.Record{}, fmt.Errorf("%w: decode record: %w", ErrHelperFailed, err)
+	}
+	if decoder.Decode(&struct{}{}) != io.EOF {
+		return remoteprotocol.Record{}, fmt.Errorf("%w: trailing JSON value", ErrHelperFailed)
+	}
+	return record, nil
+}
+
+// helperProcess owns one SSH child and its bounded pipes.
+type helperProcess struct {
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stdout io.ReadCloser
+	stderr *cappedStderr
+	// terminated records that this side killed the child, so the resulting
+	// "signal: killed" wait error is expected rather than a helper failure.
+	terminated bool
+}
+
+func startHelper(
+	ctx context.Context,
+	alias string,
+	args []string,
+	cancel context.CancelFunc,
+	options OpenOptions,
+) (*helperProcess, error) {
+	limits := options.Limits.withDefaults()
+	// Injected commands are unit-test fakes; skip real OpenSSH master setup there.
+	if options.command == nil {
+		if err := ensureControlMaster(ctx, alias, options); err != nil {
+			return nil, err
+		}
+	}
+	bin := options.SSHBin
+	if bin == "" {
+		bin = "ssh"
+	}
+	command := options.command
+	if command == nil {
+		command = exec.CommandContext
+	}
+	cmd := command(ctx, bin, args...)
+	configureProcessGroup(cmd)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("open SSH stdin: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("open SSH stdout: %w", err)
+	}
+	stderr := &cappedStderr{limit: limits.MaxStderrBytes, cancel: cancel}
+	cmd.Stderr = stderr
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start SSH: %w", err)
+	}
+	return &helperProcess{cmd: cmd, stdin: stdin, stdout: stdout, stderr: stderr}, nil
+}
+
+// writeStdin sends the request without blocking record reading, and reports the
+// write result on a channel so the caller never leaves the goroutine running.
+func (process *helperProcess) writeStdin(payload []byte) <-chan error {
+	done := make(chan error, 1)
+	go func() {
+		_, err := process.stdin.Write(payload)
+		closeErr := process.stdin.Close()
+		if err == nil && closeErr != nil && !benignSessionCloseErr(closeErr) {
+			err = closeErr
+		}
+		done <- err
+	}()
+	return done
+}
+
+// finish reaps the child. A helper that stopped writing without exiting, or one
+// abandoned mid-response, has its whole process group terminated so no orphan
+// SSH client is left holding the pipes.
+func (process *helperProcess) finish(aborted bool) (int, error) {
+	if aborted {
+		process.terminated = true
+		terminateProcessGroup(process.cmd)
+	}
+	waited := make(chan error, 1)
+	go func() { waited <- process.cmd.Wait() }()
+	select {
+	case err := <-waited:
+		return exitCodeOf(err), err
+	case <-time.After(helperExitGrace):
+		process.terminated = true
+		terminateProcessGroup(process.cmd)
+		err := <-waited
+		return exitCodeOf(err), err
+	}
+}
+
+func exitCodeOf(err error) int {
+	if err == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
+}
+
+// helperProcessError separates SSH transport failure, a missing or blocked
+// helper, and a helper that ran and reported partial coverage.
+func helperProcessError(
+	ctx context.Context,
+	exitCode int,
+	waitErr error,
+	process *helperProcess,
+) error {
+	if process.stderr.overflow {
+		return ErrStderrLimit
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	// A negative code means the child died from the signal this side sent, so the
+	// stream outcome carries the reason. A child that exited on its own still
+	// reports its own status even when it was killed afterwards.
+	if process.terminated && exitCode < 0 {
+		return nil
+	}
+	switch exitCode {
+	case 0, helperExitPartial:
+		return nil
+	case helperExitShellNotFound:
+		return ErrHelperMissing
+	case helperExitShellNotExecutable:
+		return ErrHelperBlocked
+	case helperExitBadRequest:
+		return fmt.Errorf("%w: helper rejected the request", ErrHelperIncompatible)
+	case helperExitResource:
+		return ErrHelperOutputLimit
+	case helperExitInternal:
+		return wrapSSHError(ErrHelperFailed, process.stderr.String())
+	case helperExitSSH:
+		return wrapSSHError(
+			fmt.Errorf("SSH exec failed: %w", waitErr), process.stderr.String(),
+		)
+	}
+	if waitErr != nil {
+		return wrapSSHError(waitErr, process.stderr.String())
+	}
+	return nil
+}
+
+// Exit codes the helper and the remote shell use.
+const (
+	helperExitPartial            = 3
+	helperExitBadRequest         = 4
+	helperExitInternal           = 5
+	helperExitResource           = 6
+	helperExitShellNotExecutable = 126
+	helperExitShellNotFound      = 127
+	helperExitSSH                = 255
+)

--- a/collector/internal/remote/helperexec_other.go
+++ b/collector/internal/remote/helperexec_other.go
@@ -1,0 +1,15 @@
+//go:build !unix
+
+package remote
+
+import "os/exec"
+
+// coSlash ships for macOS. Elsewhere there is no process group to place the SSH
+// client in, so cancellation falls back to killing the client itself.
+func configureProcessGroup(*exec.Cmd) {}
+
+func terminateProcessGroup(cmd *exec.Cmd) {
+	if cmd.Process != nil {
+		_ = cmd.Process.Kill()
+	}
+}

--- a/collector/internal/remote/helperexec_test.go
+++ b/collector/internal/remote/helperexec_test.go
@@ -1,0 +1,169 @@
+package remote
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/centauri-ai/coslash/collector/internal/remoteprotocol"
+	"github.com/centauri-ai/coslash/collector/internal/vendors"
+)
+
+func TestHelperCollectRejectsTrailingOutput(t *testing.T) {
+	request, baseline, response := completeResponse(t)
+	response = append(response, []byte("{}\n")...)
+	_, err := HelperCollect(context.Background(), "host", "/helper", request, baseline, fakeOptions(response, 0, "", false))
+	if !errors.Is(err, ErrHelperFailed) {
+		t.Fatalf("HelperCollect error = %v, want ErrHelperFailed", err)
+	}
+}
+
+func TestHelperCollectSuccess(t *testing.T) {
+	request, baseline, response := completeResponse(t)
+	result, err := HelperCollect(context.Background(), "host", "/helper", request, baseline, fakeOptions(response, 0, "", false))
+	if err != nil || !result.RequestComplete || result.Records != 3 {
+		t.Fatalf("HelperCollect result = %#v, error = %v", result, err)
+	}
+}
+
+func TestHelperCollectRejectsTruncatedResponse(t *testing.T) {
+	request, baseline, response := completeResponse(t)
+	firstLine := response[:strings.IndexByte(string(response), '\n')+1]
+	response = append(firstLine, []byte(`{"type":"changed_family"`)...)
+	result, err := HelperCollect(context.Background(), "host", "/helper", request, baseline, fakeOptions(response, 0, "", false))
+	if !errors.Is(err, ErrHelperFailed) {
+		t.Fatalf("HelperCollect error = %v, want ErrHelperFailed", err)
+	}
+	if result.Records != 1 || len(result.Proposal.Families) != 0 {
+		t.Fatalf("partial record mutated proposal: %#v", result)
+	}
+}
+
+func TestHelperCapabilitiesRejectsIncompatibleRange(t *testing.T) {
+	output := []byte(`{"protocol":{"min":2,"max":2},"schema":{"min":1,"max":1},"parser_version":"parsers-1"}` + "\n")
+	_, _, err := HelperCapabilities(context.Background(), "host", "/helper", fakeOptions(output, 0, "", false))
+	if !errors.Is(err, ErrHelperIncompatible) {
+		t.Fatalf("HelperCapabilities error = %v, want ErrHelperIncompatible", err)
+	}
+}
+
+func TestHelperCollectBoundsFloodsAndClassifiesExit(t *testing.T) {
+	request, baseline, _ := completeResponse(t)
+	tests := []struct {
+		name   string
+		output []byte
+		stderr string
+		exit   int
+		want   error
+	}{
+		{name: "stdout", output: []byte(strings.Repeat("x", request.Limits.MaxRecordBytes+2)), want: ErrHelperOutputLimit},
+		{name: "stderr", stderr: strings.Repeat("x", 100), want: ErrStderrLimit},
+		{name: "resource exit", exit: helperExitResource, want: ErrHelperOutputLimit},
+		{name: "missing", exit: helperExitShellNotFound, want: ErrHelperMissing},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			options := fakeOptions(test.output, test.exit, test.stderr, false)
+			options.Limits.MaxStderrBytes = 16
+			_, err := HelperCollect(context.Background(), "host", "/helper", request, baseline, options)
+			if !errors.Is(err, test.want) {
+				t.Fatalf("HelperCollect error = %v, want %v", err, test.want)
+			}
+		})
+	}
+}
+
+func TestHelperCollectCleansUpChildThatHangsAfterCompletion(t *testing.T) {
+	request, baseline, response := completeResponse(t)
+	oldGrace := helperExitGrace
+	helperExitGrace = 100 * time.Millisecond
+	defer func() { helperExitGrace = oldGrace }()
+	started := time.Now()
+	result, err := HelperCollect(context.Background(), "host", "/helper", request, baseline, fakeOptions(response, 0, "", true))
+	if err != nil || !result.RequestComplete {
+		t.Fatalf("HelperCollect result = %#v, error = %v", result, err)
+	}
+	if time.Since(started) > 2*time.Second {
+		t.Fatal("hung helper cleanup exceeded bound")
+	}
+}
+
+func TestHelperCollectHonorsCancellation(t *testing.T) {
+	request, baseline, _ := completeResponse(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err := HelperCollect(ctx, "host", "/helper", request, baseline, fakeOptions(nil, 0, "", true))
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("HelperCollect error = %v, want deadline", err)
+	}
+}
+
+func TestHelperArgsRejectInjection(t *testing.T) {
+	for _, input := range []struct{ alias, path string }{
+		{alias: "-oProxyCommand=bad", path: "/helper"},
+		{alias: "host", path: "/helper;bad"},
+		{alias: "host", path: "~/../helper"},
+	} {
+		if _, err := HelperArgs(input.alias, input.path, HelperCommandCollect, 1); err == nil {
+			t.Fatalf("accepted alias %q path %q", input.alias, input.path)
+		}
+	}
+}
+
+func completeResponse(t *testing.T) (remoteprotocol.Request, remoteprotocol.Generation, []byte) {
+	t.Helper()
+	request := remoteprotocol.Request{
+		RequestID: "req-1", Protocol: remoteprotocol.VersionRange{Min: 1, Max: 1},
+		Schema: remoteprotocol.VersionRange{Min: 1, Max: 1}, ParserVersion: vendors.ParserVersion,
+		BaselineMode: remoteprotocol.BaselineKnown, BaselineID: "base-1",
+		CollectedAtMs: 1, Vendors: []string{"codex"}, Limits: remoteprotocol.Limits{
+			MaxRecordBytes: 1024, MaxResponseBytes: 4096, MaxRecords: 10, MaxInventoryFamilies: 10,
+		},
+	}
+	baseline := remoteprotocol.Generation{BaselineID: "base-1"}
+	records := []remoteprotocol.Record{
+		{Type: remoteprotocol.RecordHandshake, ProtocolVersion: 1, RequestID: "req-1", Sequence: 1, BaselineID: "base-1", SchemaVersion: 1, ParserVersion: vendors.ParserVersion},
+		{Type: remoteprotocol.RecordVendorComplete, ProtocolVersion: 1, RequestID: "req-1", Sequence: 2, Vendor: "codex", EnumerationComplete: true, InventoryComplete: true, Inventory: []string{}},
+		{Type: remoteprotocol.RecordRequestComplete, ProtocolVersion: 1, RequestID: "req-1", Sequence: 3},
+	}
+	response, err := remoteprotocol.Encode(records)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return request, baseline, response
+}
+
+func fakeOptions(output []byte, exitCode int, stderr string, hang bool) OpenOptions {
+	return OpenOptions{
+		Limits: Limits{Deadline: 2 * time.Second, MaxStderrBytes: 1024},
+		command: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+			cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestHelperExecProcess", "--")
+			cmd.Env = append(os.Environ(),
+				"COSLASH_FAKE_HELPER=1",
+				"COSLASH_FAKE_OUTPUT="+string(output),
+				"COSLASH_FAKE_STDERR="+stderr,
+				"COSLASH_FAKE_EXIT="+strconv.Itoa(exitCode),
+				"COSLASH_FAKE_HANG="+strconv.FormatBool(hang),
+			)
+			return cmd
+		},
+	}
+}
+
+func TestHelperExecProcess(t *testing.T) {
+	if os.Getenv("COSLASH_FAKE_HELPER") != "1" {
+		return
+	}
+	_, _ = os.Stdout.WriteString(os.Getenv("COSLASH_FAKE_OUTPUT"))
+	_, _ = os.Stderr.WriteString(os.Getenv("COSLASH_FAKE_STDERR"))
+	if os.Getenv("COSLASH_FAKE_HANG") == "true" {
+		time.Sleep(time.Hour)
+	}
+	exitCode, _ := strconv.Atoi(os.Getenv("COSLASH_FAKE_EXIT"))
+	os.Exit(exitCode)
+}

--- a/collector/internal/remote/helperexec_unix.go
+++ b/collector/internal/remote/helperexec_unix.go
@@ -1,0 +1,27 @@
+//go:build unix
+
+package remote
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// configureProcessGroup puts the SSH client in its own process group so a
+// timeout, a cancellation, or an output flood can terminate the client and
+// anything it spawned (a ProxyCommand, for example) rather than only the client.
+func configureProcessGroup(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}
+
+func terminateProcessGroup(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	// The group ID equals the child PID because the child leads its own group.
+	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	_ = cmd.Process.Kill()
+}

--- a/collector/internal/remote/helperhealth.go
+++ b/collector/internal/remote/helperhealth.go
@@ -1,0 +1,108 @@
+package remote
+
+import (
+	"context"
+	"errors"
+)
+
+// Helper collection needs reasons SFTP never produced. They stay distinct from
+// transport failure so the UI can offer the right repair: install, upgrade, or
+// simply retry. User-facing copy for these lands with the Machines UI work.
+const (
+	ReasonHelperMissing      Reason = "helper_missing"
+	ReasonHelperBlocked      Reason = "helper_not_executable"
+	ReasonHelperIncompatible Reason = "helper_incompatible"
+	ReasonHelperFailed       Reason = "helper_failed"
+	ReasonOutputLimit        Reason = "output_limit"
+	ReasonHelperUnsupported  Reason = "helper_platform_unsupported"
+	ReasonHelperVerification Reason = "helper_verification_failed"
+	ReasonHelperInstallation Reason = "helper_installation_failed"
+	ReasonHelperRevoked      Reason = "helper_revoked"
+	ReasonHelperUpgrade      Reason = "helper_upgrade_required"
+	ReasonHelperRollback     Reason = "helper_rolled_back"
+)
+
+// classifyHelperError maps one collect or handshake failure to a stable reason.
+// Helper outcomes are checked before the shared SSH text matching so a helper
+// that ran and failed is never reported as a connection problem.
+func classifyHelperError(err error) Reason {
+	switch {
+	case err == nil:
+		return ReasonHelperFailed
+	case errors.Is(err, ErrHelperMissing):
+		return ReasonHelperMissing
+	case errors.Is(err, ErrHelperBlocked):
+		return ReasonHelperBlocked
+	case errors.Is(err, ErrHelperIncompatible):
+		return ReasonHelperIncompatible
+	case errors.Is(err, ErrHelperPartial):
+		return ReasonPartialAgentData
+	case errors.Is(err, ErrHelperOutputLimit), errors.Is(err, ErrStderrLimit):
+		return ReasonOutputLimit
+	case errors.Is(err, ErrHelperRequestBounds):
+		return ReasonOutputLimit
+	case errors.Is(err, context.DeadlineExceeded), errors.Is(err, context.Canceled):
+		return ReasonRefreshTimeout
+	case errors.Is(err, ErrInvalidHelperPath), errors.Is(err, ErrInvalidHelperArgs),
+		errors.Is(err, ErrInvalidAlias):
+		return ReasonHelperFailed
+	case errors.Is(err, ErrHelperFailed):
+		return ReasonInvalidData
+	default:
+		return classifyError(err)
+	}
+}
+
+// classifyLifecycleError keeps install/setup outcomes distinct from collection
+// failures so callers can accurately offer SFTP, consent, or repair actions.
+func classifyLifecycleError(err error) Reason {
+	switch {
+	case errors.Is(err, ErrUnsupportedHelperPlatform):
+		return ReasonHelperUnsupported
+	case errors.Is(err, ErrHelperMetadata), errors.Is(err, ErrHelperArtifact),
+		errors.Is(err, ErrHelperVerification):
+		return ReasonHelperVerification
+	case errors.Is(err, ErrHelperNoExec):
+		return ReasonHelperBlocked
+	case errors.Is(err, ErrHelperRevoked):
+		return ReasonHelperRevoked
+	case errors.Is(err, ErrHelperConsentRequired), errors.Is(err, ErrHelperUpgradeRequired),
+		errors.Is(err, ErrHelperIncompatible):
+		return ReasonHelperUpgrade
+	case errors.Is(err, ErrHelperRollback):
+		return ReasonHelperRollback
+	case errors.Is(err, ErrHelperInstallation):
+		return ReasonHelperInstallation
+	default:
+		return classifyHelperError(err)
+	}
+}
+
+func helperErrorCopy(reason Reason) string {
+	switch reason {
+	case ReasonHelperMissing:
+		return "collection helper is not installed"
+	case ReasonHelperBlocked:
+		return "collection helper cannot be executed"
+	case ReasonHelperIncompatible:
+		return "collection helper needs an upgrade"
+	case ReasonHelperFailed:
+		return "collection helper failed"
+	case ReasonOutputLimit:
+		return "helper output exceeded safety limits"
+	case ReasonHelperUnsupported:
+		return "remote platform cannot run the collection helper"
+	case ReasonHelperVerification:
+		return "collection helper could not be verified"
+	case ReasonHelperInstallation:
+		return "collection helper could not be installed"
+	case ReasonHelperRevoked:
+		return "collection helper was revoked and will not run"
+	case ReasonHelperUpgrade:
+		return "collection helper needs an approved upgrade"
+	case ReasonHelperRollback:
+		return "collection helper upgrade was rolled back"
+	default:
+		return genericErrorCopy(reason)
+	}
+}

--- a/collector/internal/remote/lifecycle.go
+++ b/collector/internal/remote/lifecycle.go
@@ -1,0 +1,657 @@
+package remote
+
+// This file deliberately keeps helper lifecycle operations behind a small
+// remote boundary.  An SSH/SFTP implementation must perform that boundary's
+// filesystem operations relative to a trusted directory descriptor with
+// no-follow semantics.  A sequence of remote shell `test`, `mv`, and `rm`
+// commands is not an acceptable implementation: it leaves a check/use race.
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"regexp"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/centauri-ai/coslash/collector/internal/remotefacts"
+	"github.com/centauri-ai/coslash/collector/internal/remoteprotocol"
+)
+
+const (
+	// HelperInstallBase is the only remote directory lifecycle code may touch.
+	// It is user-owned and versioned, so a failed update cannot replace a known
+	// working helper.  A noexec mount is a deliberate SFTP fallback, not a
+	// reason to try a privileged or alternate installation location.
+	HelperInstallBase            = "~/.local/lib/coslash/helpers"
+	HelperFileName               = "coslash-helper"
+	MaxHelperArtifactBytes int64 = 128 << 20
+)
+
+var (
+	ErrUnsupportedHelperPlatform = errors.New("unsupported helper platform")
+	ErrHelperConsentRequired     = errors.New("helper install or upgrade requires consent")
+	ErrHelperMetadata            = errors.New("helper release metadata is not trusted")
+	ErrHelperArtifact            = errors.New("helper artifact is invalid")
+	ErrHelperVerification        = errors.New("helper verification failed")
+	ErrHelperInstallation        = errors.New("helper installation failed")
+	ErrHelperNoExec              = errors.New("helper install directory is not executable")
+	ErrHelperRevoked             = errors.New("helper artifact is revoked")
+	ErrHelperUpgradeRequired     = errors.New("helper upgrade requires consent")
+	ErrHelperRollback            = errors.New("helper activation was rolled back")
+	ErrUnknownHelperPath         = errors.New("helper path is outside the approved install layout")
+	ErrHelperMetadataRollback    = errors.New("helper release metadata is older than previously accepted metadata")
+	ErrHelperMetadataExpired     = errors.New("helper release metadata has expired")
+)
+
+var helperVersionPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
+
+// Platform is deliberately derived only from the bounded, fixed platform
+// probe.  OS and architecture aliases are normalized before artifact lookup.
+type Platform struct {
+	OS   string
+	Arch string
+	UID  uint32
+}
+
+func normalizePlatform(osName, arch string) (Platform, error) {
+	osName = strings.ToLower(strings.TrimSpace(osName))
+	arch = strings.ToLower(strings.TrimSpace(arch))
+	if osName != "linux" {
+		return Platform{}, fmt.Errorf("%w: %s", ErrUnsupportedHelperPlatform, osName)
+	}
+	switch arch {
+	case "x86_64", "amd64":
+		arch = "amd64"
+	case "aarch64", "arm64":
+		arch = "arm64"
+	default:
+		return Platform{}, fmt.Errorf("%w: linux/%s", ErrUnsupportedHelperPlatform, arch)
+	}
+	return Platform{OS: osName, Arch: arch}, nil
+}
+
+// ParsePlatformProbe accepts the three lines produced by the fixed remote
+// command `uname -s; uname -m; id -u`.  Keeping this parser narrow prevents a
+// login banner or arbitrary command output from selecting an artifact.
+func ParsePlatformProbe(output string) (Platform, error) {
+	if len(output) > 128 {
+		return Platform{}, fmt.Errorf("%w: platform probe output too long", ErrUnsupportedHelperPlatform)
+	}
+	lines := strings.Fields(output)
+	if len(lines) != 3 {
+		return Platform{}, fmt.Errorf("%w: malformed platform probe", ErrUnsupportedHelperPlatform)
+	}
+	platform, err := normalizePlatform(lines[0], lines[1])
+	if err != nil {
+		return Platform{}, err
+	}
+	var uid uint64
+	for _, character := range lines[2] {
+		if character < '0' || character > '9' {
+			return Platform{}, fmt.Errorf("%w: malformed uid", ErrUnsupportedHelperPlatform)
+		}
+		uid = uid*10 + uint64(character-'0')
+		if uid > uint64(^uint32(0)) {
+			return Platform{}, fmt.Errorf("%w: uid out of range", ErrUnsupportedHelperPlatform)
+		}
+	}
+	platform.UID = uint32(uid)
+	return platform, nil
+}
+
+// Artifact is one executable, never an archive.  Its digest therefore covers
+// exactly the file that is uploaded and later executed.
+type Artifact struct {
+	Version  string                      `json:"version"`
+	OS       string                      `json:"os"`
+	Arch     string                      `json:"arch"`
+	Size     int64                       `json:"size"`
+	SHA256   string                      `json:"sha256"`
+	Protocol remoteprotocol.VersionRange `json:"protocol"`
+	Schema   remoteprotocol.VersionRange `json:"schema"`
+	// Current identifies the one artifact selected for a platform. Older
+	// non-revoked entries remain only for the supported deprecated window.
+	Current bool `json:"current,omitempty"`
+	Revoked bool `json:"revoked,omitempty"`
+}
+
+type ReleaseMetadata struct {
+	Sequence      uint64     `json:"sequence"`
+	ExpiresAtUnix int64      `json:"expires_at_unix"`
+	Artifacts     []Artifact `json:"artifacts"`
+}
+
+// SignedReleaseMetadata is the release document fetched by the app.  The
+// release pipeline signs canonicalMetadataPayload(metadata), not transport
+// formatting, so whitespace or object-key ordering cannot affect verification.
+type SignedReleaseMetadata struct {
+	KeyID     string          `json:"key_id"`
+	Metadata  ReleaseMetadata `json:"metadata"`
+	Signature string          `json:"signature"`
+}
+
+// TrustStore is compiled into the Mac application.  Shipping a replacement
+// app can add a key during rotation; a signed document can revoke artifacts,
+// while a compiled revoked key is never accepted even if a stale document uses
+// it.
+type TrustStore struct {
+	Keys            map[string]ed25519.PublicKey
+	RevokedKeys     map[string]bool
+	MinimumSequence uint64
+	Now             func() time.Time
+	Sequences       MetadataSequenceStore
+}
+
+// MetadataSequenceStore durably remembers the newest authenticated release
+// sequence. Accept must allow the same sequence again and reject lower values.
+// This closes the replay hole that signatures alone cannot address.
+type MetadataSequenceStore interface {
+	Accept(uint64) error
+}
+
+// MemoryMetadataSequenceStore is useful for one-process callers and tests.
+// Production callers should use FileMetadataSequenceStore.
+type MemoryMetadataSequenceStore struct {
+	mu      sync.Mutex
+	highest uint64
+}
+
+func (store *MemoryMetadataSequenceStore) Accept(sequence uint64) error {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if sequence < store.highest {
+		return ErrHelperMetadataRollback
+	}
+	store.highest = sequence
+	return nil
+}
+
+func (trust TrustStore) Verify(document SignedReleaseMetadata) (ReleaseMetadata, error) {
+	if !validMetadataID(document.KeyID) || trust.RevokedKeys[document.KeyID] {
+		return ReleaseMetadata{}, ErrHelperMetadata
+	}
+	key := trust.Keys[document.KeyID]
+	if len(key) != ed25519.PublicKeySize {
+		return ReleaseMetadata{}, ErrHelperMetadata
+	}
+	signature, err := base64.StdEncoding.DecodeString(document.Signature)
+	if err != nil || len(signature) != ed25519.SignatureSize ||
+		!ed25519.Verify(key, canonicalMetadataPayload(document.Metadata), signature) {
+		return ReleaseMetadata{}, ErrHelperMetadata
+	}
+	if err := document.Metadata.Validate(); err != nil {
+		return ReleaseMetadata{}, fmt.Errorf("%w: %v", ErrHelperMetadata, err)
+	}
+	now := time.Now()
+	if trust.Now != nil {
+		now = trust.Now()
+	}
+	if document.Metadata.ExpiresAtUnix <= now.Unix() {
+		return ReleaseMetadata{}, fmt.Errorf("%w: %w", ErrHelperMetadata, ErrHelperMetadataExpired)
+	}
+	if document.Metadata.Sequence < trust.MinimumSequence {
+		return ReleaseMetadata{}, fmt.Errorf("%w: %w", ErrHelperMetadata, ErrHelperMetadataRollback)
+	}
+	if trust.Sequences == nil {
+		return ReleaseMetadata{}, fmt.Errorf("%w: metadata sequence store is required", ErrHelperMetadata)
+	}
+	if err := trust.Sequences.Accept(document.Metadata.Sequence); err != nil {
+		return ReleaseMetadata{}, fmt.Errorf("%w: %w", ErrHelperMetadata, err)
+	}
+	return document.Metadata, nil
+}
+
+func canonicalMetadataPayload(metadata ReleaseMetadata) []byte {
+	artifacts := slices.Clone(metadata.Artifacts)
+	sort.Slice(artifacts, func(i, j int) bool {
+		return artifactIdentity(artifacts[i]) < artifactIdentity(artifacts[j])
+	})
+	payload, _ := json.Marshal(ReleaseMetadata{Artifacts: artifacts})
+	return payload
+}
+
+func (metadata ReleaseMetadata) Validate() error {
+	if metadata.Sequence == 0 || metadata.ExpiresAtUnix <= 0 {
+		return errors.New("invalid metadata sequence or expiry")
+	}
+	if len(metadata.Artifacts) == 0 || len(metadata.Artifacts) > 32 {
+		return errors.New("invalid artifact count")
+	}
+	seen := map[string]bool{}
+	platforms := map[string]bool{}
+	platformCount := map[string]int{}
+	current := map[string]int{}
+	for _, artifact := range metadata.Artifacts {
+		if err := artifact.Validate(); err != nil {
+			return err
+		}
+		identity := artifactIdentity(artifact)
+		if seen[identity] {
+			return errors.New("duplicate artifact")
+		}
+		seen[identity] = true
+		platform := artifact.OS + "/" + artifact.Arch
+		platforms[platform] = true
+		platformCount[platform]++
+		if platformCount[platform] > 2 {
+			return fmt.Errorf("%s exceeds the current-plus-previous support window", platform)
+		}
+		if artifact.Current {
+			current[platform]++
+		}
+	}
+	for platform := range platforms {
+		count := current[platform]
+		if count != 1 {
+			return fmt.Errorf("%s has %d current artifacts", platform, count)
+		}
+	}
+	if len(current) == 0 {
+		return errors.New("metadata has no current artifact")
+	}
+	return nil
+}
+
+// HelperPlatformArgs builds the fixed, bounded platform probe. Unlike helper
+// execution, it contains no remote path or caller-provided command text.
+func HelperPlatformArgs(alias string, connectTimeoutSeconds int) ([]string, error) {
+	if !aliasPattern.MatchString(alias) {
+		return nil, ErrInvalidAlias
+	}
+	if connectTimeoutSeconds <= 0 {
+		connectTimeoutSeconds = int(DefaultConnectTimeout.Seconds())
+	}
+	return []string{
+		"-T",
+		"-o", "BatchMode=yes",
+		"-o", "ConnectTimeout=" + strconv.Itoa(connectTimeoutSeconds),
+		"-o", "ControlMaster=auto",
+		"-o", "ControlPath=" + controlSocketPath(),
+		"-o", "ControlPersist=" + defaultControlPersist,
+		alias,
+		"uname -s; uname -m; id -u",
+	}, nil
+}
+
+func (artifact Artifact) Validate() error {
+	if !helperVersionPattern.MatchString(artifact.Version) || artifact.Size <= 0 || artifact.Size > MaxHelperArtifactBytes ||
+		len(artifact.SHA256) != sha256.Size*2 || !validSHA256(artifact.SHA256) {
+		return errors.New("invalid artifact identity")
+	}
+	platform, err := normalizePlatform(artifact.OS, artifact.Arch)
+	if err != nil || platform.OS != artifact.OS || platform.Arch != artifact.Arch {
+		return errors.New("invalid artifact platform")
+	}
+	if !supports(artifact.Protocol, remoteprotocol.ProtocolVersion) ||
+		!supports(artifact.Schema, remotefacts.SchemaVersion) {
+		return errors.New("artifact does not support this protocol/schema")
+	}
+	return nil
+}
+
+func validSHA256(value string) bool {
+	_, err := hex.DecodeString(value)
+	return err == nil
+}
+
+func validMetadataID(value string) bool {
+	return len(value) > 0 && len(value) <= 64 && helperVersionPattern.MatchString(value)
+}
+
+func artifactIdentity(artifact Artifact) string {
+	return artifact.Version + "/" + artifact.OS + "/" + artifact.Arch
+}
+
+func supports(range_ remoteprotocol.VersionRange, version int) bool {
+	return range_.Min > 0 && range_.Max >= range_.Min && range_.Min <= version && version <= range_.Max
+}
+
+func (metadata ReleaseMetadata) Select(platform Platform) (Artifact, error) {
+	for _, artifact := range metadata.Artifacts {
+		if artifact.OS == platform.OS && artifact.Arch == platform.Arch && artifact.Current {
+			if artifact.Revoked {
+				return Artifact{}, ErrHelperRevoked
+			}
+			return artifact, nil
+		}
+	}
+	return Artifact{}, fmt.Errorf("%w: %s/%s", ErrUnsupportedHelperPlatform, platform.OS, platform.Arch)
+}
+
+func helperPath(version string) (string, error) {
+	if !helperVersionPattern.MatchString(version) {
+		return "", ErrUnknownHelperPath
+	}
+	return HelperInstallBase + "/" + version + "/" + HelperFileName, nil
+}
+
+func helperTemporaryPath(version string) (string, error) {
+	path, err := helperPath(version)
+	if err != nil {
+		return "", err
+	}
+	return path + ".new", nil
+}
+
+// RemoteFile is evidence returned by a secure remote endpoint.  The endpoint
+// obtains it through no-follow, descriptor-relative inspection, both before
+// and after activation; callers must not substitute pathname checks.
+type RemoteFile struct {
+	Path    string
+	Size    int64
+	SHA256  string
+	Mode    fs.FileMode
+	UID     uint32
+	Regular bool
+}
+
+// InstallRequest contains only app-derived paths and locally verified bytes.
+// Temporary is an exact sibling of Destination; it is not caller supplied.
+type InstallRequest struct {
+	Artifact    Artifact
+	Bytes       []byte
+	Destination string
+	Temporary   string
+	OwnerUID    uint32
+}
+
+// LifecycleRemote is implemented by the SSH/transfer boundary.  Every path
+// argument has already passed helperPath. Implementations MUST use no-follow,
+// directory-relative operations rooted at HelperInstallBase; reject symlinked,
+// foreign-owned, or group/world-writable components; upload with O_EXCL; and
+// atomically rename Temporary to Destination only after verifying the exact
+// bytes. RemoveExact must remove only Destination (and an empty exact version
+// directory), never the base or unrelated versions.
+type LifecycleRemote interface {
+	ProbePlatform(context.Context) (Platform, error)
+	Inspect(context.Context, string) (RemoteFile, error)
+	Install(context.Context, InstallRequest) (RemoteFile, error)
+	RemoveExact(context.Context, string) error
+	Capabilities(context.Context, string) (remoteprotocol.Capabilities, error)
+}
+
+type Consent struct {
+	Install bool
+	Upgrade bool
+}
+
+type LifecycleState string
+
+const (
+	LifecycleSFTP              LifecycleState = "sftp"
+	LifecycleReady             LifecycleState = "ready"
+	LifecycleDeprecated        LifecycleState = "deprecated"
+	LifecycleUpgradeRequired   LifecycleState = "upgrade_required"
+	LifecycleUnsupported       LifecycleState = "unsupported"
+	LifecycleRevoked           LifecycleState = "revoked"
+	LifecycleVerificationError LifecycleState = "verification_failed"
+)
+
+// LifecycleResult is intentionally transport-neutral for T05. SFTP is always
+// usable when Ready is false, and CanExecute is false for revoked/incompatible
+// or unverified files, so callers never accidentally execute one of them.
+type LifecycleResult struct {
+	State      LifecycleState
+	Path       string
+	Artifact   Artifact
+	CanExecute bool
+	Fallback   bool
+	Reason     error
+}
+
+type compatibleHelper struct {
+	path     string
+	artifact Artifact
+}
+
+type Lifecycle struct {
+	Remote LifecycleRemote
+	Trust  TrustStore
+}
+
+// Setup authenticates metadata before platform lookup or any remote mutation.
+// Consent is per action: initial install and later upgrades are separate, so an
+// old consent cannot silently install fresh executable code.
+func (lifecycle Lifecycle) Setup(ctx context.Context, document SignedReleaseMetadata, artifactBytes []byte, consent Consent) LifecycleResult {
+	metadata, err := lifecycle.Trust.Verify(document)
+	if err != nil {
+		return lifecycleFailure(LifecycleVerificationError, err)
+	}
+	if lifecycle.Remote == nil {
+		return lifecycleFailure(LifecycleVerificationError, ErrHelperInstallation)
+	}
+	platform, err := lifecycle.Remote.ProbePlatform(ctx)
+	if err != nil {
+		if errors.Is(err, ErrUnsupportedHelperPlatform) {
+			return lifecycleFailure(LifecycleUnsupported, err)
+		}
+		return lifecycleFailure(LifecycleSFTP, err)
+	}
+	normalized, err := normalizePlatform(platform.OS, platform.Arch)
+	if err != nil {
+		return lifecycleFailure(LifecycleUnsupported, err)
+	}
+	normalized.UID = platform.UID
+	platform = normalized
+	artifact, err := metadata.Select(platform)
+	if err != nil {
+		state := LifecycleUnsupported
+		if errors.Is(err, ErrHelperRevoked) {
+			state = LifecycleRevoked
+		}
+		return lifecycleFailure(state, err)
+	}
+	target, _ := helperPath(artifact.Version)
+	current, currentErr := lifecycle.Remote.Inspect(ctx, target)
+	if currentErr == nil {
+		if err := verifyRemoteFile(current, target, artifact, platform.UID); err == nil {
+			result := lifecycle.capabilityResult(ctx, target, artifact, LifecycleReady)
+			if result.CanExecute || !errors.Is(result.Reason, ErrHelperIncompatible) {
+				return result
+			}
+			currentErr = ErrHelperIncompatible
+		} else {
+			currentErr = ErrHelperVerification
+		}
+	} else if !errors.Is(currentErr, fs.ErrNotExist) {
+		return lifecycleFailure(LifecycleSFTP, currentErr)
+	}
+
+	// A non-current known artifact may remain executable only if it appears in
+	// this signed manifest, is non-revoked, and verifies exactly.  T05 can show
+	// this as a visible upgrade prompt while continuing useful collection.
+	var previous *compatibleHelper
+	for _, older := range metadata.Artifacts {
+		if older.OS != platform.OS || older.Arch != platform.Arch || older.Version == artifact.Version {
+			continue
+		}
+		path, _ := helperPath(older.Version)
+		file, err := lifecycle.Remote.Inspect(ctx, path)
+		if err != nil {
+			continue
+		}
+		if older.Revoked {
+			// A revoked previous helper is never executed, but it must not block
+			// installation of the authenticated non-revoked current artifact.
+			continue
+		}
+		if verifyRemoteFile(file, path, older, platform.UID) == nil {
+			candidate := lifecycle.capabilityResult(ctx, path, older, LifecycleDeprecated)
+			if !candidate.CanExecute {
+				if !errors.Is(candidate.Reason, ErrHelperIncompatible) {
+					return candidate
+				}
+				continue
+			}
+			previous = &compatibleHelper{path: path, artifact: older}
+			if consent.Upgrade {
+				break
+			}
+			candidate.Reason = ErrHelperUpgradeRequired
+			return candidate
+		}
+	}
+
+	// A missing target is an initial installation. A target that exists but
+	// failed verification is a repair/upgrade and needs fresh upgrade consent.
+	initialInstall := errors.Is(currentErr, fs.ErrNotExist) && previous == nil
+	if (initialInstall && !consent.Install) || (!initialInstall && !consent.Upgrade) {
+		return lifecycleFailure(LifecycleUpgradeRequired, ErrHelperConsentRequired)
+	}
+	if err := verifyLocalArtifact(artifact, artifactBytes); err != nil {
+		return lifecycleFailure(LifecycleVerificationError, err)
+	}
+	temporary, _ := helperTemporaryPath(artifact.Version)
+	installed, err := lifecycle.Remote.Install(ctx, InstallRequest{
+		Artifact: artifact, Bytes: slices.Clone(artifactBytes), Destination: target,
+		Temporary: temporary, OwnerUID: platform.UID,
+	})
+	if err != nil {
+		if previous != nil {
+			return rollbackResult(*previous, err)
+		}
+		return lifecycleFailure(LifecycleSFTP, classifyLifecycleInstallError(err))
+	}
+	if err := verifyRemoteFile(installed, target, artifact, platform.UID); err != nil {
+		_ = lifecycle.Remote.RemoveExact(ctx, target)
+		if previous != nil {
+			return rollbackResult(*previous, err)
+		}
+		return lifecycleFailure(LifecycleVerificationError, err)
+	}
+	result := lifecycle.capabilityResult(ctx, target, artifact, LifecycleReady)
+	if result.CanExecute {
+		return result
+	}
+	_ = lifecycle.Remote.RemoveExact(ctx, target)
+	if previous != nil {
+		return rollbackResult(*previous, result.Reason)
+	}
+	return result
+}
+
+func (lifecycle Lifecycle) capabilityResult(ctx context.Context, path string, artifact Artifact, state LifecycleState) LifecycleResult {
+	capabilities, err := lifecycle.Remote.Capabilities(ctx, path)
+	if err != nil {
+		if errors.Is(err, ErrHelperIncompatible) {
+			return lifecycleFailure(LifecycleUpgradeRequired, ErrHelperIncompatible)
+		}
+		return lifecycleFailure(LifecycleSFTP, err)
+	}
+	if capabilities.Validate() != nil || !capabilities.Compatible() ||
+		capabilities.OS != artifact.OS || capabilities.Arch != artifact.Arch ||
+		!supports(artifact.Protocol, remoteprotocol.ProtocolVersion) || !supports(artifact.Schema, remotefacts.SchemaVersion) {
+		return lifecycleFailure(LifecycleUpgradeRequired, ErrHelperIncompatible)
+	}
+	return LifecycleResult{State: state, Path: path, Artifact: artifact, CanExecute: true}
+}
+
+func rollbackResult(previous compatibleHelper, cause error) LifecycleResult {
+	return LifecycleResult{
+		State: LifecycleDeprecated, Path: previous.path, Artifact: previous.artifact,
+		CanExecute: true, Reason: fmt.Errorf("%w: %v", ErrHelperRollback, cause),
+	}
+}
+
+func lifecycleFailure(state LifecycleState, reason error) LifecycleResult {
+	return LifecycleResult{State: state, Fallback: true, Reason: reason}
+}
+
+func classifyLifecycleInstallError(err error) error {
+	switch {
+	case errors.Is(err, ErrHelperNoExec), errors.Is(err, ErrHelperRollback):
+		return err
+	default:
+		return fmt.Errorf("%w: %v", ErrHelperInstallation, err)
+	}
+}
+
+func verifyLocalArtifact(artifact Artifact, content []byte) error {
+	if int64(len(content)) != artifact.Size || digest(content) != artifact.SHA256 {
+		return ErrHelperArtifact
+	}
+	return verifyELF(content, artifact.Arch)
+}
+
+func verifyRemoteFile(file RemoteFile, path string, artifact Artifact, uid uint32) error {
+	if file.Path != path || !file.Regular || file.Size != artifact.Size || file.SHA256 != artifact.SHA256 ||
+		file.UID != uid || file.Mode.Perm() != 0o700 || file.Mode&(fs.ModeSymlink|fs.ModeSetuid|fs.ModeSetgid) != 0 {
+		return ErrHelperVerification
+	}
+	return nil
+}
+
+func verifyELF(content []byte, arch string) error {
+	// ELF's fixed little-endian header prefix is enough for the supported Go
+	// binaries.  Parsing it directly also avoids accepting a script merely
+	// because it is executable. Linux amd64 and arm64 releases are ELF64 LE.
+	if len(content) < 20 || !bytes.Equal(content[:4], []byte{0x7f, 'E', 'L', 'F'}) ||
+		content[4] != 2 || content[5] != 1 {
+		return ErrHelperArtifact
+	}
+	type_ := binary.LittleEndian.Uint16(content[16:18])
+	if type_ != 2 && type_ != 3 { // ET_EXEC or ET_DYN (PIE)
+		return ErrHelperArtifact
+	}
+	want := uint16(62) // EM_X86_64
+	if arch == "arm64" {
+		want = 183 // EM_AARCH64
+	}
+	if binary.LittleEndian.Uint16(content[18:20]) != want {
+		return ErrHelperArtifact
+	}
+	return nil
+}
+
+func digest(content []byte) string {
+	sum := sha256.Sum256(content)
+	return hex.EncodeToString(sum[:])
+}
+
+// Uninstall authenticates the release document and probes the platform before
+// deriving an exact known artifact path. Revoked artifacts remain removable.
+func (lifecycle Lifecycle) Uninstall(ctx context.Context, document SignedReleaseMetadata, version string) error {
+	if lifecycle.Remote == nil {
+		return ErrHelperInstallation
+	}
+	metadata, err := lifecycle.Trust.Verify(document)
+	if err != nil {
+		return err
+	}
+	platform, err := lifecycle.Remote.ProbePlatform(ctx)
+	if err != nil {
+		return err
+	}
+	normalized, err := normalizePlatform(platform.OS, platform.Arch)
+	if err != nil {
+		return err
+	}
+	known := false
+	for _, artifact := range metadata.Artifacts {
+		if artifact.Version == version && artifact.OS == normalized.OS && artifact.Arch == normalized.Arch {
+			known = true
+			break
+		}
+	}
+	if !known {
+		return ErrUnknownHelperPath
+	}
+	path, err := helperPath(version)
+	if err != nil {
+		return err
+	}
+	return lifecycle.Remote.RemoveExact(ctx, path)
+}

--- a/collector/internal/remote/lifecycle.go
+++ b/collector/internal/remote/lifecycle.go
@@ -219,7 +219,11 @@ func canonicalMetadataPayload(metadata ReleaseMetadata) []byte {
 	sort.Slice(artifacts, func(i, j int) bool {
 		return artifactIdentity(artifacts[i]) < artifactIdentity(artifacts[j])
 	})
-	payload, _ := json.Marshal(ReleaseMetadata{Artifacts: artifacts})
+	payload, _ := json.Marshal(ReleaseMetadata{
+		Sequence:      metadata.Sequence,
+		ExpiresAtUnix: metadata.ExpiresAtUnix,
+		Artifacts:     artifacts,
+	})
 	return payload
 }
 

--- a/collector/internal/remote/lifecycle_metadata.go
+++ b/collector/internal/remote/lifecycle_metadata.go
@@ -1,0 +1,98 @@
+package remote
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// FileMetadataSequenceStore persists the highest authenticated metadata
+// sequence. The containing directory and file are private to the local user;
+// replacement is atomic so interruption cannot lower the remembered value.
+type FileMetadataSequenceStore struct {
+	Path string
+	mu   sync.Mutex
+}
+
+func (store *FileMetadataSequenceStore) Accept(sequence uint64) error {
+	if store == nil || store.Path == "" || sequence == 0 {
+		return ErrHelperMetadataRollback
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	highest, err := readMetadataSequence(store.Path)
+	if err != nil {
+		return err
+	}
+	if sequence < highest {
+		return ErrHelperMetadataRollback
+	}
+	if sequence == highest {
+		return nil
+	}
+	directory := filepath.Dir(store.Path)
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		return fmt.Errorf("create metadata sequence directory: %w", err)
+	}
+	if err := os.Chmod(directory, 0o700); err != nil {
+		return fmt.Errorf("secure metadata sequence directory: %w", err)
+	}
+	temporary, err := os.CreateTemp(directory, ".helper-metadata-sequence-*")
+	if err != nil {
+		return fmt.Errorf("create metadata sequence temporary file: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	if err := temporary.Chmod(0o600); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if _, err := temporary.WriteString(strconv.FormatUint(sequence, 10) + "\n"); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Sync(); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(temporaryPath, store.Path); err != nil {
+		return fmt.Errorf("commit metadata sequence: %w", err)
+	}
+	dir, err := os.Open(directory)
+	if err != nil {
+		return err
+	}
+	syncErr := dir.Sync()
+	closeErr := dir.Close()
+	return errors.Join(syncErr, closeErr)
+}
+
+func readMetadataSequence(path string) (uint64, error) {
+	content, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("read metadata sequence: %w", err)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return 0, err
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 || len(content) > 32 {
+		return 0, fmt.Errorf("%w: invalid local sequence state", ErrHelperMetadata)
+	}
+	sequence, err := strconv.ParseUint(strings.TrimSpace(string(content)), 10, 64)
+	if err != nil || sequence == 0 {
+		return 0, fmt.Errorf("%w: invalid local sequence state", ErrHelperMetadata)
+	}
+	return sequence, nil
+}

--- a/collector/internal/remote/lifecycle_metadata_test.go
+++ b/collector/internal/remote/lifecycle_metadata_test.go
@@ -1,0 +1,24 @@
+package remote
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileMetadataSequenceStorePersistsHighWaterMark(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state", "sequence")
+	store := &FileMetadataSequenceStore{Path: path}
+	if err := store.Accept(4); err != nil {
+		t.Fatal(err)
+	}
+	if err := (&FileMetadataSequenceStore{Path: path}).Accept(4); err != nil {
+		t.Fatalf("same sequence was not idempotent: %v", err)
+	}
+	if err := (&FileMetadataSequenceStore{Path: path}).Accept(3); !errors.Is(err, ErrHelperMetadataRollback) {
+		t.Fatalf("rollback error = %v", err)
+	}
+	if err := (&FileMetadataSequenceStore{Path: path}).Accept(5); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/collector/internal/remote/lifecycle_ssh.go
+++ b/collector/internal/remote/lifecycle_ssh.go
@@ -1,0 +1,368 @@
+package remote
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+
+	"github.com/centauri-ai/coslash/collector/internal/remoteprotocol"
+	"github.com/pkg/sftp"
+)
+
+const linuxStatVFSNoExec = 0x8
+
+// SSHLifecycleRemote is the production helper lifecycle adapter. It uses the
+// same bounded system-SSH and SFTP transport as remote collection.
+type SSHLifecycleRemote struct {
+	Alias   string
+	Options OpenOptions
+}
+
+func NewSSHLifecycleRemote(alias string, options OpenOptions) (*SSHLifecycleRemote, error) {
+	if !aliasPattern.MatchString(alias) {
+		return nil, ErrInvalidAlias
+	}
+	return &SSHLifecycleRemote{Alias: alias, Options: options}, nil
+}
+
+func (remote *SSHLifecycleRemote) ProbePlatform(ctx context.Context) (Platform, error) {
+	limits := remote.Options.Limits.withDefaults()
+	args, err := HelperPlatformArgs(remote.Alias, int(limits.ConnectTimeout.Seconds()))
+	if err != nil {
+		return Platform{}, err
+	}
+	if remote.Options.command == nil {
+		if err := ensureControlMaster(ctx, remote.Alias, remote.Options); err != nil {
+			return Platform{}, err
+		}
+	}
+	bin := remote.Options.SSHBin
+	if bin == "" {
+		bin = "ssh"
+	}
+	command := remote.Options.command
+	if command == nil {
+		command = exec.CommandContext
+	}
+	runCtx, cancel := context.WithTimeout(ctx, limits.ConnectTimeout)
+	defer cancel()
+	cmd := command(runCtx, bin, args...)
+	stdout := &boundedCommandOutput{limit: 128, cancel: cancel}
+	stderr := &boundedCommandOutput{limit: limits.MaxStderrBytes, cancel: cancel}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		if stdout.overflow {
+			return Platform{}, fmt.Errorf("%w: platform probe output too long", ErrUnsupportedHelperPlatform)
+		}
+		if stderr.overflow {
+			return Platform{}, ErrStderrLimit
+		}
+		if runCtx.Err() != nil {
+			return Platform{}, runCtx.Err()
+		}
+		return Platform{}, wrapSSHError(fmt.Errorf("probe helper platform: %w", err), stderr.String())
+	}
+	if stdout.overflow {
+		return Platform{}, fmt.Errorf("%w: platform probe output too long", ErrUnsupportedHelperPlatform)
+	}
+	return ParsePlatformProbe(stdout.String())
+}
+
+func (remote *SSHLifecycleRemote) Inspect(ctx context.Context, requested string) (RemoteFile, error) {
+	var result RemoteFile
+	err := remote.withSession(ctx, func(session *Session) error {
+		absolute, version, err := resolveLifecyclePath(session.source.Home(), requested)
+		if err != nil {
+			return err
+		}
+		if err := validateLifecycleDirectories(session.client, session.source.Home(), version, 0, false); err != nil {
+			return err
+		}
+		result, err = inspectLifecycleFile(session.client, absolute, requested)
+		return err
+	})
+	return result, err
+}
+
+func (remote *SSHLifecycleRemote) Install(ctx context.Context, request InstallRequest) (RemoteFile, error) {
+	if err := verifyLocalArtifact(request.Artifact, request.Bytes); err != nil {
+		return RemoteFile{}, err
+	}
+	wantDestination, err := helperPath(request.Artifact.Version)
+	if err != nil || request.Destination != wantDestination || request.Temporary != wantDestination+".new" {
+		return RemoteFile{}, ErrUnknownHelperPath
+	}
+	var installed RemoteFile
+	err = remote.withSession(ctx, func(session *Session) error {
+		destination, version, err := resolveLifecyclePath(session.source.Home(), request.Destination)
+		if err != nil {
+			return err
+		}
+		temporary := destination + ".new"
+		if err := validateLifecycleDirectories(session.client, session.source.Home(), version, request.OwnerUID, true); err != nil {
+			return err
+		}
+		vfs, err := session.client.StatVFS(path.Dir(destination))
+		if err != nil {
+			return fmt.Errorf("inspect helper filesystem: %w", err)
+		}
+		if vfs.Flag&linuxStatVFSNoExec != 0 {
+			return ErrHelperNoExec
+		}
+		if err := removeStaleLifecycleTemporary(session.client, temporary, request.OwnerUID); err != nil {
+			return err
+		}
+		file, err := session.client.OpenFile(temporary, os.O_WRONLY|os.O_CREATE|os.O_EXCL)
+		if err != nil {
+			return fmt.Errorf("create helper temporary: %w", err)
+		}
+		writeErr := writeLifecycleArtifact(file, request.Bytes)
+		closeErr := file.Close()
+		if err := errors.Join(writeErr, closeErr); err != nil {
+			_ = session.client.Remove(temporary)
+			return fmt.Errorf("write helper temporary: %w", err)
+		}
+		temporaryInfo, err := inspectLifecycleFile(session.client, temporary, request.Temporary)
+		if err != nil {
+			_ = session.client.Remove(temporary)
+			return err
+		}
+		if err := verifyRemoteFile(temporaryInfo, request.Temporary, request.Artifact, request.OwnerUID); err != nil {
+			_ = session.client.Remove(temporary)
+			return err
+		}
+		if existing, err := session.client.Lstat(destination); err == nil {
+			if err := validateLifecycleEntry(existing, request.OwnerUID, false); err != nil {
+				_ = session.client.Remove(temporary)
+				return err
+			}
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			_ = session.client.Remove(temporary)
+			return err
+		}
+		if err := session.client.PosixRename(temporary, destination); err != nil {
+			_ = session.client.Remove(temporary)
+			return fmt.Errorf("activate helper atomically: %w", err)
+		}
+		installed, err = inspectLifecycleFile(session.client, destination, request.Destination)
+		return err
+	})
+	return installed, err
+}
+
+func (remote *SSHLifecycleRemote) RemoveExact(ctx context.Context, requested string) error {
+	return remote.withSession(ctx, func(session *Session) error {
+		absolute, version, err := resolveLifecyclePath(session.source.Home(), requested)
+		if err != nil {
+			return err
+		}
+		if err := validateLifecycleDirectories(session.client, session.source.Home(), version, 0, false); err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
+			return err
+		}
+		info, err := session.client.Lstat(absolute)
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		ownerUID, err := lifecycleHomeUID(session.client, session.source.Home())
+		if err != nil {
+			return err
+		}
+		if err := validateLifecycleEntry(info, ownerUID, false); err != nil {
+			return err
+		}
+		if err := session.client.Remove(absolute); err != nil {
+			return fmt.Errorf("remove exact helper: %w", err)
+		}
+		if err := session.client.RemoveDirectory(path.Dir(absolute)); err != nil && !strings.Contains(strings.ToLower(err.Error()), "not empty") {
+			return fmt.Errorf("remove empty helper version directory: %w", err)
+		}
+		return nil
+	})
+}
+
+func (remote *SSHLifecycleRemote) Capabilities(ctx context.Context, helperPath string) (remoteprotocol.Capabilities, error) {
+	capabilities, _, err := HelperCapabilities(ctx, remote.Alias, helperPath, remote.Options)
+	return capabilities, err
+}
+
+func (remote *SSHLifecycleRemote) withSession(ctx context.Context, operation func(*Session) error) error {
+	options := remote.Options
+	options.lifecycleOnly = true
+	session, err := OpenSession(ctx, remote.Alias, options)
+	if err != nil {
+		return err
+	}
+	operationErr := operation(session)
+	closeErr := session.Close()
+	return errors.Join(operationErr, closeErr)
+}
+
+func resolveLifecyclePath(home, requested string) (string, string, error) {
+	prefix := HelperInstallBase + "/"
+	if !strings.HasPrefix(requested, prefix) || strings.HasSuffix(requested, ".new") {
+		return "", "", ErrUnknownHelperPath
+	}
+	remaining := strings.TrimPrefix(requested, prefix)
+	version, fileName, ok := strings.Cut(remaining, "/")
+	if !ok || fileName != HelperFileName || !helperVersionPattern.MatchString(version) {
+		return "", "", ErrUnknownHelperPath
+	}
+	return path.Join(home, ".local/lib/coslash/helpers", version, HelperFileName), version, nil
+}
+
+func validateLifecycleDirectories(client *sftp.Client, home, version string, uid uint32, create bool) error {
+	directories := []string{home}
+	current := home
+	for _, component := range []string{".local", "lib", "coslash", "helpers", version} {
+		current = path.Join(current, component)
+		directories = append(directories, current)
+	}
+	for index, directory := range directories {
+		info, err := client.Lstat(directory)
+		if errors.Is(err, fs.ErrNotExist) && create && index > 0 {
+			if err := client.Mkdir(directory); err != nil {
+				return fmt.Errorf("create helper directory: %w", err)
+			}
+			if err := client.Chmod(directory, 0o700); err != nil {
+				return fmt.Errorf("secure helper directory: %w", err)
+			}
+			info, err = client.Lstat(directory)
+		}
+		if err != nil {
+			return err
+		}
+		if index == 0 && uid == 0 {
+			stat, ok := info.Sys().(*sftp.FileStat)
+			if !ok {
+				return ErrHelperVerification
+			}
+			uid = stat.UID
+		}
+		if err := validateLifecycleEntry(info, uid, true); err != nil {
+			return fmt.Errorf("unsafe helper directory %s: %w", directory, err)
+		}
+	}
+	return nil
+}
+
+func lifecycleHomeUID(client *sftp.Client, home string) (uint32, error) {
+	info, err := client.Lstat(home)
+	if err != nil {
+		return 0, err
+	}
+	stat, ok := info.Sys().(*sftp.FileStat)
+	if !ok {
+		return 0, ErrHelperVerification
+	}
+	return stat.UID, nil
+}
+
+func validateLifecycleEntry(info os.FileInfo, uid uint32, directory bool) error {
+	if info.Mode()&fs.ModeSymlink != 0 || info.IsDir() != directory || (!directory && !info.Mode().IsRegular()) || info.Mode().Perm()&0o022 != 0 {
+		return ErrHelperVerification
+	}
+	stat, ok := info.Sys().(*sftp.FileStat)
+	if !ok || (uid != 0 && stat.UID != uid) {
+		return ErrHelperVerification
+	}
+	return nil
+}
+
+func inspectLifecycleFile(client *sftp.Client, absolute, reported string) (RemoteFile, error) {
+	info, err := client.Lstat(absolute)
+	if err != nil {
+		return RemoteFile{}, err
+	}
+	if err := validateLifecycleEntry(info, 0, false); err != nil {
+		return RemoteFile{}, err
+	}
+	file, err := client.Open(absolute)
+	if err != nil {
+		return RemoteFile{}, err
+	}
+	hash := sha256.New()
+	_, copyErr := io.CopyN(hash, file, info.Size()+1)
+	if errors.Is(copyErr, io.EOF) {
+		copyErr = nil
+	}
+	closeErr := file.Close()
+	if err := errors.Join(copyErr, closeErr); err != nil {
+		return RemoteFile{}, err
+	}
+	stat, ok := info.Sys().(*sftp.FileStat)
+	if !ok {
+		return RemoteFile{}, ErrHelperVerification
+	}
+	return RemoteFile{
+		Path: reported, Size: info.Size(), SHA256: fmt.Sprintf("%x", hash.Sum(nil)),
+		Mode: info.Mode(), UID: stat.UID, Regular: info.Mode().IsRegular(),
+	}, nil
+}
+
+func removeStaleLifecycleTemporary(client *sftp.Client, temporary string, uid uint32) error {
+	info, err := client.Lstat(temporary)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if err := validateLifecycleEntry(info, uid, false); err != nil {
+		return err
+	}
+	return client.Remove(temporary)
+}
+
+func writeLifecycleArtifact(file *sftp.File, content []byte) error {
+	if _, err := io.Copy(file, bytes.NewReader(content)); err != nil {
+		return err
+	}
+	if err := file.Chmod(0o700); err != nil {
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		return err
+	}
+	return nil
+}
+
+type boundedCommandOutput struct {
+	buffer   bytes.Buffer
+	limit    int
+	overflow bool
+	cancel   context.CancelFunc
+}
+
+func (output *boundedCommandOutput) Write(data []byte) (int, error) {
+	if output.overflow {
+		return len(data), nil
+	}
+	remaining := output.limit - output.buffer.Len()
+	if len(data) > remaining {
+		if remaining > 0 {
+			_, _ = output.buffer.Write(data[:remaining])
+		}
+		output.overflow = true
+		output.cancel()
+		return len(data), nil
+	}
+	_, _ = output.buffer.Write(data)
+	return len(data), nil
+}
+
+func (output *boundedCommandOutput) String() string { return output.buffer.String() }

--- a/collector/internal/remote/lifecycle_ssh.go
+++ b/collector/internal/remote/lifecycle_ssh.go
@@ -11,13 +11,13 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"strconv"
 	"strings"
 
+	"github.com/centauri-ai/coslash/collector/internal/remoteinstall"
 	"github.com/centauri-ai/coslash/collector/internal/remoteprotocol"
 	"github.com/pkg/sftp"
 )
-
-const linuxStatVFSNoExec = 0x8
 
 // SSHLifecycleRemote is the production helper lifecycle adapter. It uses the
 // same bounded system-SSH and SFTP transport as remote collection.
@@ -103,60 +103,98 @@ func (remote *SSHLifecycleRemote) Install(ctx context.Context, request InstallRe
 	}
 	var installed RemoteFile
 	err = remote.withSession(ctx, func(session *Session) error {
-		destination, version, err := resolveLifecyclePath(session.source.Home(), request.Destination)
+		_, version, err := resolveLifecyclePath(session.source.Home(), request.Destination)
 		if err != nil {
 			return err
 		}
-		temporary := destination + ".new"
-		if err := validateLifecycleDirectories(session.client, session.source.Home(), version, request.OwnerUID, true); err != nil {
+		home := session.source.Home()
+		if err := validateLifecycleHome(session.client, home, request.OwnerUID); err != nil {
 			return err
 		}
-		vfs, err := session.client.StatVFS(path.Dir(destination))
-		if err != nil {
-			return fmt.Errorf("inspect helper filesystem: %w", err)
-		}
-		if vfs.Flag&linuxStatVFSNoExec != 0 {
-			return ErrHelperNoExec
-		}
-		if err := removeStaleLifecycleTemporary(session.client, temporary, request.OwnerUID); err != nil {
+		// The staging path is directly below the already-validated home directory.
+		// Activation itself happens in the staged, authenticated static helper using
+		// descriptor-relative openat/renameat calls; SFTP has no such primitive.
+		staging := path.Join(home, "."+HelperFileName+"-"+version+".stage")
+		if err := removeStaleLifecycleTemporary(session.client, staging, request.OwnerUID); err != nil {
 			return err
 		}
-		file, err := session.client.OpenFile(temporary, os.O_WRONLY|os.O_CREATE|os.O_EXCL)
+		file, err := session.client.OpenFile(staging, os.O_WRONLY|os.O_CREATE|os.O_EXCL)
 		if err != nil {
-			return fmt.Errorf("create helper temporary: %w", err)
+			return fmt.Errorf("create helper staging file: %w", err)
 		}
 		writeErr := writeLifecycleArtifact(file, request.Bytes)
 		closeErr := file.Close()
 		if err := errors.Join(writeErr, closeErr); err != nil {
-			_ = session.client.Remove(temporary)
-			return fmt.Errorf("write helper temporary: %w", err)
+			_ = session.client.Remove(staging)
+			return fmt.Errorf("write helper staging file: %w", err)
 		}
-		temporaryInfo, err := inspectLifecycleFile(session.client, temporary, request.Temporary)
+		stagingInfo, err := inspectLifecycleFile(session.client, staging, staging)
 		if err != nil {
-			_ = session.client.Remove(temporary)
+			_ = session.client.Remove(staging)
 			return err
 		}
-		if err := verifyRemoteFile(temporaryInfo, request.Temporary, request.Artifact, request.OwnerUID); err != nil {
-			_ = session.client.Remove(temporary)
+		if err := verifyRemoteFile(stagingInfo, staging, request.Artifact, request.OwnerUID); err != nil {
+			_ = session.client.Remove(staging)
 			return err
 		}
-		if existing, err := session.client.Lstat(destination); err == nil {
-			if err := validateLifecycleEntry(existing, request.OwnerUID, false); err != nil {
-				_ = session.client.Remove(temporary)
-				return err
-			}
-		} else if !errors.Is(err, fs.ErrNotExist) {
-			_ = session.client.Remove(temporary)
-			return err
+		installErr := remote.runStagedInstaller(ctx, staging, home, version, request.Artifact.SHA256)
+		_ = session.client.Remove(staging)
+		if errors.Is(installErr, remoteinstall.ErrNoExec) {
+			return ErrHelperNoExec
 		}
-		if err := session.client.PosixRename(temporary, destination); err != nil {
-			_ = session.client.Remove(temporary)
-			return fmt.Errorf("activate helper atomically: %w", err)
+		if installErr != nil {
+			return installErr
 		}
-		installed, err = inspectLifecycleFile(session.client, destination, request.Destination)
-		return err
+		installed = RemoteFile{Path: request.Destination, Size: request.Artifact.Size,
+			SHA256: request.Artifact.SHA256, Mode: 0o700, UID: request.OwnerUID, Regular: true}
+		return nil
 	})
 	return installed, err
+}
+
+func (remote *SSHLifecycleRemote) runStagedInstaller(ctx context.Context, staging, home, version, sha256 string) error {
+	limits := remote.Options.Limits.withDefaults()
+	if remote.Options.command == nil {
+		if err := ensureControlMaster(ctx, remote.Alias, remote.Options); err != nil {
+			return err
+		}
+	}
+	bin := remote.Options.SSHBin
+	if bin == "" {
+		bin = "ssh"
+	}
+	command := remote.Options.command
+	if command == nil {
+		command = exec.CommandContext
+	}
+	runCtx, cancel := context.WithTimeout(ctx, limits.Deadline)
+	defer cancel()
+	args := []string{
+		"-T", "-o", "BatchMode=yes", "-o", "ConnectTimeout=" + strconv.Itoa(int(limits.ConnectTimeout.Seconds())),
+		"-o", "ControlMaster=auto", "-o", "ControlPath=" + controlSocketPath(), "-o", "ControlPersist=" + defaultControlPersist,
+		remote.Alias, shellQuote(staging) + " install " + shellQuote(home) + " " + shellQuote(version) + " " + shellQuote(sha256),
+	}
+	cmd := command(runCtx, bin, args...)
+	stdout := &boundedCommandOutput{limit: 128, cancel: cancel}
+	stderr := &boundedCommandOutput{limit: limits.MaxStderrBytes, cancel: cancel}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		if stderr.overflow {
+			return ErrStderrLimit
+		}
+		if runCtx.Err() != nil {
+			return runCtx.Err()
+		}
+		if strings.Contains(stderr.String(), remoteinstall.ErrNoExec.Error()) {
+			return remoteinstall.ErrNoExec
+		}
+		return wrapSSHError(fmt.Errorf("run secure helper installer: %w", err), stderr.String())
+	}
+	if stdout.overflow || stderr.overflow {
+		return ErrStderrLimit
+	}
+	return nil
 }
 
 func (remote *SSHLifecycleRemote) RemoveExact(ctx context.Context, requested string) error {
@@ -256,6 +294,17 @@ func validateLifecycleDirectories(client *sftp.Client, home, version string, uid
 		if err := validateLifecycleEntry(info, uid, true); err != nil {
 			return fmt.Errorf("unsafe helper directory %s: %w", directory, err)
 		}
+	}
+	return nil
+}
+
+func validateLifecycleHome(client *sftp.Client, home string, uid uint32) error {
+	info, err := client.Lstat(home)
+	if err != nil {
+		return err
+	}
+	if err := validateLifecycleEntry(info, uid, true); err != nil {
+		return fmt.Errorf("unsafe helper home %s: %w", home, err)
 	}
 	return nil
 }

--- a/collector/internal/remote/lifecycle_ssh_test.go
+++ b/collector/internal/remote/lifecycle_ssh_test.go
@@ -1,0 +1,103 @@
+package remote
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/pkg/sftp"
+)
+
+func TestSSHLifecycleRemoteUsesBoundedFixedPlatformProbe(t *testing.T) {
+	remote, err := NewSSHLifecycleRemote("host", fakeOptions([]byte("Linux\nx86_64\n501\n"), 0, "", false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	platform, err := remote.ProbePlatform(context.Background())
+	if err != nil || platform.OS != "linux" || platform.Arch != "amd64" || platform.UID != 501 {
+		t.Fatalf("platform = %#v, error = %v", platform, err)
+	}
+	remote.Options = fakeOptions(bytes.Repeat([]byte("x"), 129), 0, "", false)
+	if _, err := remote.ProbePlatform(context.Background()); !errors.Is(err, ErrUnsupportedHelperPlatform) {
+		t.Fatalf("oversized probe error = %v", err)
+	}
+}
+
+func TestLifecycleSFTPPrimitivesCreateVerifyAndRejectSymlink(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Chmod(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	clientConn, serverConn := net.Pipe()
+	server, err := sftp.NewServer(serverConn, sftp.WithServerWorkingDirectory(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- server.Serve() }()
+	client, err := sftp.NewClientPipe(clientConn, clientConn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = client.Close()
+		_ = server.Close()
+		<-serveDone
+	})
+	home, err := client.RealPath(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	uid := uint32(os.Getuid())
+	if err := validateLifecycleDirectories(client, home, "v1", uid, true); err != nil {
+		t.Fatal(err)
+	}
+	absolute := path.Join(home, ".local/lib/coslash/helpers/v1/coslash-helper")
+	file, err := client.OpenFile(absolute, os.O_WRONLY|os.O_CREATE|os.O_EXCL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := syntheticELF("amd64")
+	if _, err := file.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Chmod(0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	remoteFile, err := inspectLifecycleFile(client, absolute, "reported")
+	if err != nil || remoteFile.SHA256 != digest(content) || remoteFile.Mode.Perm() != 0o700 || remoteFile.UID != uid {
+		t.Fatalf("remote file = %#v, error = %v", remoteFile, err)
+	}
+	symlink := filepath.Join(root, ".local/lib/coslash/helpers/symlink")
+	if err := os.Symlink(filepath.Join(root, ".local/lib/coslash/helpers/v1"), symlink); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateLifecycleDirectories(client, home, "symlink", uid, false); !errors.Is(err, ErrHelperVerification) {
+		t.Fatalf("symlink validation error = %v", err)
+	}
+}
+
+func TestResolveLifecyclePathAcceptsOnlyExactKnownLayout(t *testing.T) {
+	want, _ := helperPath("v1")
+	absolute, version, err := resolveLifecyclePath("/home/user", want)
+	if err != nil || absolute != "/home/user/.local/lib/coslash/helpers/v1/coslash-helper" || version != "v1" {
+		t.Fatalf("path = %q, version = %q, error = %v", absolute, version, err)
+	}
+	for _, candidate := range []string{
+		"~/.local/lib/coslash/helpers/v1/other",
+		"~/.local/lib/coslash/helpers/v1/coslash-helper.new",
+		"~/.local/lib/coslash/helpers/../coslash-helper",
+	} {
+		if _, _, err := resolveLifecyclePath("/home/user", candidate); !errors.Is(err, ErrUnknownHelperPath) {
+			t.Fatalf("accepted lifecycle path %q: %v", candidate, err)
+		}
+	}
+}

--- a/collector/internal/remote/lifecycle_test.go
+++ b/collector/internal/remote/lifecycle_test.go
@@ -193,6 +193,22 @@ func TestTrustStoreRejectsExpiredAndReplayedMetadata(t *testing.T) {
 	}
 }
 
+func TestTrustStoreRejectsMutatedSignedMetadataFields(t *testing.T) {
+	remote, _, _ := lifecycleFixture(t)
+	for name, mutate := range map[string]func(*ReleaseMetadata){
+		"sequence": func(metadata *ReleaseMetadata) { metadata.Sequence++ },
+		"expiry":   func(metadata *ReleaseMetadata) { metadata.ExpiresAtUnix += 3600 },
+	} {
+		t.Run(name, func(t *testing.T) {
+			document := remote.document
+			mutate(&document.Metadata)
+			if _, err := lifecycleFor(remote).Trust.Verify(document); !errors.Is(err, ErrHelperMetadata) {
+				t.Fatalf("Verify mutated metadata error = %v, want ErrHelperMetadata", err)
+			}
+		})
+	}
+}
+
 func TestLifecycleDoesNotMisclassifyTransportFailureAsUnsupported(t *testing.T) {
 	remote, _, content := lifecycleFixture(t)
 	remote.probeErr = context.DeadlineExceeded

--- a/collector/internal/remote/lifecycle_test.go
+++ b/collector/internal/remote/lifecycle_test.go
@@ -1,0 +1,366 @@
+package remote
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/centauri-ai/coslash/collector/internal/remoteprotocol"
+)
+
+func TestLifecycleReusesVerifiedCurrentHelper(t *testing.T) {
+	remote, artifact, content := lifecycleFixture(t)
+	path, _ := helperPath(artifact.Version)
+	remote.files[path] = remoteFile(path, artifact, remote.platform.UID)
+	result := lifecycleFor(remote).Setup(context.Background(), remote.document, content, Consent{})
+	if result.State != LifecycleReady || !result.CanExecute || remote.installs != 0 || remote.capabilitiesCalls != 1 {
+		t.Fatalf("result = %#v, installs = %d, capabilities = %d", result, remote.installs, remote.capabilitiesCalls)
+	}
+}
+
+func TestLifecycleDeprecatedHelperIsReusedUntilUpgradeConsent(t *testing.T) {
+	remote, current, content := lifecycleFixture(t)
+	older := current
+	older.Version = "v0"
+	older.Current = false
+	remote.document.Metadata.Artifacts = []Artifact{current, older}
+	remote.document = signDocument(t, remote.document.Metadata)
+	path, _ := helperPath(older.Version)
+	remote.files[path] = remoteFile(path, older, remote.platform.UID)
+	result := lifecycleFor(remote).Setup(context.Background(), remote.document, content, Consent{})
+	if result.State != LifecycleDeprecated || !result.CanExecute || !errors.Is(result.Reason, ErrHelperUpgradeRequired) || remote.installs != 0 {
+		t.Fatalf("result = %#v, installs = %d", result, remote.installs)
+	}
+	result = lifecycleFor(remote).Setup(context.Background(), remote.document, content, Consent{Upgrade: true})
+	currentPath, _ := helperPath(current.Version)
+	if result.State != LifecycleReady || remote.files[path].Path == "" || remote.files[currentPath].Path == "" {
+		t.Fatalf("upgrade result = %#v, files = %#v", result, remote.files)
+	}
+}
+
+func TestLifecycleInstallsOnlyWithConsentAndVerifiesActivation(t *testing.T) {
+	remote, artifact, content := lifecycleFixture(t)
+	result := lifecycleFor(remote).Setup(context.Background(), remote.document, content, Consent{})
+	if result.State != LifecycleUpgradeRequired || !errors.Is(result.Reason, ErrHelperConsentRequired) || remote.installs != 0 {
+		t.Fatalf("without consent = %#v, installs = %d", result, remote.installs)
+	}
+	result = lifecycleFor(remote).Setup(context.Background(), remote.document, content, Consent{Install: true})
+	if result.State != LifecycleReady || !result.CanExecute || remote.installs != 1 {
+		t.Fatalf("with consent = %#v, installs = %d", result, remote.installs)
+	}
+	if remote.lastRequest.Destination != "~/.local/lib/coslash/helpers/v1/coslash-helper" || remote.lastRequest.Temporary != remote.lastRequest.Destination+".new" {
+		t.Fatalf("install request = %#v", remote.lastRequest)
+	}
+	if _, err := os.Stat(filepath.Join(remote.root, artifact.Version, HelperFileName)); err != nil {
+		t.Fatalf("activated helper missing from fake remote: %v", err)
+	}
+	_ = artifact
+}
+
+func TestLifecycleRejectsTamperedAndRevokedBeforeExecution(t *testing.T) {
+	remote, artifact, content := lifecycleFixture(t)
+	path, _ := helperPath(artifact.Version)
+	bad := remoteFile(path, artifact, remote.platform.UID)
+	bad.SHA256 = "00" + bad.SHA256[2:]
+	remote.files[path] = bad
+	result := lifecycleFor(remote).Setup(context.Background(), remote.document, content, Consent{})
+	if result.CanExecute || result.State != LifecycleUpgradeRequired || remote.capabilitiesCalls != 0 {
+		t.Fatalf("tampered result = %#v, caps = %d", result, remote.capabilitiesCalls)
+	}
+	remote.document.Metadata.Artifacts[0].Revoked = true
+	remote.document = signDocument(t, remote.document.Metadata)
+	result = lifecycleFor(remote).Setup(context.Background(), remote.document, content, Consent{Upgrade: true})
+	if result.State != LifecycleRevoked || result.CanExecute || remote.capabilitiesCalls != 0 {
+		t.Fatalf("revoked result = %#v, caps = %d", result, remote.capabilitiesCalls)
+	}
+}
+
+func TestLifecycleRevokedPreviousDoesNotBlockSafeCurrentInstall(t *testing.T) {
+	remote, current, content := lifecycleFixture(t)
+	older := current
+	older.Version = "v0"
+	older.Current = false
+	older.Revoked = true
+	remote.document.Metadata.Artifacts = []Artifact{current, older}
+	remote.document = signDocument(t, remote.document.Metadata)
+	oldPath, _ := helperPath(older.Version)
+	remote.files[oldPath] = remoteFile(oldPath, older, remote.platform.UID)
+	result := lifecycleFor(remote).Setup(context.Background(), remote.document, content, Consent{Install: true})
+	if result.State != LifecycleReady || !result.CanExecute || remote.installs != 1 {
+		t.Fatalf("result = %#v, installs = %d", result, remote.installs)
+	}
+}
+
+func TestLifecycleNoExecAndRollbackStayOnSFTP(t *testing.T) {
+	remote, _, content := lifecycleFixture(t)
+	remote.installErr = ErrHelperNoExec
+	result := lifecycleFor(remote).Setup(context.Background(), remote.document, content, Consent{Install: true})
+	if result.State != LifecycleSFTP || !result.Fallback || !errors.Is(result.Reason, ErrHelperNoExec) {
+		t.Fatalf("noexec result = %#v", result)
+	}
+	remote.installErr = ErrHelperRollback
+	result = lifecycleFor(remote).Setup(context.Background(), remote.document, content, Consent{Install: true})
+	if result.State != LifecycleSFTP || !errors.Is(result.Reason, ErrHelperRollback) {
+		t.Fatalf("rollback result = %#v", result)
+	}
+}
+
+func TestLifecyclePlatformAndMetadataAreAuthenticated(t *testing.T) {
+	remote, _, content := lifecycleFixture(t)
+	remote.platform.Arch = "riscv64"
+	result := lifecycleFor(remote).Setup(context.Background(), remote.document, content, Consent{Install: true})
+	if result.State != LifecycleUnsupported || remote.installs != 0 {
+		t.Fatalf("unsupported result = %#v", result)
+	}
+	remote.platform.Arch = "amd64"
+	remote.document.Signature = base64.StdEncoding.EncodeToString([]byte("not a signature"))
+	result = lifecycleFor(remote).Setup(context.Background(), remote.document, content, Consent{Upgrade: true})
+	if result.State != LifecycleVerificationError || remote.installs != 0 {
+		t.Fatalf("metadata result = %#v", result)
+	}
+}
+
+func TestLifecycleUninstallIsExactAndIdempotent(t *testing.T) {
+	remote, artifact, _ := lifecycleFixture(t)
+	path, _ := helperPath(artifact.Version)
+	remote.files[path] = remoteFile(path, artifact, remote.platform.UID)
+	lifecycle := lifecycleFor(remote)
+	if err := lifecycle.Uninstall(context.Background(), remote.document, artifact.Version); err != nil {
+		t.Fatal(err)
+	}
+	if remote.removed != path || remote.files[path].Path != "" {
+		t.Fatalf("removed = %q, files = %#v", remote.removed, remote.files)
+	}
+	if _, err := os.Stat(filepath.Join(remote.root, artifact.Version, HelperFileName)); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("uninstall did not remove exact helper: %v", err)
+	}
+	if err := lifecycle.Uninstall(context.Background(), remote.document, artifact.Version); err != nil {
+		t.Fatal(err)
+	}
+	if err := lifecycle.Uninstall(context.Background(), remote.document, "unknown"); !errors.Is(err, ErrUnknownHelperPath) {
+		t.Fatalf("unknown uninstall error = %v", err)
+	}
+}
+
+func TestLifecycleRollsBackToPreviousHelperAfterCapabilityFailure(t *testing.T) {
+	remote, current, content := lifecycleFixture(t)
+	older := current
+	older.Version = "v0"
+	older.Current = false
+	remote.document.Metadata.Artifacts = []Artifact{current, older}
+	remote.document = signDocument(t, remote.document.Metadata)
+	oldPath, _ := helperPath(older.Version)
+	currentPath, _ := helperPath(current.Version)
+	remote.files[oldPath] = remoteFile(oldPath, older, remote.platform.UID)
+	remote.capabilityErrors = map[string]error{currentPath: ErrHelperIncompatible}
+
+	result := lifecycleFor(remote).Setup(context.Background(), remote.document, content, Consent{Upgrade: true})
+	if result.State != LifecycleDeprecated || !result.CanExecute || result.Path != oldPath || !errors.Is(result.Reason, ErrHelperRollback) {
+		t.Fatalf("rollback result = %#v", result)
+	}
+	if _, exists := remote.files[currentPath]; exists {
+		t.Fatalf("failed current helper was retained: %#v", remote.files[currentPath])
+	}
+}
+
+func TestTrustStoreRejectsExpiredAndReplayedMetadata(t *testing.T) {
+	remote, _, _ := lifecycleFixture(t)
+	guard := &MemoryMetadataSequenceStore{}
+	trust := lifecycleFor(remote).Trust
+	trust.Sequences = guard
+	newer := remote.document.Metadata
+	newer.Sequence = 2
+	newerDocument := signDocument(t, newer)
+	if _, err := trust.Verify(newerDocument); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := trust.Verify(remote.document); !errors.Is(err, ErrHelperMetadataRollback) {
+		t.Fatalf("replay error = %v", err)
+	}
+	expired := newer
+	expired.Sequence = 3
+	expired.ExpiresAtUnix = 1
+	if _, err := trust.Verify(signDocument(t, expired)); !errors.Is(err, ErrHelperMetadataExpired) {
+		t.Fatalf("expiry error = %v", err)
+	}
+}
+
+func TestLifecycleDoesNotMisclassifyTransportFailureAsUnsupported(t *testing.T) {
+	remote, _, content := lifecycleFixture(t)
+	remote.probeErr = context.DeadlineExceeded
+	result := lifecycleFor(remote).Setup(context.Background(), remote.document, content, Consent{Install: true})
+	if result.State != LifecycleSFTP || !errors.Is(result.Reason, context.DeadlineExceeded) {
+		t.Fatalf("transport result = %#v", result)
+	}
+}
+
+func TestParsePlatformProbeRejectsAnythingButFixedOutput(t *testing.T) {
+	platform, err := ParsePlatformProbe("Linux\nx86_64\n501\n")
+	if err != nil || platform.Arch != "amd64" || platform.UID != 501 {
+		t.Fatalf("platform = %#v, error = %v", platform, err)
+	}
+	for _, output := range []string{"Linux\nx86_64\n", "Linux\nriscv64\n1", "Linux x86_64 1 trailing"} {
+		if _, err := ParsePlatformProbe(output); err == nil {
+			t.Fatalf("accepted probe %q", output)
+		}
+	}
+}
+
+func TestHelperPlatformArgsAreFixed(t *testing.T) {
+	args, err := HelperPlatformArgs("host", 1)
+	if err != nil || args[len(args)-1] != "uname -s; uname -m; id -u" {
+		t.Fatalf("args = %#v, error = %v", args, err)
+	}
+	if _, err := HelperPlatformArgs("host; hostile", 1); !errors.Is(err, ErrInvalidAlias) {
+		t.Fatalf("injection error = %v", err)
+	}
+}
+
+func TestClassifyLifecycleError(t *testing.T) {
+	for _, test := range []struct {
+		err  error
+		want Reason
+	}{
+		{ErrUnsupportedHelperPlatform, ReasonHelperUnsupported},
+		{ErrHelperVerification, ReasonHelperVerification},
+		{ErrHelperNoExec, ReasonHelperBlocked},
+		{ErrHelperRevoked, ReasonHelperRevoked},
+		{ErrHelperConsentRequired, ReasonHelperUpgrade},
+		{ErrHelperRollback, ReasonHelperRollback},
+		{ErrHelperInstallation, ReasonHelperInstallation},
+	} {
+		if got := classifyLifecycleError(test.err); got != test.want {
+			t.Errorf("classifyLifecycleError(%v) = %q, want %q", test.err, got, test.want)
+		}
+	}
+}
+
+func lifecycleFixture(t *testing.T) (*fakeLifecycleRemote, Artifact, []byte) {
+	t.Helper()
+	arch := "amd64"
+	content := syntheticELF(arch)
+	artifact := Artifact{Version: "v1", OS: "linux", Arch: arch, Size: int64(len(content)), SHA256: digest(content), Protocol: remoteprotocol.VersionRange{Min: 1, Max: 1}, Schema: remoteprotocol.VersionRange{Min: 1, Max: 1}, Current: true}
+	capabilities := compatibleCapabilities()
+	capabilities.Arch = arch
+	remote := &fakeLifecycleRemote{root: t.TempDir(), platform: Platform{OS: "linux", Arch: arch, UID: 501}, files: map[string]RemoteFile{}, capabilities: capabilities}
+	remote.document = signDocument(t, ReleaseMetadata{Sequence: 1, ExpiresAtUnix: time.Now().Add(time.Hour).Unix(), Artifacts: []Artifact{artifact}})
+	return remote, artifact, content
+}
+
+func syntheticELF(arch string) []byte {
+	content := make([]byte, 64)
+	copy(content, []byte{0x7f, 'E', 'L', 'F', 2, 1})
+	binary.LittleEndian.PutUint16(content[16:18], 2)
+	machine := uint16(62)
+	if arch == "arm64" {
+		machine = 183
+	}
+	binary.LittleEndian.PutUint16(content[18:20], machine)
+	return content
+}
+
+var lifecyclePrivate ed25519.PrivateKey
+
+func signDocument(t *testing.T, metadata ReleaseMetadata) SignedReleaseMetadata {
+	t.Helper()
+	if lifecyclePrivate == nil {
+		_, private, err := ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		lifecyclePrivate = private
+	}
+	return SignedReleaseMetadata{KeyID: "test-2026", Metadata: metadata, Signature: base64.StdEncoding.EncodeToString(ed25519.Sign(lifecyclePrivate, canonicalMetadataPayload(metadata)))}
+}
+
+func lifecycleFor(remote *fakeLifecycleRemote) Lifecycle {
+	return Lifecycle{Remote: remote, Trust: TrustStore{
+		Keys:      map[string]ed25519.PublicKey{"test-2026": lifecyclePrivate.Public().(ed25519.PublicKey)},
+		Sequences: &MemoryMetadataSequenceStore{},
+	}}
+}
+
+func compatibleCapabilities() remoteprotocol.Capabilities {
+	return remoteprotocol.Capabilities{Protocol: remoteprotocol.VersionRange{Min: 1, Max: 1}, Schema: remoteprotocol.VersionRange{Min: 1, Max: 1}, ParserVersion: "parsers-1", OS: "linux", Arch: "amd64"}
+}
+
+func remoteFile(path string, artifact Artifact, uid uint32) RemoteFile {
+	return RemoteFile{Path: path, Size: artifact.Size, SHA256: artifact.SHA256, Mode: 0o700, UID: uid, Regular: true}
+}
+
+type fakeLifecycleRemote struct {
+	root              string
+	platform          Platform
+	files             map[string]RemoteFile
+	document          SignedReleaseMetadata
+	capabilities      remoteprotocol.Capabilities
+	installErr        error
+	installs          int
+	capabilitiesCalls int
+	probeErr          error
+	capabilityErrors  map[string]error
+	lastRequest       InstallRequest
+	removed           string
+}
+
+func (remote *fakeLifecycleRemote) ProbePlatform(context.Context) (Platform, error) {
+	return remote.platform, remote.probeErr
+}
+func (remote *fakeLifecycleRemote) Inspect(_ context.Context, path string) (RemoteFile, error) {
+	file, ok := remote.files[path]
+	if !ok {
+		return RemoteFile{}, fs.ErrNotExist
+	}
+	return file, nil
+}
+func (remote *fakeLifecycleRemote) Install(_ context.Context, request InstallRequest) (RemoteFile, error) {
+	remote.installs++
+	remote.lastRequest = request
+	if remote.installErr != nil {
+		return RemoteFile{}, remote.installErr
+	}
+	directory := filepath.Join(remote.root, request.Artifact.Version)
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		return RemoteFile{}, err
+	}
+	temporary := filepath.Join(directory, HelperFileName+".new")
+	destination := filepath.Join(directory, HelperFileName)
+	if err := os.WriteFile(temporary, request.Bytes, 0o600); err != nil {
+		return RemoteFile{}, err
+	}
+	if err := os.Chmod(temporary, 0o700); err != nil {
+		return RemoteFile{}, err
+	}
+	if err := os.Rename(temporary, destination); err != nil {
+		return RemoteFile{}, err
+	}
+	file := remoteFile(request.Destination, request.Artifact, request.OwnerUID)
+	remote.files[request.Destination] = file
+	return file, nil
+}
+func (remote *fakeLifecycleRemote) RemoveExact(_ context.Context, path string) error {
+	remote.removed = path
+	for _, artifact := range remote.document.Metadata.Artifacts {
+		known, _ := helperPath(artifact.Version)
+		if known == path {
+			if err := os.Remove(filepath.Join(remote.root, artifact.Version, HelperFileName)); err != nil && !errors.Is(err, fs.ErrNotExist) {
+				return err
+			}
+			break
+		}
+	}
+	delete(remote.files, path)
+	return nil
+}
+func (remote *fakeLifecycleRemote) Capabilities(_ context.Context, path string) (remoteprotocol.Capabilities, error) {
+	remote.capabilitiesCalls++
+	return remote.capabilities, remote.capabilityErrors[path]
+}

--- a/collector/internal/remote/sftp.go
+++ b/collector/internal/remote/sftp.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -181,9 +182,10 @@ type Session struct {
 }
 
 type OpenOptions struct {
-	SSHBin  string
-	Limits  Limits
-	command func(context.Context, string, ...string) *exec.Cmd
+	SSHBin        string
+	Limits        Limits
+	command       func(context.Context, string, ...string) *exec.Cmd
+	lifecycleOnly bool
 }
 
 type sshProcessError struct {
@@ -271,7 +273,17 @@ func OpenSession(ctx context.Context, alias string, options OpenOptions) (*Sessi
 			return client.Open(path)
 		},
 	}
-	source, err := newSource(operations, limits)
+	var source *Source
+	if options.lifecycleOnly {
+		home, homeErr := client.RealPath(".")
+		if homeErr != nil {
+			err = fmt.Errorf("resolve SFTP home: %w", homeErr)
+		} else {
+			source = &Source{home: path.Clean(home), limits: limits}
+		}
+	} else {
+		source, err = newSource(operations, limits)
+	}
 	if err != nil {
 		_ = client.Close()
 		_ = cmd.Wait()

--- a/collector/internal/remotefacts/README.md
+++ b/collector/internal/remotefacts/README.md
@@ -13,7 +13,8 @@ Only these source facts cross the remote boundary:
 - start/activity/duration, in-turn/stopped, bounded counts, token totals, and
   cost converted deterministically to integer micro-USD;
 - spawn completion/turn, human command **labels** (never command text), approved
-  name/live metadata, and opaque file comparison keys with size/mtime.
+  name/live metadata, opaque file comparison keys with size/mtime, and bounded
+  Codex key-to-session/parent header mappings used only for warm discovery.
 
 The adapter excludes by construction: `LogPath`, working directory, repository,
 edited paths, file edit rows, raw commands, prompts, summary, digest/tool output,
@@ -35,6 +36,7 @@ family also requires `stale_reason`. Empty optional strings are omitted.
 | Model | 120 UTF-8 bytes |
 | Sessions/family | 256 |
 | Fingerprints/family | 512 |
+| Codex header mappings/family | 512 |
 | Models/session | 32 |
 | Spawns/session | 256 |
 | Command labels/session | 128 |

--- a/collector/internal/remotefacts/facts.go
+++ b/collector/internal/remotefacts/facts.go
@@ -23,6 +23,7 @@ const (
 	MaxModelBytes       = 120
 	MaxSessions         = 256
 	MaxFingerprints     = 512
+	MaxHeaderMappings   = 512
 	MaxModelsPerSession = 32
 	MaxSpawnsPerSession = 256
 	MaxCommands         = 128
@@ -41,15 +42,16 @@ const (
 // Family is the complete normalized replacement unit. Paths and raw transcript
 // content deliberately have no representation in this type.
 type Family struct {
-	SchemaVersion int           `json:"schema_version"`
-	ParserVersion string        `json:"parser_version"`
-	Vendor        string        `json:"vendor"`
-	FamilyID      string        `json:"family_id"`
-	State         string        `json:"state"`
-	StaleReason   string        `json:"stale_reason,omitempty"`
-	Sessions      []Session     `json:"sessions"`
-	Metadata      Metadata      `json:"metadata"`
-	Fingerprints  []Fingerprint `json:"fingerprints"`
+	SchemaVersion  int             `json:"schema_version"`
+	ParserVersion  string          `json:"parser_version"`
+	Vendor         string          `json:"vendor"`
+	FamilyID       string          `json:"family_id"`
+	State          string          `json:"state"`
+	StaleReason    string          `json:"stale_reason,omitempty"`
+	Sessions       []Session       `json:"sessions"`
+	Metadata       Metadata        `json:"metadata"`
+	Fingerprints   []Fingerprint   `json:"fingerprints"`
+	HeaderMappings []HeaderMapping `json:"header_mappings,omitempty"`
 }
 
 type Session struct {
@@ -118,6 +120,15 @@ type Fingerprint struct {
 	Key          string `json:"key"`
 	Size         int64  `json:"size"`
 	ModifiedAtMs int64  `json:"modified_at_ms"`
+}
+
+// HeaderMapping is the privacy-safe part of a Codex rollout header needed to
+// reconstruct a family without reopening an unchanged transcript. Key is the
+// opaque fingerprint key, never a path.
+type HeaderMapping struct {
+	Key       string `json:"key"`
+	SessionID string `json:"session_id"`
+	ParentID  string `json:"parent_id,omitempty"`
 }
 
 func Validate(f Family) error {
@@ -193,6 +204,7 @@ func Validate(f Family) error {
 		return err
 	}
 	previous := ""
+	fingerprintKeys := map[string]bool{}
 	for i, fp := range f.Fingerprints {
 		if !identifier(fp.Key) || fp.Size < 0 || fp.ModifiedAtMs < 0 || fp.ModifiedAtMs > MaxTimestampMs {
 			return fmt.Errorf("fingerprints[%d] is invalid", i)
@@ -201,6 +213,20 @@ func Validate(f Family) error {
 			return errors.New("fingerprints must be uniquely sorted by key")
 		}
 		previous = fp.Key
+		fingerprintKeys[fp.Key] = true
+	}
+	if len(f.HeaderMappings) > MaxHeaderMappings {
+		return errors.New("header mapping count exceeds limit")
+	}
+	previous = ""
+	for i, mapping := range f.HeaderMappings {
+		if !fingerprintKeys[mapping.Key] || !identifier(mapping.SessionID) ||
+			!seenSessions[mapping.SessionID] ||
+			(mapping.ParentID != "" && (!identifier(mapping.ParentID) || !seenSessions[mapping.ParentID])) ||
+			mapping.Key <= previous {
+			return fmt.Errorf("header_mappings[%d] is invalid or unsorted", i)
+		}
+		previous = mapping.Key
 	}
 	return nil
 }
@@ -311,7 +337,7 @@ func validateOptionalCount(value *int) error {
 // FromParsed creates a deterministic family replacement and applies the wire
 // allowlist. It intentionally drops paths, prompts, digest/tool text, commands,
 // file edits, repository data, environment data, and synthesis.
-func FromParsed(vendor, familyID, parserVersion, state, staleReason string, parsed []*vendors.ParsedSession, metadata *vendors.SessionMetadata, fingerprints []vendors.FileFingerprint) (Family, error) {
+func FromParsed(vendor, familyID, parserVersion, state, staleReason string, parsed []*vendors.ParsedSession, metadata *vendors.SessionMetadata, fingerprints []vendors.FileFingerprint, headerMappings ...[]HeaderMapping) (Family, error) {
 	f := Family{SchemaVersion: SchemaVersion, ParserVersion: parserVersion, Vendor: vendor, FamilyID: familyID, State: state, StaleReason: truncate(staleReason, MaxDisplayBytes)}
 	for _, p := range parsed {
 		s := p.Session
@@ -371,6 +397,10 @@ func FromParsed(vendor, familyID, parserVersion, state, staleReason string, pars
 		f.Fingerprints = append(f.Fingerprints, Fingerprint{Key: fp.Key, Size: fp.Size, ModifiedAtMs: fp.ModifiedAtMs})
 	}
 	sort.Slice(f.Fingerprints, func(i, j int) bool { return f.Fingerprints[i].Key < f.Fingerprints[j].Key })
+	if len(headerMappings) > 0 {
+		f.HeaderMappings = append([]HeaderMapping(nil), headerMappings[0]...)
+		sort.Slice(f.HeaderMappings, func(i, j int) bool { return f.HeaderMappings[i].Key < f.HeaderMappings[j].Key })
+	}
 	return f, Validate(f)
 }
 

--- a/collector/internal/remotefacts/facts_test.go
+++ b/collector/internal/remotefacts/facts_test.go
@@ -44,6 +44,14 @@ func TestValidateRejectsUnsortedAndUnboundedFacts(t *testing.T) {
 	}
 }
 
+func TestValidateHeaderMappingsMustReferenceFingerprint(t *testing.T) {
+	f := validFamily()
+	f.HeaderMappings = []HeaderMapping{{Key: "missing", SessionID: "root"}}
+	if err := Validate(f); err == nil {
+		t.Fatal("accepted header mapping without a matching fingerprint")
+	}
+}
+
 func TestParsedRoundTripPreservesApprovedCompositionFacts(t *testing.T) {
 	model, branch, status := "gpt-5", "main", "waiting"
 	cost := 1.25

--- a/collector/internal/remotehelper/README.md
+++ b/collector/internal/remotehelper/README.md
@@ -1,0 +1,95 @@
+# Linux collection helper
+
+`coslash-helper` parses Claude and Codex transcripts beside the data and writes
+bounded protocol v1 records to stdout. The Mac keeps settings, cache,
+composition, health, and UI. The helper keeps nothing: no daemon, no listener, no
+state between runs, and no transcript ever leaves the machine.
+
+## Commands
+
+| Command | Input | Output |
+| --- | --- | --- |
+| `version` (alias `capabilities`) | none | one capability document |
+| `collect` | one JSON request line on stdin | NDJSON records |
+
+The request travels on stdin only. Nothing in it is ever treated as a path, a
+name, or a command, and the remote command line carries no request data at all.
+
+## Read boundary
+
+Reads resolve beneath one open handle on the SSH user's home directory
+(`os.Root`), so a path component swapped for a symlink mid-traversal cannot
+redirect a read outside that tree. Directory entries that are symlinks are
+dropped rather than followed, and files open with `O_NOFOLLOW` after an `lstat`
+that already rejected links.
+
+The allowlist matches the SFTP transport, so both transports read the same files:
+
+```text
+.claude/projects   .claude/sessions   .claude/jobs
+.codex/sessions    .codex/archived_sessions   .codex/session_index.jsonl
+```
+
+Process liveness is the only probe outside those paths: signal 0 against a PID
+that Claude's own session metadata names.
+
+## Limits
+
+Response limits arrive in the request. Traversal limits are helper-owned and not
+negotiable: 200,000 directory entries, depth 16 beneath a root, 512 MiB per file,
+and a four-minute deadline. Local reads cost disk and CPU rather than SSH
+bandwidth, which is why the per-file bound is far above the SFTP one.
+
+## Families and fingerprints
+
+A family is one card's replacement unit. Grouping is cheap and happens before
+any body is opened: Claude groups by transcript path, Codex by the parent chain
+in header rows. For Codex, unchanged file size/mtime fingerprints reuse bounded
+opaque key-to-session/parent mappings supplied with the known baseline; only new
+or changed files reread their header. Each family's fingerprint is a digest over
+its files' opaque keys, sizes, and modification times, plus the approved metadata
+facts for its sessions — so a session that only changed liveness or name still
+recollects, which a file-only fingerprint would report as unchanged forever.
+
+A fingerprint that matches the Mac's cached value yields `unchanged_family` and
+no transcript read. Anything else is parsed. Fingerprint equality is an
+optimisation, not proof of immutability: after parsing, every file is re-stated,
+and a family whose files moved is re-parsed up to twice before it is reported
+skipped with a structured reason.
+
+Families outside the requested window are neither confirmed nor replaced. Their
+absence from a response is never deletion, and the inventory still proves they
+exist.
+
+## Deletion
+
+`vendor_complete` asserts that the vendor's whole allowlisted tree was
+enumerated, so it is emitted only when the scan skipped nothing, hit no limit,
+and finished inside the deadline. A missing vendor root is complete coverage of
+zero families; an unreadable directory is not. Tombstones name known families
+that a complete scan did not find, and they commit only against the bounded
+authoritative inventory. An interrupted or incomplete scan therefore cannot
+delete a cached family — it publishes what it collected and leaves the rest.
+
+## Exit codes
+
+| Code | Meaning |
+| ---: | --- |
+| 0 | `request_complete` was emitted |
+| 2 | usage error |
+| 3 | ran, but coverage is partial |
+| 4 | the request was rejected |
+| 5 | internal failure |
+| 6 | negotiated output/resource limit reached |
+
+126 and 127 come from the remote shell, not the helper, and mean the executable
+is blocked or missing. The Mac maps each of these to a distinct health reason so
+the UI can offer the right repair.
+
+## Privacy
+
+Only the facts in `internal/remotefacts` cross the boundary. stdout carries no
+transcript rows, prompts, tool output, absolute paths, working directories, or
+environment values, and stderr is bounded diagnostics that the Mac redacts before
+showing. Codex's prompt-derived fallback name is cleared at the helper adapter;
+approved session-index names remain available as bounded display text.

--- a/collector/internal/remotehelper/collect.go
+++ b/collector/internal/remotehelper/collect.go
@@ -1,0 +1,576 @@
+package remotehelper
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/centauri-ai/coslash/collector/internal/remotefacts"
+	"github.com/centauri-ai/coslash/collector/internal/remoteprotocol"
+	"github.com/centauri-ai/coslash/collector/internal/session"
+	"github.com/centauri-ai/coslash/collector/internal/vendors"
+	"github.com/centauri-ai/coslash/collector/internal/vendors/codex"
+)
+
+// Options are the helper's run inputs. Nothing here comes from the request: the
+// home directory is the SSH user's own, and the limits are helper-owned.
+type Options struct {
+	Home         string
+	Now          func() time.Time
+	Limits       Limits
+	Deadline     time.Duration
+	ProcessAlive func(int) bool
+}
+
+// Outcome reports what the response contained. RequestComplete is false when a
+// vendor could not be enumerated authoritatively, which leaves the refresh
+// partial without discarding the families that did arrive.
+type Outcome struct {
+	Records         int
+	Bytes           int
+	VendorsComplete []string
+	RequestComplete bool
+}
+
+// Collect answers one validated request. It streams records as they are produced
+// and returns an error only when the response itself cannot continue.
+func Collect(
+	ctx context.Context,
+	request remoteprotocol.Request,
+	options Options,
+	output io.Writer,
+) (Outcome, error) {
+	if err := remoteprotocol.ValidateRequest(request); err != nil {
+		return Outcome{}, fmt.Errorf("invalid request: %w", err)
+	}
+	home := options.Home
+	if home == "" {
+		resolved, err := os.UserHomeDir()
+		if err != nil {
+			return Outcome{}, fmt.Errorf("resolve home directory: %w", err)
+		}
+		home = resolved
+	}
+	now := options.Now
+	if now == nil {
+		now = time.Now
+	}
+	// Liveness is the one probe outside the file allowlist: signal 0 against a
+	// PID the metadata files name, never a path from the request.
+	alive := options.ProcessAlive
+	if alive == nil {
+		alive = session.IsProcessAlive
+	}
+	deadline := options.Deadline
+	if deadline <= 0 {
+		deadline = CollectDeadline
+	}
+	ctx, cancel := context.WithTimeout(ctx, deadline)
+	defer cancel()
+
+	source, err := OpenSource(home, options.Limits)
+	if err != nil {
+		return Outcome{}, err
+	}
+	defer source.Close()
+
+	started := time.Now()
+	emitter := newEmitter(output, request)
+	if err := emitter.handshake(); err != nil {
+		return outcomeOf(emitter, nil, false), err
+	}
+	completed := []string{}
+	parserTotal := time.Duration(0)
+	totals := remoteprotocol.Counts{}
+	for _, vendor := range request.Vendors {
+		if ctx.Err() != nil {
+			break
+		}
+		result, err := collectVendor(
+			ctx, emitter, request, vendor, source, home, now(), alive,
+		)
+		parserTotal += result.parser
+		addCounts(&totals, result.counts)
+		if err != nil {
+			return outcomeOf(emitter, completed, false), err
+		}
+		if result.complete {
+			completed = append(completed, vendor)
+		}
+	}
+	if len(completed) != len(request.Vendors) {
+		return outcomeOf(emitter, completed, false), nil
+	}
+	total := time.Since(started)
+	err = emitter.emit(remoteprotocol.Record{
+		Type:   remoteprotocol.RecordRequestComplete,
+		Counts: totals,
+		Timing: timing(parserTotal, total),
+	})
+	if err != nil {
+		return outcomeOf(emitter, completed, false), err
+	}
+	return outcomeOf(emitter, completed, true), nil
+}
+
+func collectVendor(
+	ctx context.Context,
+	emitter *emitter,
+	request remoteprotocol.Request,
+	vendor string,
+	source *Source,
+	home string,
+	now time.Time,
+	alive func(int) bool,
+) (vendorResult, error) {
+	started := time.Now()
+	scanned := scanVendor(vendor, source, home, request, now, alive)
+	if scanned == nil {
+		return vendorResult{}, nil
+	}
+	known := knownFamilies(request, vendor)
+	baselineKnown := request.BaselineMode == remoteprotocol.BaselineKnown
+
+	changed := []*family{}
+	counts := remoteprotocol.Counts{
+		CandidateFamilies: len(scanned.scan.families),
+		CandidateFiles:    scanned.scan.candidateFiles,
+		SelectedFiles:     scanned.scan.selectedFiles,
+	}
+	for _, item := range scanned.scan.sortedFamilies() {
+		cached, isKnown := known[item.id]
+		switch {
+		case item.skipReason != "":
+			if !isKnown {
+				continue
+			}
+			if err := emitSkipped(emitter, vendor, item.id, item.skipReason); err != nil {
+				return vendorResult{counts: counts}, err
+			}
+			counts.SkippedFamilies++
+		case baselineKnown && isKnown && cached == item.fingerprint:
+			err := emitter.emit(remoteprotocol.Record{
+				Type: remoteprotocol.RecordUnchanged, Vendor: vendor,
+				FamilyID: item.id, Fingerprint: item.fingerprint,
+			})
+			if err != nil {
+				return vendorResult{counts: counts}, err
+			}
+			counts.SelectedFamilies++
+		case !item.inWindow:
+			// Outside the requested window a family is neither confirmed nor
+			// replaced. Its absence from the response is never deletion, and the
+			// inventory still proves it exists.
+			continue
+		default:
+			changed = append(changed, item)
+		}
+	}
+
+	parser, err := publishChanged(ctx, emitter, request, scanned, changed, known, &counts)
+	result := vendorResult{parser: parser, counts: counts}
+	if err != nil {
+		return result, err
+	}
+
+	if baselineKnown && scanned.scan.complete {
+		for _, id := range sortedKeys(known) {
+			if _, exists := scanned.scan.families[id]; exists {
+				continue
+			}
+			err := emitter.emit(remoteprotocol.Record{
+				Type: remoteprotocol.RecordTombstone, Vendor: vendor, FamilyID: id,
+			})
+			if err != nil {
+				return result, err
+			}
+		}
+	}
+
+	inventory, inventoryComplete := scanned.scan.inventory(request.Limits.MaxInventoryFamilies)
+	// vendor_complete asserts authoritative enumeration, so it is emitted only
+	// when the scan really saw everything. A baseline-free response must also
+	// carry the complete inventory or it cannot authorise any deletion.
+	if !scanned.scan.complete || ctx.Err() != nil {
+		return result, nil
+	}
+	if request.BaselineMode == remoteprotocol.BaselineNone && !inventoryComplete {
+		return result, nil
+	}
+	err = emitter.emit(remoteprotocol.Record{
+		Type: remoteprotocol.RecordVendorComplete, Vendor: vendor,
+		EnumerationComplete: true, InventoryComplete: inventoryComplete,
+		Inventory: inventory, Counts: counts,
+		Timing: timing(parser, time.Since(started)),
+	})
+	if err != nil {
+		return result, err
+	}
+	result.complete = true
+	return result, nil
+}
+
+// vendorResult is what one vendor contributed: whether it could be enumerated
+// authoritatively, how long parsing took, and its coverage counts.
+type vendorResult struct {
+	complete bool
+	parser   time.Duration
+	counts   remoteprotocol.Counts
+}
+
+func addCounts(total *remoteprotocol.Counts, item remoteprotocol.Counts) {
+	total.CandidateFamilies += item.CandidateFamilies
+	total.SelectedFamilies += item.SelectedFamilies
+	total.CandidateFiles += item.CandidateFiles
+	total.SelectedFiles += item.SelectedFiles
+	total.SkippedFamilies += item.SkippedFamilies
+}
+
+// publishChanged parses the changed families and emits one record each. A parse
+// failure is isolated to its own family, and a family whose files moved under
+// the parser is retried before it is reported unstable.
+func publishChanged(
+	ctx context.Context,
+	emitter *emitter,
+	request remoteprotocol.Request,
+	scanned *vendorScan,
+	changed []*family,
+	known map[string]string,
+	counts *remoteprotocol.Counts,
+) (time.Duration, error) {
+	if len(changed) == 0 {
+		return 0, nil
+	}
+	parser := time.Duration(0)
+	started := time.Now()
+	parsed, err := scanned.parse(familyFiles(changed))
+	parser += time.Since(started)
+	byFamily := map[string][]*vendors.ParsedSession{}
+	if err == nil {
+		byFamily = groupByFamily(parsed, changed)
+	}
+	for _, item := range changed {
+		if ctx.Err() != nil {
+			return parser, nil
+		}
+		sessions := byFamily[item.id]
+		if err != nil {
+			// The batch could not be trusted, so this family is parsed alone.
+			retryStarted := time.Now()
+			single, singleErr := scanned.parse(item.files)
+			parser += time.Since(retryStarted)
+			if singleErr != nil {
+				if skipErr := emitSkipped(
+					emitter, scanned.vendor, item.id,
+					boundedReason("transcript could not be parsed", singleErr),
+				); skipErr != nil {
+					return parser, skipErr
+				}
+				counts.SkippedFamilies++
+				continue
+			}
+			sessions = groupByFamily(single, []*family{item})[item.id]
+		}
+		spent, err := publishFamily(emitter, request, scanned, item, sessions, known, counts)
+		parser += spent
+		if err != nil {
+			return parser, err
+		}
+	}
+	return parser, nil
+}
+
+func publishFamily(
+	emitter *emitter,
+	request remoteprotocol.Request,
+	scanned *vendorScan,
+	item *family,
+	sessions []*vendors.ParsedSession,
+	known map[string]string,
+	counts *remoteprotocol.Counts,
+) (time.Duration, error) {
+	parser := time.Duration(0)
+	for attempt := 0; ; attempt++ {
+		if len(sessions) == 0 {
+			return parser, skipFamily(
+				emitter, scanned, item, counts, "no sessions could be parsed for this family",
+			)
+		}
+		if stable, reason := restabilize(scanned, item); !stable {
+			if attempt >= UnstableRetries {
+				return parser, skipFamily(emitter, scanned, item, counts, reason)
+			}
+			started := time.Now()
+			reparsed, err := scanned.parse(item.files)
+			parser += time.Since(started)
+			if err != nil {
+				return parser, skipFamily(
+					emitter, scanned, item, counts,
+					boundedReason("transcript could not be parsed", err),
+				)
+			}
+			sessions = groupByFamily(reparsed, []*family{item})[item.id]
+			continue
+		}
+		facts, err := familyFacts(scanned, item, sessions)
+		if err != nil {
+			return parser, skipFamily(
+				emitter, scanned, item, counts,
+				boundedReason("family facts failed validation", err),
+			)
+		}
+		// A baseline-free response carries no prior fingerprint: the helper was
+		// given no comparison state, and the inventory is the deletion authority.
+		prior := ""
+		if request.BaselineMode == remoteprotocol.BaselineKnown {
+			prior = known[item.id]
+		}
+		emitErr := emitter.emit(remoteprotocol.Record{
+			Type: remoteprotocol.RecordChanged, Vendor: scanned.vendor, FamilyID: item.id,
+			PriorFingerprint: prior, Fingerprint: item.fingerprint, Family: &facts,
+		})
+		if emitErr != nil {
+			return parser, emitErr
+		}
+		counts.SelectedFamilies++
+		return parser, nil
+	}
+}
+
+// familyFacts assembles one rooted family. Membership comes from the grouping
+// pass, so the family ID the Mac caches always matches the ID the inventory
+// proves exists.
+func familyFacts(
+	scanned *vendorScan,
+	item *family,
+	sessions []*vendors.ParsedSession,
+) (remotefacts.Family, error) {
+	present := map[string]bool{}
+	for _, parsed := range sessions {
+		present[parsed.Session.ID] = true
+	}
+	if !present[item.id] {
+		return remotefacts.Family{}, errors.New("family root transcript is unavailable")
+	}
+	state := remotefacts.StateComplete
+	if len(sessions) < len(item.sessionIDs) {
+		state = remotefacts.StatePartial
+	}
+	for _, parsed := range sessions {
+		if parsed.Session.ID == item.id {
+			// Within its family the root has no parent, whatever a header claimed.
+			parsed.ParentID, parsed.SpawnKey = "", ""
+			continue
+		}
+		if parsed.ParentID == "" || !present[parsed.ParentID] {
+			// The linking transcript is missing this generation; keep the session
+			// on its own card rather than dropping collected facts.
+			parsed.ParentID = item.id
+			state = remotefacts.StatePartial
+		}
+	}
+	return remotefacts.FromParsed(
+		scanned.vendor, item.id, vendors.ParserVersion, state, "",
+		sessions, scanned.metadata, item.fingerprints, item.headerMappings,
+	)
+}
+
+// restabilize re-stats a family's files after the parse. Fingerprint equality is
+// an optimisation, not proof of immutability, so a file that moved under the
+// parser invalidates the facts just produced.
+func restabilize(scanned *vendorScan, item *family) (bool, string) {
+	if item.identityUnstable {
+		return false, "transcript family header changed while it was read"
+	}
+	stable := true
+	for _, file := range item.files {
+		before, ok := scanned.fileFacts[file]
+		if !ok {
+			return false, "transcript disappeared while it was read"
+		}
+		info, err := scanned.statFile(file)
+		if err != nil {
+			return false, "transcript disappeared while it was read"
+		}
+		if info.Size() != before.Size || info.ModTime().UnixMilli() != before.ModifiedAtMs {
+			stable = false
+			refreshed := before
+			refreshed.Size = info.Size()
+			refreshed.ModifiedAtMs = info.ModTime().UnixMilli()
+			scanned.fileFacts[file] = refreshed
+			for index := range item.fingerprints {
+				if item.fingerprints[index].Key == refreshed.Key {
+					item.fingerprints[index] = refreshed
+				}
+			}
+		}
+	}
+	if stable {
+		return true, ""
+	}
+	if scanned.vendor == vendors.AgentCodex && !codexHeadersStillMatch(scanned, item) {
+		item.identityUnstable = true
+		return false, "transcript family header changed while it was read"
+	}
+	item.fingerprint = aggregateFingerprint(item, scanned.metadata)
+	return false, "transcript changed while it was read"
+}
+
+func codexHeadersStillMatch(scanned *vendorScan, item *family) bool {
+	expected := make(map[string]remotefacts.HeaderMapping, len(item.headerMappings))
+	for _, mapping := range item.headerMappings {
+		expected[mapping.Key] = mapping
+	}
+	for file, header := range codex.HeadersSource(scanned.source, item.files) {
+		fingerprint, ok := scanned.fileFacts[file]
+		mapping, mapped := expected[fingerprint.Key]
+		if !ok || !mapped || header.Err != nil || mapping.SessionID != header.SessionID ||
+			mapping.ParentID != header.ParentID {
+			return false
+		}
+	}
+	return true
+}
+
+func skipFamily(
+	emitter *emitter,
+	scanned *vendorScan,
+	item *family,
+	counts *remoteprotocol.Counts,
+	reason string,
+) error {
+	if err := emitSkipped(emitter, scanned.vendor, item.id, reason); err != nil {
+		return err
+	}
+	counts.SkippedFamilies++
+	return nil
+}
+
+func emitSkipped(emitter *emitter, vendor, familyID, reason string) error {
+	return emitter.emit(remoteprotocol.Record{
+		Type: remoteprotocol.RecordSkipped, Vendor: vendor,
+		FamilyID: familyID, Reason: reason,
+	})
+}
+
+// groupByFamily maps parsed sessions onto the families the grouping pass built.
+// A session the grouping pass never saw belongs to no requested family and is
+// dropped rather than published under a guessed identity.
+func groupByFamily(
+	parsed []*vendors.ParsedSession,
+	families []*family,
+) map[string][]*vendors.ParsedSession {
+	owner := map[string]string{}
+	for _, item := range families {
+		for _, id := range item.sessionIDs {
+			owner[id] = item.id
+		}
+	}
+	result := map[string][]*vendors.ParsedSession{}
+	for _, item := range parsed {
+		if item == nil || item.Session == nil {
+			continue
+		}
+		familyID, ok := owner[item.Session.ID]
+		if !ok {
+			continue
+		}
+		result[familyID] = append(result[familyID], item)
+	}
+	return result
+}
+
+func scanVendor(
+	vendor string,
+	source *Source,
+	home string,
+	request remoteprotocol.Request,
+	now time.Time,
+	alive func(int) bool,
+) *vendorScan {
+	switch vendor {
+	case vendors.AgentClaude:
+		return scanClaude(source, home, request.SinceMs, now, alive)
+	case vendors.AgentCodex:
+		return scanCodex(source, home, request)
+	default:
+		return nil
+	}
+}
+
+func knownFamilies(request remoteprotocol.Request, vendor string) map[string]string {
+	known := map[string]string{}
+	if request.BaselineMode != remoteprotocol.BaselineKnown {
+		return known
+	}
+	for _, item := range request.Known {
+		if item.Vendor == vendor {
+			known[item.FamilyID] = item.Fingerprint
+		}
+	}
+	return known
+}
+
+func familyFiles(families []*family) []string {
+	files := []string{}
+	for _, item := range families {
+		files = append(files, item.files...)
+	}
+	sort.Strings(files)
+	return files
+}
+
+func sortedKeys(values map[string]string) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func timing(parser, total time.Duration) remoteprotocol.Timing {
+	parserMs := parser.Milliseconds()
+	totalMs := total.Milliseconds()
+	if parserMs > totalMs {
+		parserMs = totalMs
+	}
+	return remoteprotocol.Timing{ParserMs: parserMs, TotalMs: totalMs}
+}
+
+func outcomeOf(emitter *emitter, completed []string, requestComplete bool) Outcome {
+	return Outcome{
+		Records: emitter.records, Bytes: emitter.bytes,
+		VendorsComplete: completed, RequestComplete: requestComplete,
+	}
+}
+
+// boundedReason keeps a structured skip reason inside the schema's display bound
+// and never repeats a path or transcript content back to the Mac.
+func boundedReason(reason string, err error) string {
+	if err == nil {
+		return reason
+	}
+	switch {
+	case errors.Is(err, ErrFileLimit):
+		return reason + ": file exceeds the size limit"
+	case errors.Is(err, ErrEntryLimit), errors.Is(err, ErrDepthLimit):
+		return reason + ": safety limit reached"
+	case errors.Is(err, ErrSymlink):
+		return reason + ": symlinks are not followed"
+	case errors.Is(err, ErrPathDenied):
+		return reason + ": path is outside the read allowlist"
+	case errors.Is(err, vendors.ErrInvalidData):
+		return reason + ": transcript data is invalid"
+	case errors.Is(err, os.ErrNotExist):
+		return reason + ": file no longer exists"
+	case errors.Is(err, os.ErrPermission):
+		return reason + ": file is not readable"
+	default:
+		return reason
+	}
+}

--- a/collector/internal/remotehelper/emit.go
+++ b/collector/internal/remotehelper/emit.go
@@ -1,0 +1,78 @@
+package remotehelper
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/centauri-ai/coslash/collector/internal/remotefacts"
+	"github.com/centauri-ai/coslash/collector/internal/remoteprotocol"
+	"github.com/centauri-ai/coslash/collector/internal/vendors"
+)
+
+// emitter writes strict NDJSON with a gapless sequence and enforces the record,
+// count, and response ceilings the request negotiated. Each record is flushed on
+// its own line so a response cut short still delivers whole records the Mac can
+// apply.
+type emitter struct {
+	writer   *bufio.Writer
+	request  remoteprotocol.Request
+	sequence int
+	bytes    int
+	records  int
+}
+
+func newEmitter(output io.Writer, request remoteprotocol.Request) *emitter {
+	return &emitter{writer: bufio.NewWriter(output), request: request}
+}
+
+func (e *emitter) emit(record remoteprotocol.Record) error {
+	record.ProtocolVersion = remoteprotocol.ProtocolVersion
+	record.RequestID = e.request.RequestID
+	record.Sequence = e.sequence + 1
+	line, err := marshalRecord(record)
+	if err != nil {
+		return err
+	}
+	if len(bytes.TrimRight(line, "\n")) > e.request.Limits.MaxRecordBytes {
+		return fmt.Errorf("%w: %s record", ErrRecordLimit, record.Type)
+	}
+	if e.records+1 > e.request.Limits.MaxRecords {
+		return fmt.Errorf("%w: record count", ErrRecordLimit)
+	}
+	if e.bytes+len(line) > e.request.Limits.MaxResponseBytes {
+		return fmt.Errorf("%w: response bytes", ErrRecordLimit)
+	}
+	if _, err := e.writer.Write(line); err != nil {
+		return err
+	}
+	if err := e.writer.Flush(); err != nil {
+		return err
+	}
+	e.sequence++
+	e.records++
+	e.bytes += len(line)
+	return nil
+}
+
+func (e *emitter) handshake() error {
+	return e.emit(remoteprotocol.Record{
+		Type:          remoteprotocol.RecordHandshake,
+		BaselineID:    e.request.BaselineID,
+		SchemaVersion: remotefacts.SchemaVersion,
+		ParserVersion: vendors.ParserVersion,
+		Capabilities:  Capabilities,
+	})
+}
+
+func marshalRecord(record remoteprotocol.Record) ([]byte, error) {
+	var buffer bytes.Buffer
+	encoder := json.NewEncoder(&buffer)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(record); err != nil {
+		return nil, fmt.Errorf("encode %s record: %w", record.Type, err)
+	}
+	return buffer.Bytes(), nil
+}

--- a/collector/internal/remotehelper/families.go
+++ b/collector/internal/remotehelper/families.go
@@ -1,0 +1,164 @@
+package remotehelper
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/centauri-ai/coslash/collector/internal/remotefacts"
+	"github.com/centauri-ai/coslash/collector/internal/vendors"
+)
+
+// family is one replacement unit: the files whose facts compose one card, the
+// sessions those files carry, and the fingerprint that decides whether the Mac
+// already holds its facts.
+type family struct {
+	id               string
+	files            []string
+	sessionIDs       []string
+	fingerprints     []vendors.FileFingerprint
+	headerMappings   []remotefacts.HeaderMapping
+	fingerprint      string
+	inWindow         bool
+	skipReason       string
+	identityUnstable bool
+}
+
+// scan is one vendor's enumeration result. Complete is the deletion gate: it is
+// true only when the whole allowlisted tree was listed without a skip, a limit,
+// or a missing-root surprise, because absence can only be proven by a scan that
+// saw everything.
+type scan struct {
+	families       map[string]*family
+	order          []string
+	candidateFiles int
+	selectedFiles  int
+	complete       bool
+	incompleteWhy  string
+}
+
+func newScan() *scan {
+	return &scan{families: map[string]*family{}}
+}
+
+func (s *scan) family(id string) *family {
+	existing, ok := s.families[id]
+	if ok {
+		return existing
+	}
+	created := &family{id: id}
+	s.families[id] = created
+	s.order = append(s.order, id)
+	return created
+}
+
+// add records one discovered file against its family. Fingerprints stay sorted
+// and unique by key so the aggregate is order-independent.
+func (s *scan) add(
+	familyID, sessionID string,
+	fingerprint vendors.FileFingerprint,
+	file string,
+	selected bool,
+) {
+	item := s.family(familyID)
+	item.files = append(item.files, file)
+	if sessionID != "" {
+		item.sessionIDs = append(item.sessionIDs, sessionID)
+	}
+	item.fingerprints = append(item.fingerprints, fingerprint)
+	item.inWindow = item.inWindow || selected
+}
+
+// finish computes each family's aggregate fingerprint. Metadata facts join the
+// hash so a session that only changed liveness or name still recollects, which
+// a file-only fingerprint would report as unchanged forever.
+func (s *scan) finish(metadata *vendors.SessionMetadata) {
+	for _, item := range s.families {
+		sort.Strings(item.files)
+		sort.Strings(item.sessionIDs)
+		sort.Slice(item.fingerprints, func(i, j int) bool {
+			return item.fingerprints[i].Key < item.fingerprints[j].Key
+		})
+		item.fingerprints = dedupeFingerprints(item.fingerprints)
+		sort.Slice(item.headerMappings, func(i, j int) bool {
+			return item.headerMappings[i].Key < item.headerMappings[j].Key
+		})
+		item.sessionIDs = dedupeStrings(item.sessionIDs)
+		item.fingerprint = aggregateFingerprint(item, metadata)
+	}
+}
+
+func (s *scan) sortedFamilies() []*family {
+	result := make([]*family, 0, len(s.families))
+	for _, id := range s.order {
+		result = append(result, s.families[id])
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].id < result[j].id })
+	return result
+}
+
+// inventory is the bounded authoritative family list a complete scan can prove.
+func (s *scan) inventory(limit int) ([]string, bool) {
+	ids := make([]string, 0, len(s.families))
+	for id := range s.families {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	if !s.complete || len(ids) > limit {
+		return nil, false
+	}
+	return ids, true
+}
+
+// aggregateFingerprint is comparison data only. It is a digest, never a path,
+// and the helper never resolves one that arrives in a request.
+func aggregateFingerprint(item *family, metadata *vendors.SessionMetadata) string {
+	digest := sha256.New()
+	fmt.Fprintf(digest, "v1\n%s\n%s\n", vendors.ParserVersion, item.id)
+	for _, fingerprint := range item.fingerprints {
+		fmt.Fprintf(
+			digest, "f\t%s\t%s\t%s\n", fingerprint.Key,
+			strconv.FormatInt(fingerprint.Size, 10),
+			strconv.FormatInt(fingerprint.ModifiedAtMs, 10),
+		)
+	}
+	if metadata != nil {
+		for _, id := range item.sessionIDs {
+			if name, ok := metadata.Names[id]; ok {
+				fmt.Fprintf(digest, "n\t%s\t%s\n", id, name)
+			}
+			if status, ok := metadata.Live[id]; ok {
+				fmt.Fprintf(digest, "l\t%s\t%s\n", id, status)
+			}
+		}
+	}
+	return hex.EncodeToString(digest.Sum(nil))
+}
+
+func dedupeFingerprints(items []vendors.FileFingerprint) []vendors.FileFingerprint {
+	result := items[:0]
+	previous := ""
+	for _, item := range items {
+		if item.Key == previous {
+			continue
+		}
+		previous = item.Key
+		result = append(result, item)
+	}
+	return result
+}
+
+func dedupeStrings(items []string) []string {
+	result := items[:0]
+	previous := ""
+	for index, item := range items {
+		if index > 0 && item == previous {
+			continue
+		}
+		previous = item
+		result = append(result, item)
+	}
+	return result
+}

--- a/collector/internal/remotehelper/limits.go
+++ b/collector/internal/remotehelper/limits.go
@@ -1,0 +1,59 @@
+// Package remotehelper implements the Linux-side collector the Mac drives over
+// SSH exec. It parses transcripts beside the data and writes bounded protocol
+// records to stdout. It keeps no state between runs, persists no transcript,
+// opens no listener, and never resolves a path supplied by the Mac request.
+package remotehelper
+
+import (
+	"errors"
+	"time"
+)
+
+const (
+	// MaxEntries bounds one collection's directory entries across both vendors.
+	MaxEntries = 200_000
+	// MaxDepth bounds traversal beneath an allowlisted root.
+	MaxDepth = 16
+	// MaxFileBytes bounds one transcript read. Local reads cost disk and CPU
+	// rather than SSH bandwidth, so this is far above the SFTP per-file limit.
+	MaxFileBytes = 512 << 20
+	// CollectDeadline bounds one collect command end to end.
+	CollectDeadline = 4 * time.Minute
+	// UnstableRetries bounds re-parsing a family whose files moved under it.
+	UnstableRetries = 2
+)
+
+// Capabilities is the uniquely sorted capability set the handshake advertises.
+var Capabilities = []string{"claude", "codex", "inventory", "tombstones", "unchanged"}
+
+var (
+	ErrPathDenied  = errors.New("path is outside the helper read allowlist")
+	ErrSymlink     = errors.New("helper does not follow symlinks")
+	ErrNotRegular  = errors.New("path is not a regular file")
+	ErrFileLimit   = errors.New("file exceeds the helper byte limit")
+	ErrEntryLimit  = errors.New("collection exceeds the directory entry limit")
+	ErrDepthLimit  = errors.New("path exceeds the directory depth limit")
+	ErrRecordLimit = errors.New("record exceeds the response byte limit")
+	ErrDeadline    = errors.New("collection deadline exceeded")
+)
+
+// Limits are the helper-owned traversal bounds. Response bounds arrive in the
+// request; traversal bounds are never negotiable from the Mac side.
+type Limits struct {
+	MaxEntries   int64
+	MaxDepth     int
+	MaxFileBytes int64
+}
+
+func (limits Limits) withDefaults() Limits {
+	if limits.MaxEntries <= 0 {
+		limits.MaxEntries = MaxEntries
+	}
+	if limits.MaxDepth <= 0 {
+		limits.MaxDepth = MaxDepth
+	}
+	if limits.MaxFileBytes <= 0 {
+		limits.MaxFileBytes = MaxFileBytes
+	}
+	return limits
+}

--- a/collector/internal/remotehelper/nofollow_other.go
+++ b/collector/internal/remotehelper/nofollow_other.go
@@ -1,0 +1,9 @@
+//go:build !unix
+
+package remotehelper
+
+// The helper ships for Linux. Elsewhere the open flag is unavailable, and the
+// lstat check plus the confined root handle remain the symlink boundary.
+const openNoFollow = 0
+
+func isSymlinkOpenErr(error) bool { return false }

--- a/collector/internal/remotehelper/nofollow_unix.go
+++ b/collector/internal/remotehelper/nofollow_unix.go
@@ -1,0 +1,18 @@
+//go:build unix
+
+package remotehelper
+
+import (
+	"errors"
+	"syscall"
+)
+
+// openNoFollow refuses a final path component that became a symlink after it
+// was inspected.
+const openNoFollow = syscall.O_NOFOLLOW
+
+// isSymlinkOpenErr recognises the refusal. Linux reports ELOOP; the BSDs report
+// EMLINK for O_NOFOLLOW.
+func isSymlinkOpenErr(err error) bool {
+	return errors.Is(err, syscall.ELOOP) || errors.Is(err, syscall.EMLINK)
+}

--- a/collector/internal/remotehelper/remotehelper_test.go
+++ b/collector/internal/remotehelper/remotehelper_test.go
@@ -1,0 +1,97 @@
+package remotehelper
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/centauri-ai/coslash/collector/internal/remoteprotocol"
+	"github.com/centauri-ai/coslash/collector/internal/vendors"
+)
+
+func TestSourceEntryLimitIsEnforcedWhileReadingDirectory(t *testing.T) {
+	home := t.TempDir()
+	root := filepath.Join(home, ".codex", "sessions")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"a", "b", "c", "d"} {
+		if err := os.WriteFile(filepath.Join(root, name), nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	source, err := OpenSource(home, Limits{MaxEntries: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer source.Close()
+	if _, err := source.ReadDir(root); !errors.Is(err, ErrEntryLimit) {
+		t.Fatalf("ReadDir error = %v, want ErrEntryLimit", err)
+	}
+}
+
+func TestCodexScanReusesUnchangedCachedHeader(t *testing.T) {
+	home := t.TempDir()
+	root := filepath.Join(home, ".codex", "sessions")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	id := "019f4dde-db5b-7100-bdc0-09b5aaaac56f"
+	file := filepath.Join(root, "rollout-2026-07-10T14-11-18-"+id+".jsonl")
+	// Deliberately not a valid Codex header. Successful attribution proves the
+	// unchanged cached mapping was used instead of reopening the first row.
+	if err := os.WriteFile(file, []byte("not-json\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	source, err := OpenSource(home, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer source.Close()
+	fingerprints, err := vendors.FingerprintSourceFiles(source, root, []string{file})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fp := fingerprints[0]
+	request := validRequest()
+	request.Known = []remoteprotocol.KnownFamily{{
+		Vendor: "codex", FamilyID: id, Fingerprint: "family-fingerprint",
+		Headers: []remoteprotocol.KnownHeader{{
+			Key: fp.Key, Size: fp.Size, ModifiedAtMs: fp.ModifiedAtMs, SessionID: id,
+		}},
+	}}
+	scan := scanCodex(source, home, request)
+	item := scan.scan.families[id]
+	if item == nil || item.skipReason != "" || len(item.headerMappings) != 1 {
+		t.Fatalf("cached header was not reused: %#v", item)
+	}
+}
+
+func TestEmitterReportsNegotiatedOutputLimit(t *testing.T) {
+	request := validRequest()
+	request.Limits.MaxRecords = 1
+	var output discardWriter
+	_, err := Collect(context.Background(), request, Options{Home: t.TempDir()}, &output)
+	if !errors.Is(err, ErrRecordLimit) {
+		t.Fatalf("Collect error = %v, want ErrRecordLimit", err)
+	}
+}
+
+func validRequest() remoteprotocol.Request {
+	return remoteprotocol.Request{
+		RequestID: "req-1", Protocol: remoteprotocol.VersionRange{Min: 1, Max: 1},
+		Schema: remoteprotocol.VersionRange{Min: 1, Max: 1}, ParserVersion: vendors.ParserVersion,
+		BaselineMode: remoteprotocol.BaselineKnown, BaselineID: "base-1",
+		CollectedAtMs: time.Now().UnixMilli(), Vendors: []string{"codex"},
+		Limits: remoteprotocol.Limits{MaxRecordBytes: remoteprotocol.MaxRecordBytes,
+			MaxResponseBytes: remoteprotocol.MaxResponseBytes, MaxRecords: 100,
+			MaxInventoryFamilies: remoteprotocol.MaxInventoryFamilies},
+	}
+}
+
+type discardWriter struct{}
+
+func (*discardWriter) Write(data []byte) (int, error) { return len(data), nil }

--- a/collector/internal/remotehelper/remotehelper_test.go
+++ b/collector/internal/remotehelper/remotehelper_test.go
@@ -3,6 +3,7 @@ package remotehelper
 import (
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,6 +31,34 @@ func TestSourceEntryLimitIsEnforcedWhileReadingDirectory(t *testing.T) {
 	defer source.Close()
 	if _, err := source.ReadDir(root); !errors.Is(err, ErrEntryLimit) {
 		t.Fatalf("ReadDir error = %v, want ErrEntryLimit", err)
+	}
+}
+
+func TestSourceReadsFileAtExactByteLimit(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".codex", "session_index.jsonl")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("four"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	source, err := OpenSource(home, Limits{MaxFileBytes: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer source.Close()
+	file, err := source.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	content, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatalf("ReadAll error = %v", err)
+	}
+	if string(content) != "four" {
+		t.Fatalf("content = %q, want %q", content, "four")
 	}
 }
 

--- a/collector/internal/remotehelper/source.go
+++ b/collector/internal/remotehelper/source.go
@@ -1,0 +1,217 @@
+package remotehelper
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"sync/atomic"
+)
+
+// homeAllowlist is the helper's fixed read allowlist, relative to the SSH user's
+// home. It matches the SFTP allowlist so both transports read the same files.
+var homeAllowlist = []struct {
+	relative string
+	tree     bool
+}{
+	{relative: ".claude/projects", tree: true},
+	{relative: ".claude/sessions", tree: true},
+	{relative: ".claude/jobs", tree: true},
+	{relative: ".codex/sessions", tree: true},
+	{relative: ".codex/archived_sessions", tree: true},
+	{relative: ".codex/session_index.jsonl"},
+}
+
+// Source is the only filesystem access collection has. Every operation resolves
+// beneath one open home directory handle, so a path component swapped for a
+// symlink mid-traversal cannot redirect a read outside the home tree. Names
+// arriving from the vendor parsers are absolute host paths; names arriving from
+// a Mac request are never paths at all and never reach this type.
+type Source struct {
+	root   *os.Root
+	home   string
+	limits Limits
+
+	entries atomic.Int64
+}
+
+// OpenSource opens the home directory once and derives every later read from
+// that handle.
+func OpenSource(home string, limits Limits) (*Source, error) {
+	if !filepath.IsAbs(home) {
+		return nil, fmt.Errorf("%w: home must be absolute", ErrPathDenied)
+	}
+	home = filepath.Clean(home)
+	root, err := os.OpenRoot(home)
+	if err != nil {
+		return nil, fmt.Errorf("open home directory: %w", err)
+	}
+	return &Source{root: root, home: home, limits: limits.withDefaults()}, nil
+}
+
+func (source *Source) Close() error { return source.root.Close() }
+
+func (source *Source) Home() string { return source.home }
+
+func (source *Source) Open(name string) (io.ReadCloser, error) {
+	relative, err := source.resolve(name, false)
+	if err != nil {
+		return nil, err
+	}
+	info, err := source.lstat(relative, name)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%w: %s", ErrNotRegular, name)
+	}
+	if info.Size() > source.limits.MaxFileBytes {
+		return nil, fmt.Errorf("%w: %s", ErrFileLimit, name)
+	}
+	// O_NOFOLLOW rejects a final component swapped for a symlink after the
+	// lstat above; the root handle confines every earlier component.
+	file, err := source.root.OpenFile(relative, os.O_RDONLY|openNoFollow, 0)
+	if err != nil {
+		if isSymlinkOpenErr(err) {
+			return nil, fmt.Errorf("%w: %s", ErrSymlink, name)
+		}
+		return nil, err
+	}
+	return &boundedFile{File: file, path: name, left: source.limits.MaxFileBytes}, nil
+}
+
+func (source *Source) ReadDir(name string) ([]fs.DirEntry, error) {
+	relative, err := source.resolve(name, true)
+	if err != nil {
+		return nil, err
+	}
+	info, err := source.lstat(relative, name)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("path is not a directory: %s", name)
+	}
+	directory, err := source.root.OpenFile(relative, os.O_RDONLY|openNoFollow, 0)
+	if err != nil {
+		if isSymlinkOpenErr(err) {
+			return nil, fmt.Errorf("%w: %s", ErrSymlink, name)
+		}
+		return nil, err
+	}
+	defer directory.Close()
+	entries := []fs.DirEntry{}
+	for {
+		remaining := source.limits.MaxEntries - source.entries.Load()
+		if remaining < 0 {
+			return nil, ErrEntryLimit
+		}
+		batchSize := int64(1024)
+		if remaining+1 < batchSize {
+			batchSize = remaining + 1
+		}
+		batch, readErr := directory.ReadDir(int(batchSize))
+		if source.entries.Add(int64(len(batch))) > source.limits.MaxEntries {
+			return nil, ErrEntryLimit
+		}
+		entries = append(entries, batch...)
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+		if readErr != nil {
+			return nil, readErr
+		}
+	}
+	// Symlinked entries are dropped rather than followed, so a link planted in
+	// an allowlisted tree is never traversed or parsed.
+	result := slices.DeleteFunc(entries, func(entry fs.DirEntry) bool {
+		return entry.Type()&fs.ModeSymlink != 0
+	})
+	sort.Slice(result, func(i, j int) bool { return result[i].Name() < result[j].Name() })
+	return result, nil
+}
+
+func (source *Source) Stat(name string) (fs.FileInfo, error) {
+	relative, err := source.resolve(name, false)
+	if err != nil {
+		return nil, err
+	}
+	return source.lstat(relative, name)
+}
+
+// lstat never follows a final symlink, so a link is reported as denied instead
+// of silently describing its target.
+func (source *Source) lstat(relative, name string) (fs.FileInfo, error) {
+	info, err := source.root.Lstat(relative)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&fs.ModeSymlink != 0 {
+		return nil, fmt.Errorf("%w: %s", ErrSymlink, name)
+	}
+	return info, nil
+}
+
+// resolve maps an absolute host path to a home-relative name inside the fixed
+// allowlist. It is lexical on purpose: containment is enforced by the root
+// handle, not by resolving the path a second time.
+func (source *Source) resolve(name string, requireTree bool) (string, error) {
+	clean := filepath.Clean(name)
+	if !filepath.IsAbs(clean) {
+		return "", fmt.Errorf("%w: %s", ErrPathDenied, name)
+	}
+	relative, err := filepath.Rel(source.home, clean)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("%w: %s", ErrPathDenied, name)
+	}
+	relative = filepath.ToSlash(relative)
+	for _, allowed := range homeAllowlist {
+		if requireTree && !allowed.tree {
+			continue
+		}
+		if relative == allowed.relative {
+			return relative, nil
+		}
+		if !allowed.tree || !strings.HasPrefix(relative, allowed.relative+"/") {
+			continue
+		}
+		if depth(relative, allowed.relative) > source.limits.MaxDepth {
+			return "", fmt.Errorf("%w: %s", ErrDepthLimit, name)
+		}
+		return relative, nil
+	}
+	return "", fmt.Errorf("%w: %s", ErrPathDenied, name)
+}
+
+func depth(relative, root string) int {
+	trimmed := strings.TrimPrefix(strings.TrimPrefix(relative, root), "/")
+	if trimmed == "" {
+		return 0
+	}
+	return strings.Count(trimmed, "/") + 1
+}
+
+// boundedFile stops a transcript read at the helper's per-file limit even when
+// the file grows while it is being parsed.
+type boundedFile struct {
+	*os.File
+	path string
+	left int64
+}
+
+func (file *boundedFile) Read(buffer []byte) (int, error) {
+	if file.left <= 0 {
+		return 0, fmt.Errorf("%w: %s", ErrFileLimit, file.path)
+	}
+	if int64(len(buffer)) > file.left {
+		buffer = buffer[:file.left]
+	}
+	read, err := file.File.Read(buffer)
+	file.left -= int64(read)
+	return read, err
+}

--- a/collector/internal/remotehelper/source.go
+++ b/collector/internal/remotehelper/source.go
@@ -205,8 +205,18 @@ type boundedFile struct {
 }
 
 func (file *boundedFile) Read(buffer []byte) (int, error) {
-	if file.left <= 0 {
-		return 0, fmt.Errorf("%w: %s", ErrFileLimit, file.path)
+	if len(buffer) == 0 {
+		return 0, nil
+	}
+	if file.left == 0 {
+		// Probe for EOF before reporting the limit. A file that is exactly the
+		// configured size is valid; a file that grew after the initial stat is not.
+		var probe [1]byte
+		read, err := file.File.Read(probe[:])
+		if read > 0 {
+			return 0, fmt.Errorf("%w: %s", ErrFileLimit, file.path)
+		}
+		return 0, err
 	}
 	if int64(len(buffer)) > file.left {
 		buffer = buffer[:file.left]

--- a/collector/internal/remotehelper/vendorscan.go
+++ b/collector/internal/remotehelper/vendorscan.go
@@ -1,0 +1,229 @@
+package remotehelper
+
+import (
+	"io/fs"
+	"time"
+
+	"github.com/centauri-ai/coslash/collector/internal/remotefacts"
+	"github.com/centauri-ai/coslash/collector/internal/remoteprotocol"
+	"github.com/centauri-ai/coslash/collector/internal/vendors"
+	"github.com/centauri-ai/coslash/collector/internal/vendors/claude"
+	"github.com/centauri-ai/coslash/collector/internal/vendors/codex"
+)
+
+// vendorScan is one vendor's enumeration plus the parse entry point for its
+// changed families. Grouping reads directory metadata (and, for Codex, header
+// rows only); transcript bodies open during parse and never for a family the
+// Mac already holds.
+type vendorScan struct {
+	vendor   string
+	source   *Source
+	scan     *scan
+	metadata *vendors.SessionMetadata
+	parse    func(files []string) ([]*vendors.ParsedSession, error)
+	// fileFacts is the metadata captured before parsing, which the stability
+	// check compares against afterwards.
+	fileFacts map[string]vendors.FileFingerprint
+}
+
+// statFile re-reads one file's metadata through the same confined source the
+// parse used, so a stability check cannot be redirected by a swapped path.
+func (v *vendorScan) statFile(file string) (fs.FileInfo, error) {
+	return v.source.Stat(file)
+}
+
+func scanClaude(
+	source *Source,
+	home string,
+	since int64,
+	now time.Time,
+	alive func(int) bool,
+) *vendorScan {
+	metadata := vendors.BestEffortMetadata(
+		vendors.AgentClaude,
+		func() (*vendors.SessionMetadata, error) {
+			return claude.LoadRemoteMetadata(source, home, now, alive)
+		},
+	)
+	result := &vendorScan{
+		vendor:    vendors.AgentClaude,
+		source:    source,
+		scan:      newScan(),
+		metadata:  metadata,
+		fileFacts: map[string]vendors.FileFingerprint{},
+		parse: func(files []string) ([]*vendors.ParsedSession, error) {
+			return claude.ParseFamilyFilesSource(source, files)
+		},
+	}
+	root := claude.ProjectsRoot(home)
+	found, err := claude.ScanSource(source, root)
+	if err != nil {
+		result.scan.incompleteWhy = boundedReason("directory scan failed", err)
+		return result
+	}
+	result.scan.complete = found.SkippedTotal == 0
+	if !result.scan.complete {
+		result.scan.incompleteWhy = "some directories or files were unreadable"
+	}
+	result.scan.candidateFiles = len(found.Files)
+	selected := found.Files
+	if since > 0 {
+		selected = claude.FilesSinceSource(source, found.Files, metadata.Live, since)
+	}
+	selected, _ = vendors.LimitNewestSourceFileFamilies(
+		source, selected, vendors.MaxCandidateFilesPerAgent, claude.FamilyIDFromPath,
+	)
+	inWindow := stringSet(selected)
+	result.scan.selectedFiles = len(selected)
+	for _, file := range found.Files {
+		sessionID := claude.SessionIDFromPath(file)
+		result.record(source, root, claude.FamilyIDFromPath(file), sessionID, file, inWindow[file])
+	}
+	result.scan.finish(metadata)
+	return result
+}
+
+func scanCodex(source *Source, home string, request remoteprotocol.Request) *vendorScan {
+	metadata := vendors.BestEffortMetadata(
+		vendors.AgentCodex,
+		func() (*vendors.SessionMetadata, error) { return codex.LoadRemoteMetadata(source, home) },
+	)
+	result := &vendorScan{
+		vendor:    vendors.AgentCodex,
+		source:    source,
+		scan:      newScan(),
+		metadata:  metadata,
+		fileFacts: map[string]vendors.FileFingerprint{},
+		parse: func(files []string) ([]*vendors.ParsedSession, error) {
+			return codex.ParseFamilyFilesSource(source, home, files)
+		},
+	}
+	root := codex.SessionsRoot(home)
+	found, err := codex.ScanSource(source, root)
+	if err != nil {
+		result.scan.incompleteWhy = boundedReason("directory scan failed", err)
+		return result
+	}
+	result.scan.complete = found.SkippedTotal == 0
+	if !result.scan.complete {
+		result.scan.incompleteWhy = "some directories or files were unreadable"
+	}
+	result.scan.candidateFiles = len(found.Files)
+	known := knownCodexHeaders(request)
+	headers := make(map[string]codex.FileHeader, len(found.Files))
+	fingerprints := make(map[string]vendors.FileFingerprint, len(found.Files))
+	readHeaders := make([]string, 0, len(found.Files))
+	for _, file := range found.Files {
+		items, fingerprintErr := vendors.FingerprintSourceFiles(source, root, []string{file})
+		if fingerprintErr == nil && len(items) == 1 {
+			fingerprints[file] = items[0]
+			if cached, ok := known[items[0].Key]; ok && cached.Size == items[0].Size &&
+				cached.ModifiedAtMs == items[0].ModifiedAtMs &&
+				cached.SessionID == codex.SessionIDFromRollout(file) {
+				headers[file] = codex.FileHeader{SessionID: cached.SessionID, ParentID: cached.ParentID}
+				continue
+			}
+		}
+		readHeaders = append(readHeaders, file)
+	}
+	for file, header := range codex.HeadersSource(source, readHeaders) {
+		headers[file] = header
+	}
+	roots := codex.FamilyRoots(headers)
+	selected := found.Files
+	if request.SinceMs > 0 {
+		selected = codex.FilesSinceSource(source, found.Files, metadata.Live, request.SinceMs)
+	}
+	selected, _ = vendors.LimitNewestSourceFileFamilies(
+		source, selected, vendors.MaxCandidateFilesPerAgent,
+		func(file string) string {
+			if id := roots[file]; id != "" {
+				return id
+			}
+			return file
+		},
+	)
+	inWindow := stringSet(selected)
+	result.scan.selectedFiles = len(selected)
+	for _, file := range found.Files {
+		familyID := roots[file]
+		if familyID == "" {
+			// An unattributable rollout could belong to a family that would
+			// otherwise look absent, so enumeration is no longer authoritative.
+			result.scan.complete = false
+			result.scan.incompleteWhy = "a rollout could not be attributed to a family"
+			continue
+		}
+		header := headers[file]
+		sessionID := header.SessionID
+		if sessionID == "" {
+			sessionID = codex.SessionIDFromRollout(file)
+		}
+		fingerprint, ok := fingerprints[file]
+		if !ok {
+			result.record(source, root, familyID, sessionID, file, inWindow[file])
+		} else {
+			result.recordFingerprint(familyID, sessionID, file, fingerprint, inWindow[file])
+		}
+		if ok && header.Err == nil && header.SessionID != "" {
+			item := result.scan.family(familyID)
+			item.headerMappings = append(item.headerMappings, remotefacts.HeaderMapping{
+				Key: fingerprint.Key, SessionID: header.SessionID, ParentID: header.ParentID,
+			})
+		}
+		if header.Err != nil {
+			result.scan.family(familyID).skipReason = boundedReason("header unreadable", header.Err)
+		}
+	}
+	result.scan.finish(metadata)
+	return result
+}
+
+// record fingerprints one file and files it under its family. A file that
+// vanished or became unreadable between listing and stat marks its family
+// skipped for this generation; it is never treated as a deletion.
+func (v *vendorScan) record(
+	source *Source,
+	root, familyID, sessionID, file string,
+	selected bool,
+) {
+	fingerprints, err := vendors.FingerprintSourceFiles(source, root, []string{file})
+	if err != nil || len(fingerprints) != 1 {
+		v.scan.family(familyID).skipReason = boundedReason("file became unreadable", err)
+		return
+	}
+	v.recordFingerprint(familyID, sessionID, file, fingerprints[0], selected)
+}
+
+func (v *vendorScan) recordFingerprint(
+	familyID, sessionID, file string,
+	fingerprint vendors.FileFingerprint,
+	selected bool,
+) {
+	v.fileFacts[file] = fingerprint
+	v.scan.add(familyID, sessionID, fingerprint, file, selected)
+}
+
+func knownCodexHeaders(request remoteprotocol.Request) map[string]remoteprotocol.KnownHeader {
+	result := map[string]remoteprotocol.KnownHeader{}
+	if request.BaselineMode != remoteprotocol.BaselineKnown {
+		return result
+	}
+	for _, family := range request.Known {
+		if family.Vendor != vendors.AgentCodex {
+			continue
+		}
+		for _, header := range family.Headers {
+			result[header.Key] = header
+		}
+	}
+	return result
+}
+
+func stringSet(items []string) map[string]bool {
+	result := make(map[string]bool, len(items))
+	for _, item := range items {
+		result[item] = true
+	}
+	return result
+}

--- a/collector/internal/remoteinstall/install_linux.go
+++ b/collector/internal/remoteinstall/install_linux.go
@@ -1,0 +1,203 @@
+//go:build linux
+
+// Package remoteinstall performs the one-time helper activation on the remote
+// Linux host.  It intentionally uses descriptor-relative operations throughout:
+// a hostile process may rename a directory after it has been opened, but cannot
+// redirect operations performed through that descriptor.
+package remoteinstall
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	fileName = "coslash-helper"
+	tmpName  = fileName + ".new"
+)
+
+var (
+	ErrNoExec = errors.New("helper install directory is not executable")
+	version   = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
+)
+
+// Install copies this running, already authenticated helper into its versioned
+// location below home. The source is /proc/self/exe rather than its launch path,
+// so replacing the staging name after exec cannot change the copied bytes.
+func Install(home, release, expectedSHA256 string) error {
+	source, err := os.Open("/proc/self/exe")
+	if err != nil {
+		return fmt.Errorf("open running helper: %w", err)
+	}
+	defer source.Close()
+	return install(source, home, release, expectedSHA256, nil)
+}
+
+func install(source *os.File, home, release, expectedSHA256 string, beforeWrite func() error) error {
+	if !version.MatchString(release) {
+		return errors.New("invalid helper version")
+	}
+	if len(expectedSHA256) != sha256.Size*2 {
+		return errors.New("invalid helper digest")
+	}
+	if _, err := hex.DecodeString(expectedSHA256); err != nil {
+		return errors.New("invalid helper digest")
+	}
+	hash := sha256.New()
+	if _, err := io.Copy(hash, source); err != nil {
+		return fmt.Errorf("hash running helper: %w", err)
+	}
+	if hex.EncodeToString(hash.Sum(nil)) != expectedSHA256 {
+		return errors.New("running helper digest does not match staged artifact")
+	}
+	homeFD, err := unix.Open(home, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return fmt.Errorf("open helper home: %w", err)
+	}
+	defer unix.Close(homeFD)
+	if err := secureDirectory(homeFD, uint32(os.Geteuid())); err != nil {
+		return fmt.Errorf("verify helper home: %w", err)
+	}
+
+	directoryFD := homeFD
+	for _, component := range []string{".local", "lib", "coslash", "helpers", release} {
+		next, err := openOrCreateDirectory(directoryFD, component, uint32(os.Geteuid()))
+		if directoryFD != homeFD {
+			unix.Close(directoryFD)
+		}
+		if err != nil {
+			return err
+		}
+		directoryFD = next
+	}
+	defer unix.Close(directoryFD)
+
+	var statfs unix.Statfs_t
+	if err := unix.Fstatfs(directoryFD, &statfs); err != nil {
+		return fmt.Errorf("inspect helper filesystem: %w", err)
+	}
+	if statfs.Flags&unix.ST_NOEXEC != 0 {
+		return ErrNoExec
+	}
+	if beforeWrite != nil {
+		if err := beforeWrite(); err != nil {
+			return err
+		}
+	}
+	if err := removeTemporary(directoryFD, uint32(os.Geteuid())); err != nil {
+		return err
+	}
+	temporaryFD, err := unix.Openat(directoryFD, tmpName, unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0o700)
+	if err != nil {
+		return fmt.Errorf("create helper temporary: %w", err)
+	}
+	temporary := os.NewFile(uintptr(temporaryFD), tmpName)
+	defer temporary.Close()
+
+	if _, err := source.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("rewind running helper: %w", err)
+	}
+	if _, err := io.Copy(temporary, source); err != nil {
+		return fmt.Errorf("write helper temporary: %w", err)
+	}
+	if err := unix.Fchmod(temporaryFD, 0o700); err != nil {
+		return fmt.Errorf("secure helper temporary: %w", err)
+	}
+	if err := unix.Fsync(temporaryFD); err != nil {
+		return fmt.Errorf("sync helper temporary: %w", err)
+	}
+	if err := secureRegular(temporaryFD, uint32(os.Geteuid())); err != nil {
+		return fmt.Errorf("verify helper temporary: %w", err)
+	}
+	if err := validateExistingDestination(directoryFD, uint32(os.Geteuid())); err != nil {
+		return err
+	}
+	if err := unix.Renameat(directoryFD, tmpName, directoryFD, fileName); err != nil {
+		return fmt.Errorf("activate helper atomically: %w", err)
+	}
+	// A successful rename is the commit point. The digest check above binds the
+	// copied bytes to the authenticated artifact that launched this installer.
+	return nil
+}
+
+func openOrCreateDirectory(parent int, name string, uid uint32) (int, error) {
+	fd, err := unix.Openat(parent, name, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if errors.Is(err, unix.ENOENT) {
+		if err := unix.Mkdirat(parent, name, 0o700); err != nil && !errors.Is(err, unix.EEXIST) {
+			return -1, fmt.Errorf("create helper directory: %w", err)
+		}
+		fd, err = unix.Openat(parent, name, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	}
+	if err != nil {
+		return -1, fmt.Errorf("open helper directory: %w", err)
+	}
+	if err := secureDirectory(fd, uid); err != nil {
+		unix.Close(fd)
+		return -1, fmt.Errorf("verify helper directory: %w", err)
+	}
+	return fd, nil
+}
+
+func removeTemporary(directoryFD int, uid uint32) error {
+	var stat unix.Stat_t
+	err := unix.Fstatat(directoryFD, tmpName, &stat, unix.AT_SYMLINK_NOFOLLOW)
+	if errors.Is(err, unix.ENOENT) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect helper temporary: %w", err)
+	}
+	if !isRegular(stat) || stat.Uid != uid || stat.Mode&0o022 != 0 {
+		return errors.New("unsafe helper temporary")
+	}
+	if err := unix.Unlinkat(directoryFD, tmpName, 0); err != nil {
+		return fmt.Errorf("remove stale helper temporary: %w", err)
+	}
+	return nil
+}
+
+func validateExistingDestination(directoryFD int, uid uint32) error {
+	var stat unix.Stat_t
+	err := unix.Fstatat(directoryFD, fileName, &stat, unix.AT_SYMLINK_NOFOLLOW)
+	if errors.Is(err, unix.ENOENT) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect existing helper: %w", err)
+	}
+	if !isRegular(stat) || stat.Uid != uid || stat.Mode&0o022 != 0 {
+		return errors.New("unsafe existing helper")
+	}
+	return nil
+}
+
+func secureDirectory(fd int, uid uint32) error {
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil {
+		return err
+	}
+	if stat.Mode&unix.S_IFMT != unix.S_IFDIR || stat.Uid != uid || stat.Mode&0o022 != 0 {
+		return errors.New("unsafe helper directory")
+	}
+	return nil
+}
+
+func secureRegular(fd int, uid uint32) error {
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil {
+		return err
+	}
+	if !isRegular(stat) || stat.Uid != uid || stat.Mode&0o022 != 0 {
+		return errors.New("unsafe helper file")
+	}
+	return nil
+}
+
+func isRegular(stat unix.Stat_t) bool { return stat.Mode&unix.S_IFMT == unix.S_IFREG }

--- a/collector/internal/remoteinstall/install_linux_test.go
+++ b/collector/internal/remoteinstall/install_linux_test.go
@@ -1,0 +1,64 @@
+//go:build linux
+
+package remoteinstall
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInstallKeepsOpenedVersionDirectoryAcrossIntermediateSwap(t *testing.T) {
+	home := t.TempDir()
+	versionDir := filepath.Join(home, ".local", "lib", "coslash", "helpers", "v1")
+	// All components exist before the operation begins, just as they do in the
+	// replacement attack.
+	if err := os.MkdirAll(versionDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for directory := versionDir; directory != home; directory = filepath.Dir(directory) {
+		if err := os.Chmod(directory, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sourcePath := filepath.Join(home, "source")
+	content := []byte("verified static helper bytes")
+	if err := os.WriteFile(sourcePath, content, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer source.Close()
+
+	helpers := filepath.Dir(versionDir)
+	moved := filepath.Join(home, "helpers-validated")
+	attacker := filepath.Join(home, "attacker")
+	if err := os.Mkdir(attacker, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	digest := fmt.Sprintf("%x", sha256.Sum256(content))
+	err = install(source, home, "v1", digest, func() error {
+		if err := os.Rename(helpers, moved); err != nil {
+			return err
+		}
+		return os.Symlink(attacker, helpers)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	installed, err := os.ReadFile(filepath.Join(moved, "v1", fileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(installed, content) {
+		t.Fatalf("installed bytes = %q, want %q", installed, content)
+	}
+	if _, err := os.Stat(filepath.Join(attacker, "v1", fileName)); !os.IsNotExist(err) {
+		t.Fatalf("attacker tree received helper: %v", err)
+	}
+}

--- a/collector/internal/remoteinstall/install_other.go
+++ b/collector/internal/remoteinstall/install_other.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+package remoteinstall
+
+import "errors"
+
+var ErrNoExec = errors.New("helper install directory is not executable")
+
+func Install(string, string, string) error {
+	return errors.New("secure helper installation requires linux")
+}

--- a/collector/internal/remoteprotocol/capabilities.go
+++ b/collector/internal/remoteprotocol/capabilities.go
@@ -1,0 +1,94 @@
+package remoteprotocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/centauri-ai/coslash/collector/internal/remotefacts"
+)
+
+// MaxCapabilityBytes bounds the capability document a helper prints. It is far
+// smaller than a collect response because it carries versions, not facts.
+const MaxCapabilityBytes = 8 << 10
+
+// Capabilities is what a helper answers before any collection: the protocol and
+// schema ranges it supports, plus identity for diagnostics. Compatibility is
+// decided by overlapping ranges, so helper and Mac build strings never need to
+// match.
+type Capabilities struct {
+	Protocol      VersionRange `json:"protocol"`
+	Schema        VersionRange `json:"schema"`
+	ParserVersion string       `json:"parser_version"`
+	Capabilities  []string     `json:"capabilities,omitempty"`
+	Build         string       `json:"build,omitempty"`
+	OS            string       `json:"os,omitempty"`
+	Arch          string       `json:"arch,omitempty"`
+}
+
+// Compatible reports whether this Mac can speak to the helper at all.
+func (c Capabilities) Compatible() bool {
+	return supports(c.Protocol, ProtocolVersion) && supports(c.Schema, remotefacts.SchemaVersion)
+}
+
+// Deprecated reports a helper that still works but no longer offers the current
+// protocol as its newest, which is the prompt-to-upgrade case.
+func (c Capabilities) Deprecated() bool {
+	return c.Compatible() && (c.Protocol.Max < ProtocolVersion || c.Schema.Max < remotefacts.SchemaVersion)
+}
+
+func (c Capabilities) Validate() error {
+	if c.Protocol.Min <= 0 || c.Protocol.Max < c.Protocol.Min {
+		return errors.New("invalid protocol range")
+	}
+	if c.Schema.Min <= 0 || c.Schema.Max < c.Schema.Min {
+		return errors.New("invalid schema range")
+	}
+	if !validID(c.ParserVersion) {
+		return errors.New("invalid parser_version")
+	}
+	if len(c.Capabilities) > 32 {
+		return errors.New("capability list exceeds limit")
+	}
+	previous := ""
+	for _, capability := range c.Capabilities {
+		if !validID(capability) || capability <= previous {
+			return errors.New("capabilities must be uniquely sorted")
+		}
+		previous = capability
+	}
+	for _, value := range []string{c.Build, c.OS, c.Arch} {
+		if len(value) > remotefacts.MaxIDBytes {
+			return errors.New("capability identity exceeds limit")
+		}
+	}
+	return nil
+}
+
+// DecodeCapabilities reads one bounded capability document. Trailing content is
+// rejected so a helper cannot smuggle extra output past the handshake.
+func DecodeCapabilities(reader io.Reader) (Capabilities, error) {
+	limited := &io.LimitedReader{R: reader, N: MaxCapabilityBytes + 1}
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return Capabilities{}, fmt.Errorf("read capabilities: %w", err)
+	}
+	if len(data) > MaxCapabilityBytes {
+		return Capabilities{}, errors.New("capabilities exceed byte limit")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var capabilities Capabilities
+	if err := decoder.Decode(&capabilities); err != nil {
+		return Capabilities{}, fmt.Errorf("decode capabilities: %w", err)
+	}
+	if decoder.Decode(&struct{}{}) != io.EOF {
+		return Capabilities{}, errors.New("trailing content after capabilities")
+	}
+	if err := capabilities.Validate(); err != nil {
+		return Capabilities{}, err
+	}
+	return capabilities, nil
+}

--- a/collector/internal/remoteprotocol/protocol.go
+++ b/collector/internal/remoteprotocol/protocol.go
@@ -21,6 +21,7 @@ const (
 	MaxResponseBytes     = 32 << 20
 	MaxRecords           = 4096
 	MaxKnownFamilies     = 1024
+	MaxKnownHeaders      = 2048
 	MaxInventoryFamilies = 2048
 )
 
@@ -47,9 +48,17 @@ type Limits struct {
 	MaxInventoryFamilies int `json:"max_inventory_families"`
 }
 type KnownFamily struct {
-	Vendor      string `json:"vendor"`
-	FamilyID    string `json:"family_id"`
-	Fingerprint string `json:"fingerprint"`
+	Vendor      string        `json:"vendor"`
+	FamilyID    string        `json:"family_id"`
+	Fingerprint string        `json:"fingerprint"`
+	Headers     []KnownHeader `json:"headers,omitempty"`
+}
+type KnownHeader struct {
+	Key          string `json:"key"`
+	Size         int64  `json:"size"`
+	ModifiedAtMs int64  `json:"modified_at_ms"`
+	SessionID    string `json:"session_id"`
+	ParentID     string `json:"parent_id,omitempty"`
 }
 type Request struct {
 	RequestID     string        `json:"request_id"`
@@ -69,6 +78,14 @@ type Request struct {
 // complete known set cannot fit. It never sends a partial known baseline.
 func BuildRequest(request Request, known []KnownFamily) (Request, error) {
 	known = append([]KnownFamily(nil), known...)
+	headerCount := 0
+	for index := range known {
+		known[index].Headers = append([]KnownHeader(nil), known[index].Headers...)
+		sort.Slice(known[index].Headers, func(i, j int) bool {
+			return known[index].Headers[i].Key < known[index].Headers[j].Key
+		})
+		headerCount += len(known[index].Headers)
+	}
 	sort.Slice(known, func(i, j int) bool {
 		if known[i].Vendor == known[j].Vendor {
 			return known[i].FamilyID < known[j].FamilyID
@@ -77,7 +94,7 @@ func BuildRequest(request Request, known []KnownFamily) (Request, error) {
 	})
 	request.Known = append([]KnownFamily(nil), known...)
 	request.BaselineMode = BaselineKnown
-	if len(known) > MaxKnownFamilies || encodedSize(request) > MaxRequestBytes {
+	if len(known) > MaxKnownFamilies || headerCount > MaxKnownHeaders || encodedSize(request) > MaxRequestBytes {
 		request.BaselineMode, request.BaselineID, request.Known = BaselineNone, "", []KnownFamily{}
 	}
 	if err := ValidateRequest(request); err != nil {
@@ -113,11 +130,29 @@ func ValidateRequest(r Request) error {
 		previousVendor = vendor
 	}
 	previousKnown := KnownFamily{}
+	headerCount := 0
+	seenHeaderKeys := map[string]bool{}
 	for _, known := range r.Known {
 		if !validVendor(known.Vendor) || !validID(known.FamilyID) || !validID(known.Fingerprint) || known.Vendor < previousKnown.Vendor || (known.Vendor == previousKnown.Vendor && known.FamilyID <= previousKnown.FamilyID) {
 			return errors.New("known families must be valid and uniquely sorted")
 		}
 		previousKnown = known
+		previousKey := ""
+		for _, header := range known.Headers {
+			if known.Vendor != "codex" || !validID(header.Key) || header.Key <= previousKey ||
+				seenHeaderKeys[header.Key] ||
+				header.Size < 0 || header.ModifiedAtMs < 0 ||
+				header.ModifiedAtMs > remotefacts.MaxTimestampMs || !validID(header.SessionID) ||
+				(header.ParentID != "" && !validID(header.ParentID)) {
+				return errors.New("known headers must be valid and uniquely sorted")
+			}
+			previousKey = header.Key
+			seenHeaderKeys[header.Key] = true
+			headerCount++
+		}
+	}
+	if headerCount > MaxKnownHeaders {
+		return errors.New("known header mappings exceed limit")
 	}
 	if r.SinceMs < 0 || r.CollectedAtMs <= 0 || r.SinceMs > r.CollectedAtMs {
 		return errors.New("invalid request window")

--- a/collector/internal/remoteprotocol/protocol_test.go
+++ b/collector/internal/remoteprotocol/protocol_test.go
@@ -2,6 +2,7 @@ package remoteprotocol
 
 import (
 	"bytes"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -45,8 +46,30 @@ func TestBuildRequestDoesNotMutateKnownInput(t *testing.T) {
 	if _, err := BuildRequest(request(), known); err != nil {
 		t.Fatal(err)
 	}
-	if known[0] != original[0] || known[1] != original[1] {
+	if !reflect.DeepEqual(known, original) {
 		t.Fatalf("BuildRequest mutated input: got %#v want %#v", known, original)
+	}
+}
+
+func TestBuildRequestSortsHeaderMappingsAndFallsBackWhenTheyOverflow(t *testing.T) {
+	known := []KnownFamily{{Vendor: "codex", FamilyID: "root", Fingerprint: "fp", Headers: []KnownHeader{
+		{Key: "z", Size: 1, ModifiedAtMs: 1, SessionID: "z"},
+		{Key: "a", Size: 1, ModifiedAtMs: 1, SessionID: "a"},
+	}}}
+	got, err := BuildRequest(request(), known)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Known[0].Headers[0].Key != "a" || known[0].Headers[0].Key != "z" {
+		t.Fatalf("header ordering/input mutation: got %#v input %#v", got.Known, known)
+	}
+	known[0].Headers = make([]KnownHeader, MaxKnownHeaders+1)
+	got, err = BuildRequest(request(), known)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.BaselineMode != BaselineNone || len(got.Known) != 0 {
+		t.Fatalf("header overflow did not discard baseline: %#v", got)
 	}
 }
 

--- a/collector/internal/vendors/claude/family.go
+++ b/collector/internal/vendors/claude/family.go
@@ -1,0 +1,26 @@
+package claude
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/centauri-ai/coslash/collector/internal/vendors"
+)
+
+// SessionIDFromPath returns the session a transcript file carries. Subagent
+// files are named agent-<id>.jsonl, so the file basename is the identity for
+// both roots and children.
+func SessionIDFromPath(file string) string {
+	return strings.TrimSuffix(filepath.Base(file), ".jsonl")
+}
+
+// ParseFamilyFilesSource parses one selected file set through the same pipeline
+// remote collection uses, returning every main-file failure to the caller so
+// one bad transcript can be isolated to its own family.
+func ParseFamilyFilesSource(
+	source vendors.ReadSource,
+	files []string,
+) ([]*vendors.ParsedSession, error) {
+	parsed, _, err := parseFilesSourceStrict(source, files)
+	return parsed, err
+}

--- a/collector/internal/vendors/codex/family.go
+++ b/collector/internal/vendors/codex/family.go
@@ -1,0 +1,95 @@
+package codex
+
+import (
+	"path/filepath"
+
+	"github.com/centauri-ai/coslash/collector/internal/vendors"
+)
+
+// FileHeader is the session identity a rollout's first row carries. Err marks a
+// file whose header could not be read; its family cannot be resolved from it.
+type FileHeader struct {
+	SessionID string
+	ParentID  string
+	Err       error
+}
+
+// HeadersSource reads only the first row of each rollout. Codex families are
+// recoverable only from headers, so grouping reads them before deciding which
+// families changed; transcript bodies stay closed.
+func HeadersSource(source vendors.ReadSource, files []string) map[string]FileHeader {
+	headers := make(map[string]FileHeader, len(files))
+	for _, file := range files {
+		id, parentID, err := readHeaderSource(source, file)
+		headers[file] = FileHeader{SessionID: id, ParentID: parentID, Err: err}
+	}
+	return headers
+}
+
+// FamilyRoots walks parent headers to the root session that names each file's
+// family. A file whose header failed falls back to its filename session ID, and
+// a cycle stops at the session it was first seen from.
+func FamilyRoots(headers map[string]FileHeader) map[string]string {
+	parents := make(map[string]string, len(headers))
+	for _, header := range headers {
+		if header.Err == nil && header.SessionID != "" {
+			parents[header.SessionID] = header.ParentID
+		}
+	}
+	rootID := func(id string) string {
+		seen := map[string]struct{}{}
+		for {
+			parentID, ok := parents[id]
+			if !ok || parentID == "" {
+				return id
+			}
+			if _, repeated := seen[id]; repeated {
+				return id
+			}
+			seen[id] = struct{}{}
+			id = parentID
+		}
+	}
+	roots := make(map[string]string, len(headers))
+	for file, header := range headers {
+		id := header.SessionID
+		if header.Err != nil || id == "" {
+			id = SessionIDFromRollout(file)
+		}
+		if id == "" {
+			continue
+		}
+		roots[file] = rootID(id)
+	}
+	return roots
+}
+
+// ParseFamilyFilesSource parses one selected file set through the same pipeline
+// remote collection uses, returning every main-file failure to the caller so one
+// bad rollout can be isolated to its own family.
+func ParseFamilyFilesSource(
+	source vendors.ReadSource,
+	home string,
+	files []string,
+) ([]*vendors.ParsedSession, error) {
+	parsed, _, err := parseFilesSourceStrict(
+		source,
+		filepath.Join(home, ".codex", "archived_sessions"),
+		files,
+		// Remote collection never inspects the remote working directory, so every
+		// command keeps the approval-required shape both transports agree on.
+		func(string, string) bool { return true },
+	)
+	if err != nil {
+		return nil, err
+	}
+	// Codex currently derives ParsedSession.Name from the first user prompt.
+	// Prompts are outside remote schema v1, so do not let that fallback cross the
+	// helper boundary. Approved session-index metadata remains available.
+	for _, item := range parsed {
+		if item != nil {
+			item.Name = ""
+		}
+	}
+	return parsed, nil
+}

--- a/collector/internal/vendors/codex/family_test.go
+++ b/collector/internal/vendors/codex/family_test.go
@@ -1,0 +1,30 @@
+package codex
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/centauri-ai/coslash/collector/internal/vendors"
+)
+
+func TestParseFamilyFilesSourceDoesNotExposePromptAsName(t *testing.T) {
+	home := t.TempDir()
+	id := "019f4dde-db5b-7100-bdc0-09b5aaaac56f"
+	file := filepath.Join(home, ".codex", "sessions", "rollout-2026-07-10T14-11-18-"+id+".jsonl")
+	if err := os.MkdirAll(filepath.Dir(file), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	content := `{"timestamp":"2026-07-10T14:11:18Z","type":"session_meta","payload":{"id":"` + id + `","session_id":"` + id + `"}}` + "\n" +
+		`{"timestamp":"2026-07-10T14:11:19Z","type":"event_msg","payload":{"type":"user_message","message":"private first prompt"}}` + "\n"
+	if err := os.WriteFile(file, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := ParseFamilyFilesSource(vendors.LocalReadSource, home, []string{file})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(parsed) != 1 || parsed[0].Name != "" {
+		t.Fatalf("remote parsed name exposed prompt: %#v", parsed)
+	}
+}

--- a/collector/internal/vendors/version.go
+++ b/collector/internal/vendors/version.go
@@ -1,0 +1,7 @@
+package vendors
+
+// ParserVersion identifies transcript parser behavior, not the product build.
+// Remote families cache the version that produced their facts, so bump this
+// whenever parsing changes which facts a transcript yields: cached families
+// then recollect even though their files never changed.
+const ParserVersion = "parsers-1"


### PR DESCRIPTION
## Summary

- Add a bounded Linux collection helper.
- Execute it through the existing SSH connection.
- Verify platform, digest, ownership, mode, and protocol.
- Require explicit lifecycle consent and retain SFTP fallback.

## Validation

- Go tests and vet pass.
- Remote, helper, and protocol race tests pass.

## Stack

- 2 of 3.
- Depends on #135.
- Machines integration and release packaging follow in #133.