### PR TITLE
Recognize OpenAI-prefixed model IDs for pricing

### DIFF
--- a/collector/internal/session/models.go
+++ b/collector/internal/session/models.go
@@ -57,6 +57,8 @@ var releaseDateSuffix = regexp.MustCompile(`-\d{4}-?\d{2}-?\d{2}$`)
 
 func modelInfoFor(model string) (modelInfo, bool) {
 	key := strings.TrimSuffix(model, "[1m]")
+	key = strings.TrimPrefix(key, "openai.")
+
 	if info, ok := models[key]; ok {
 		return info, true
 	}


### PR DESCRIPTION
## Context

Some OpenAI sessions report model names with an `openai.` prefix. The pricing lookup did not remove this prefix, so it excluded these models from cost estimates.

## Changes

- Remove the `openai.` prefix before the pricing lookup.

## Test

- `go test ./internal/session` — passed

### Screenshots

- [x] Before — pricing warning for an `openai.`-prefixed model
<img width="1384" height="409" alt="Screenshot 2026-09-01 at 22 57 52" src="https://github.com/user-attachments/assets/03101174-778b-438e-b092-58dee1f64cda" />

- [x] After — cost estimate without the pricing warning
<img width="1393" height="265" alt="Screenshot 2026-09-01 at 23 02 36" src="https://github.com/user-attachments/assets/60d8d970-f54c-4ad8-b1a8-53fee4f09d76" />
