### PR TITLE
Polish remote Machines SSH setup UX

### DIFF
--- a/collector/internal/remote/health.go
+++ b/collector/internal/remote/health.go
@@ -92,11 +92,11 @@ func redactDiagnostic(text string) string {
 func genericErrorCopy(reason Reason) string {
 	switch reason {
 	case ReasonAuthentication:
-		return "SSH authentication failed"
+		return "SSH authentication failed — run ssh once in Terminal, then Retry"
 	case ReasonHostKey:
-		return "SSH host key verification failed"
+		return "SSH host key needs confirmation — run ssh once in Terminal, then Retry"
 	case ReasonConnectionFailed:
-		return "connection failed"
+		return "SSH is not reachable yet — check the alias, then Retry"
 	case ReasonSFTPUnavailable:
 		return "SFTP subsystem unavailable"
 	case ReasonPermissionDenied:

--- a/collector/internal/remote/limits.go
+++ b/collector/internal/remote/limits.go
@@ -15,8 +15,10 @@ const (
 	DefaultMaxDepth       = 16
 	DefaultMaxStderrBytes = 8 << 10
 
-	FreshnessInterval   = 3 * time.Minute
-	InitialRetryBackoff = 3 * time.Minute
+	FreshnessInterval = 3 * time.Minute
+	// Short first retry so fixing SSH (keys/host) recovers the board without a
+	// long wait or a manual Retry click; later failures still back off hard.
+	InitialRetryBackoff = 30 * time.Second
 	MaxRetryBackoff     = 30 * time.Minute
 	ActivityWindowMs    = 2 * 60_000
 	MaxDiagnosticBytes  = 2 << 10

--- a/collector/internal/remote/manager.go
+++ b/collector/internal/remote/manager.go
@@ -858,6 +858,6 @@ func retryBackoff(failures int) time.Duration {
 	if failures <= 1 {
 		return InitialRetryBackoff
 	}
-	delay := InitialRetryBackoff << min(failures-1, 4)
+	delay := InitialRetryBackoff << min(failures-1, 6)
 	return min(delay, MaxRetryBackoff)
 }

--- a/collector/internal/remote/manager.go
+++ b/collector/internal/remote/manager.go
@@ -390,7 +390,21 @@ func (manager *Manager) TestAlias(ctx context.Context, alias string) (Health, er
 		return health, nil
 	}
 	health.State = StateOK
+	// A successful settings test of the active host means SSH works again —
+	// clear backoff and collect so the board strip updates without a manual Retry.
+	manager.recoverAfterSuccessfulTest(alias)
 	return health, nil
+}
+
+func (manager *Manager) recoverAfterSuccessfulTest(alias string) {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if manager.cfg == nil || !manager.cfg.Enabled || manager.cfg.SSHAlias != alias {
+		return
+	}
+	manager.failures = 0
+	manager.nextRetryAt = time.Time{}
+	manager.maybeStartRefreshLocked(manager.lastRequestedMs, true)
 }
 
 func (manager *Manager) DiagnosticsHealth() Health {

--- a/collector/internal/remote/manager_test.go
+++ b/collector/internal/remote/manager_test.go
@@ -739,7 +739,13 @@ func TestSuccessfulAliasTestClearsBackoffAndKicksRefresh(t *testing.T) {
 			default:
 			}
 			return refreshOutcome{
-				Snapshot:  CachedSnapshotV2{Version: cacheV2Version, CoverageSinceMs: now.UnixMilli()},
+				Snapshot: CachedSnapshotV2{
+					Version:         cacheV2Version,
+					CoverageSinceMs: now.UnixMilli(),
+					// Non-empty coverage avoids ReasonNoSupportedData, which would
+					// re-arm limited-state backoff and hide the recovery under test.
+					Coverage: []AgentCoverage{{Agent: "claude", CandidateFiles: 1, SelectedFiles: 1}},
+				},
 				RoundTrip: 20 * time.Millisecond,
 			}, nil
 		},
@@ -767,11 +773,11 @@ func TestSuccessfulAliasTestClearsBackoffAndKicksRefresh(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("successful test did not kick a board refresh")
 	}
-	manager.mu.Lock()
-	defer manager.mu.Unlock()
-	if manager.failures != 0 || !manager.nextRetryAt.IsZero() {
-		t.Fatalf("backoff not cleared: failures=%d nextRetryAt=%v", manager.failures, manager.nextRetryAt)
-	}
+	waitUntil(t, func() bool {
+		manager.mu.Lock()
+		defer manager.mu.Unlock()
+		return manager.state == StateOK && manager.failures == 0 && manager.nextRetryAt.IsZero() && !manager.refreshing
+	})
 }
 
 func strPtr(value string) *string { return &value }

--- a/collector/internal/remote/manager_test.go
+++ b/collector/internal/remote/manager_test.go
@@ -722,6 +722,58 @@ func TestReadOnlyDiscoveryDoesNotFetchAnArtifact(t *testing.T) {
 	}
 }
 
+func TestSuccessfulAliasTestClearsBackoffAndKicksRefresh(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("COSLASH_HOME", home)
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	refreshed := make(chan struct{}, 1)
+	manager := NewManager(Options{
+		Cache: NewCache(filepath.Join(home, "remote-cache")),
+		Now:   func() time.Time { return now },
+		Test: func(context.Context, string) (probeResult, error) {
+			return probeResult{RoundTrip: 12 * time.Millisecond}, nil
+		},
+		Refresh: func(context.Context, string, int64, time.Time, CachedSnapshotV2) (refreshOutcome, error) {
+			select {
+			case refreshed <- struct{}{}:
+			default:
+			}
+			return refreshOutcome{
+				Snapshot:  CachedSnapshotV2{Version: cacheV2Version, CoverageSinceMs: now.UnixMilli()},
+				RoundTrip: 20 * time.Millisecond,
+			}, nil
+		},
+	})
+	if err := manager.ApplySettings(&settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	manager.mu.Lock()
+	manager.state = StateError
+	manager.reason = reasonPtr(ReasonConnectionFailed)
+	manager.failures = 2
+	manager.nextRetryAt = now.Add(30 * time.Minute)
+	manager.lastRequestedMs = now.Add(-time.Hour).UnixMilli()
+	manager.mu.Unlock()
+
+	health, err := manager.TestAlias(context.Background(), "agent-box")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if health.State != StateOK {
+		t.Fatalf("test health = %#v", health)
+	}
+	select {
+	case <-refreshed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("successful test did not kick a board refresh")
+	}
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if manager.failures != 0 || !manager.nextRetryAt.IsZero() {
+		t.Fatalf("backoff not cleared: failures=%d nextRetryAt=%v", manager.failures, manager.nextRetryAt)
+	}
+}
+
 func strPtr(value string) *string { return &value }
 
 func waitUntil(t *testing.T, ready func() bool) {

--- a/collector/internal/remote/manager_test.go
+++ b/collector/internal/remote/manager_test.go
@@ -147,6 +147,15 @@ func TestHardFailureFallsBackToStaleWhenCacheExists(t *testing.T) {
 	manager.mu.Unlock()
 }
 
+func TestRetryBackoffReachesMaximum(t *testing.T) {
+	if got := retryBackoff(7); got != MaxRetryBackoff {
+		t.Fatalf("retryBackoff(7) = %v, want %v", got, MaxRetryBackoff)
+	}
+	if got := retryBackoff(8); got != MaxRetryBackoff {
+		t.Fatalf("retryBackoff(8) = %v, want %v", got, MaxRetryBackoff)
+	}
+}
+
 type fixedHelperRelease struct {
 	document SignedReleaseMetadata
 	content  []byte

--- a/frontend/src/pages/coslash/CoslashPage.tsx
+++ b/frontend/src/pages/coslash/CoslashPage.tsx
@@ -425,7 +425,18 @@ export function CoslashPage() {
 
   const saveSettings = async (...args: Parameters<typeof settingsState.save>) => {
     const ok = await settingsState.save(...args);
-    if (ok) retrySessions();
+    if (ok) {
+      // Kick a remote collect immediately after save so SSH recovery is not
+      // stuck behind the previous failure backoff.
+      setRemoteRetryInFlight(true);
+      void retryRemoteRefresh()
+        .catch(() => undefined)
+        .finally(() => {
+          setRemoteRetryInFlight(false);
+          retrySessions();
+          if (diagnosticsOpen) refreshDiagnostics();
+        });
+    }
     return ok;
   };
 
@@ -548,6 +559,7 @@ export function CoslashPage() {
         saveError={settingsState.saveError}
         isSaving={settingsState.isSaving}
         onSave={saveSettings}
+        onRemoteConnectionVerified={handleRemoteRetry}
       />
     </div>
   );

--- a/frontend/src/pages/coslash/CoslashPage.tsx
+++ b/frontend/src/pages/coslash/CoslashPage.tsx
@@ -48,7 +48,7 @@ import {
   remoteMachine,
 } from '@/pages/coslash/lib/host-strip';
 import { sessionsEmptyStateCopy } from '@/pages/coslash/lib/page-copy';
-import { retryRemoteRefresh } from '@/pages/coslash/lib/remote-api';
+import { retryRemoteRefreshAndWait } from '@/pages/coslash/lib/remote-api';
 import { sessionMatchesSearchTerm } from '@/pages/coslash/lib/search';
 import {
   getSessionVendors,
@@ -414,7 +414,7 @@ export function CoslashPage() {
   const handleRemoteRetry = () => {
     if (remoteRetryInFlight) return;
     setRemoteRetryInFlight(true);
-    void retryRemoteRefresh()
+    void retryRemoteRefreshAndWait()
       .catch(() => undefined)
       .finally(() => {
         setRemoteRetryInFlight(false);
@@ -426,16 +426,7 @@ export function CoslashPage() {
   const saveSettings = async (...args: Parameters<typeof settingsState.save>) => {
     const ok = await settingsState.save(...args);
     if (ok) {
-      // Kick a remote collect immediately after save so SSH recovery is not
-      // stuck behind the previous failure backoff.
-      setRemoteRetryInFlight(true);
-      void retryRemoteRefresh()
-        .catch(() => undefined)
-        .finally(() => {
-          setRemoteRetryInFlight(false);
-          retrySessions();
-          if (diagnosticsOpen) refreshDiagnostics();
-        });
+      handleRemoteRetry();
     }
     return ok;
   };

--- a/frontend/src/pages/coslash/components/MachinesSettingsSection.tsx
+++ b/frontend/src/pages/coslash/components/MachinesSettingsSection.tsx
@@ -15,10 +15,12 @@ export function MachinesSettingsSection({
   remote,
   onChange,
   onOwnershipActionChange,
+  onConnectionVerified,
 }: {
   remote: RemoteHostSettings | null | undefined;
   onChange: (remote: RemoteHostSettings | null) => void;
   onOwnershipActionChange: (action: RemoteOwnershipAction | null) => void;
+  onConnectionVerified?: () => void;
 }) {
   const draft = remote ?? { sshAlias: '', enabled: true };
   const hasHost = remote != null;
@@ -34,6 +36,17 @@ export function MachinesSettingsSection({
   const helperOwned = hostStatus?.helperOwnershipRecorded === true;
   const helperOwnershipCorrupt = hostStatus?.helperOwnershipCorrupt === true;
   const setupFailed = setupResult?.error != null;
+  const connectionOk = testResult?.state === 'ok';
+  const helperNeedsUpgrade = hostStatus?.helper?.state === 'deprecated';
+  const helperInstallAvailable =
+    hasHost &&
+    connectionOk &&
+    hostStatus?.helperInstallationAvailable === true &&
+    hostStatus?.helperProbeState !== 'probing' &&
+    (hostStatus?.helper?.state == null ||
+      hostStatus.helper.state === 'sftp' ||
+      helperNeedsUpgrade ||
+      hostStatus.helper.fallback === true);
 
   useEffect(() => {
     if (!remote?.id) {
@@ -90,13 +103,15 @@ export function MachinesSettingsSection({
     setTestResult(null);
     setSetupResult(null);
     try {
-      setTestResult(await testRemoteAlias(alias));
+      const result = await testRemoteAlias(alias);
+      setTestResult(result);
       try {
         setHostStatus(await remoteStatus());
       } catch {
         // SFTP test success remains useful if the optional helper inspection
         // endpoint is temporarily unavailable.
       }
+      if (result.state === 'ok' && hasHost) onConnectionVerified?.();
     } catch (error: unknown) {
       setTestError(error instanceof Error ? error.message : String(error));
     } finally {
@@ -119,6 +134,7 @@ export function MachinesSettingsSection({
       setSetupResult(result);
       setTestResult(result.machine);
       setHostStatus(result.machine);
+      if (result.error == null) onConnectionVerified?.();
     } catch (error: unknown) {
       setTestError(error instanceof Error ? error.message : String(error));
     } finally {
@@ -152,7 +168,11 @@ export function MachinesSettingsSection({
     setPendingAlias(null);
   };
 
-  const showFirstTimeHint = testResult?.state === 'error' && testResult.reason === 'connection_failed';
+  const showFirstTimeHint =
+    testResult?.state === 'error' &&
+    (testResult.reason === 'connection_failed' ||
+      testResult.reason === 'authentication_failed' ||
+      testResult.reason === 'host_key_failed');
 
   return (
     <div className="flex flex-col gap-2">
@@ -166,8 +186,8 @@ export function MachinesSettingsSection({
         <div className="flex flex-col gap-1 p-4">
           <div className="text-sm font-semibold">Remote host</div>
           <div className="text-muted-foreground text-xs text-pretty">
-            Monitor Claude Code and Codex through your existing SSH config. SFTP works without Linux code; you
-            can explicitly install the optional, verified collection helper for faster refreshes.
+            Monitor Claude Code and Codex through your existing SSH config. Test the connection first; you can
+            install the optional verified helper afterward for faster refreshes.
           </div>
         </div>
 
@@ -250,40 +270,45 @@ export function MachinesSettingsSection({
           </button>
         </div>
 
-        <div className="border-border flex flex-wrap items-center justify-between gap-3 border-t p-4">
+        <div className="border-border flex flex-col gap-3 border-t p-4">
           <div className="flex flex-wrap items-center gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              disabled={testing || !draft.sshAlias.trim()}
-              onClick={() => void runTest()}
-            >
-              {testing ? 'Testing…' : 'Test connection'}
-            </Button>
-            {hasHost && (
+            {!helperInstallAvailable ? (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={testing || helperAction != null || !draft.sshAlias.trim()}
+                onClick={() => void runTest()}
+              >
+                {testing ? 'Testing…' : 'Test connection'}
+              </Button>
+            ) : (
               <>
                 <Button
                   type="button"
-                  variant="outline"
                   size="sm"
-                  disabled={
-                    testing ||
-                    helperAction != null ||
-                    testResult?.state !== 'ok' ||
-                    hostStatus?.helperInstallationAvailable !== true ||
-                    hostStatus?.helperProbeState === 'probing'
-                  }
-                  onClick={() =>
-                    void setupHelper(hostStatus?.helper?.state === 'deprecated' ? 'upgrade' : 'install')
-                  }
+                  disabled={testing || helperAction != null}
+                  onClick={() => void setupHelper(helperNeedsUpgrade ? 'upgrade' : 'install')}
                 >
                   {helperAction != null
                     ? 'Setting up helper…'
-                    : hostStatus?.helper?.state === 'deprecated'
+                    : helperNeedsUpgrade
                       ? 'Upgrade helper'
                       : 'Install helper'}
                 </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  disabled={testing || helperAction != null}
+                  onClick={() => void runTest()}
+                >
+                  {testing ? 'Testing…' : 'Retest SSH'}
+                </Button>
+              </>
+            )}
+            {hasHost && (
+              <>
                 <Button type="button" variant="outline" size="sm" onClick={() => void removeHost('only')}>
                   {removeAction === 'only' ? 'Confirm remove only' : 'Remove host only'}
                 </Button>
@@ -301,6 +326,11 @@ export function MachinesSettingsSection({
               </>
             )}
           </div>
+          {helperInstallAvailable && (
+            <div className="text-muted-foreground text-xs text-pretty">
+              Connection works. Install the optional helper for faster refreshes, or keep using SFTP.
+            </div>
+          )}
         </div>
 
         {hasHost && (
@@ -325,9 +355,6 @@ export function MachinesSettingsSection({
             )}
             {hostStatus?.helperInstallationAvailable === false && (
               <div>Helper installation is unavailable in this build.</div>
-            )}
-            {testResult?.state !== 'ok' && hostStatus?.helperInstallationAvailable !== false && (
-              <div>Test SSH/SFTP before installing or upgrading the helper.</div>
             )}
           </div>
         )}

--- a/frontend/src/pages/coslash/components/SettingsDialog.tsx
+++ b/frontend/src/pages/coslash/components/SettingsDialog.tsx
@@ -184,6 +184,7 @@ export function SettingsDialog({
   saveError,
   isSaving,
   onSave,
+  onRemoteConnectionVerified,
 }: {
   open: boolean;
   mode: SettingsDialogMode;
@@ -194,6 +195,7 @@ export function SettingsDialog({
   saveError: string | null;
   isSaving: boolean;
   onSave: (settings: CoslashSettings, remoteOwnershipAction?: RemoteOwnershipAction) => Promise<boolean>;
+  onRemoteConnectionVerified?: () => void;
 }) {
   const [draft, setDraft] = useState<CoslashSettings | null>(
     response ? initialSettingsDraft(response) : null,
@@ -493,6 +495,7 @@ export function SettingsDialog({
                     setDraft({ ...draft, remote: { ...remote, sshAlias: remote.sshAlias.trim() } });
                   }}
                   onOwnershipActionChange={setRemoteOwnershipAction}
+                  onConnectionVerified={onRemoteConnectionVerified}
                 />
               )}
 

--- a/frontend/src/pages/coslash/lib/host-strip.test.ts
+++ b/frontend/src/pages/coslash/lib/host-strip.test.ts
@@ -43,8 +43,16 @@ describe('Mac-only remote health copy', () => {
   });
 
   it('describes optional-helper setup and first-use SSH guidance', () => {
-    expect(formatTestConnectionResult(machine('ok'))).toContain('optional helper');
+    expect(formatTestConnectionResult(machine('ok'))).toContain('SSH/SFTP is ready');
     expect(firstTimeSshHint('gpu-server')).toContain('ssh gpu-server');
+    expect(firstTimeSshHint('gpu-server')).toContain('Test connection again');
+  });
+
+  it('uses recoverable tone for first-time SSH failures', () => {
+    const model = hostStripModel(machine('error', 'connection_failed'), { nowMs: 10_000 });
+    expect(model.tone).toBe('warning');
+    expect(model.message).toContain('SSH is not reachable yet');
+    expect(model.message).toContain('Retry');
   });
 });
 

--- a/frontend/src/pages/coslash/lib/host-strip.ts
+++ b/frontend/src/pages/coslash/lib/host-strip.ts
@@ -30,6 +30,15 @@ function snapshotAgeLabel(lastSuccessAtMs: number | undefined, nowMs: number): s
   return `the view from ${minutes}m ago`;
 }
 
+function isFirstTimeSshSetup(machine: MachineFact): boolean {
+  return (
+    machine.lastSuccessAtMs == null &&
+    (machine.reason === 'connection_failed' ||
+      machine.reason === 'authentication_failed' ||
+      machine.reason === 'host_key_failed')
+  );
+}
+
 function reasonMessage(reason: MachineReason | undefined): string {
   switch (reason) {
     case 'sftp_unavailable':
@@ -45,9 +54,11 @@ function reasonMessage(reason: MachineReason | undefined): string {
     case 'refresh_timeout':
       return 'the refresh timed out';
     case 'authentication_failed':
-      return 'SSH authentication failed';
+      return 'SSH login failed — run ssh once in Terminal, then Retry';
     case 'host_key_failed':
-      return 'SSH host key verification failed';
+      return 'SSH host key needs confirmation — run ssh once in Terminal, then Retry';
+    case 'connection_failed':
+      return 'SSH is not reachable yet — check the alias, then Retry';
     case 'invalid_remote_data':
       return 'agent data could not be parsed';
     case 'local_cache_failed':
@@ -75,7 +86,7 @@ function reasonMessage(reason: MachineReason | undefined): string {
     case 'helper_failed':
       return 'the helper collection failed';
     default:
-      return 'the SFTP refresh failed';
+      return 'the remote refresh failed';
   }
 }
 
@@ -84,16 +95,25 @@ function stripMessage(machine: MachineFact, nowMs: number): string {
     case 'connecting':
       return machine.reason === 'broader_history'
         ? `${machine.label} · refreshing older history · showing the previous view`
-        : `${machine.label} · connecting over ${machine.transport === 'helper' ? 'the helper' : 'SFTP'}…`;
+        : `${machine.label} · connecting over ${machine.transport === 'helper' ? 'the helper' : 'SSH'}…`;
     case 'limited':
       return `${machine.label} · ${reasonMessage(machine.reason)}`;
     case 'stale':
-      return `${machine.label} · unreachable · showing ${snapshotAgeLabel(machine.lastSuccessAtMs, nowMs)}`;
+      return isFirstTimeSshSetup(machine)
+        ? `${machine.label} · ${reasonMessage(machine.reason)}`
+        : `${machine.label} · unreachable · showing ${snapshotAgeLabel(machine.lastSuccessAtMs, nowMs)}`;
     case 'error':
       return `${machine.label} · ${reasonMessage(machine.reason)}`;
     default:
       return `${machine.label} · remote host needs attention`;
   }
+}
+
+function stripTone(machine: MachineFact): 'warning' | 'danger' {
+  if (machine.state === 'connecting' || machine.state === 'limited') return 'warning';
+  // First-time SSH setup should feel recoverable, not alarming.
+  if (isFirstTimeSshSetup(machine)) return 'warning';
+  return 'danger';
 }
 
 function stripActions(state: MachineState, reason: MachineReason | undefined): HostStripAction[] {
@@ -110,16 +130,15 @@ export function hostStripModel(
     message: stripMessage(machine, options.nowMs ?? Date.now()),
     actions: stripActions(machine.state, machine.reason),
     retryDisabled: options.retryInFlight === true || machine.state === 'connecting',
-    tone: machine.state === 'error' || machine.state === 'stale' ? 'danger' : 'warning',
+    tone: stripTone(machine),
   };
 }
 
 export function formatTestConnectionResult(machine: MachineFact): string {
-  if (machine.state === 'ok')
-    return 'Connected · SFTP is ready · optional helper available with your consent';
+  if (machine.state === 'ok') return 'Connected · SSH/SFTP is ready';
   return `${machine.label} · ${machine.error || reasonMessage(machine.reason)}`;
 }
 
 export function firstTimeSshHint(alias: string): string {
-  return `Run ssh ${alias} once in Terminal if OpenSSH still needs host-key confirmation or authentication.`;
+  return `Run ssh ${alias} once in Terminal if OpenSSH still needs host-key confirmation or authentication. After it works, Test connection again — the board refreshes automatically.`;
 }

--- a/frontend/src/pages/coslash/lib/remote-api.test.ts
+++ b/frontend/src/pages/coslash/lib/remote-api.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { retryRemoteRefreshAndWait } from './remote-api';
+
+const connectingMachine = {
+  sourceId: 'r_0123456789abcdef',
+  label: 'gpu-server',
+  state: 'connecting',
+  complete: false,
+};
+
+const readyMachine = { ...connectingMachine, state: 'ok', complete: true };
+
+describe('retryRemoteRefreshAndWait', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('waits for collection to leave connecting before resolving', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('window', {
+      location: { hash: '', pathname: '/', search: '' },
+      history: { state: null, replaceState: vi.fn() },
+      sessionStorage: { getItem: vi.fn(() => null), setItem: vi.fn() },
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json(connectingMachine, { status: 202 }))
+      .mockResolvedValueOnce(Response.json(readyMachine));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = retryRemoteRefreshAndWait();
+    await vi.advanceTimersByTimeAsync(400);
+
+    await expect(result).resolves.toEqual(readyMachine);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/remote/retry');
+    expect(fetchMock.mock.calls[1]?.[0]).toBe('/api/remote/status');
+  });
+});

--- a/frontend/src/pages/coslash/lib/remote-api.ts
+++ b/frontend/src/pages/coslash/lib/remote-api.ts
@@ -46,6 +46,20 @@ export async function retryRemoteRefresh(): Promise<{ status: number; machine: M
   return { status: response.status, machine: decodeMachineFact(body) };
 }
 
+const REMOTE_REFRESH_POLL_INTERVAL_MS = 400;
+
+// The retry endpoint acknowledges that collection has started, rather than
+// waiting for it to finish. Wait for its terminal health state before callers
+// reload the board, so it does not remain on the transient "connecting" view.
+export async function retryRemoteRefreshAndWait(): Promise<MachineFact> {
+  let { machine } = await retryRemoteRefresh();
+  while (machine.state === 'connecting') {
+    await new Promise<void>((resolve) => setTimeout(resolve, REMOTE_REFRESH_POLL_INTERVAL_MS));
+    machine = await remoteStatus();
+  }
+  return machine;
+}
+
 export async function setupRemoteHelper(
   sshAlias: string,
   consent: 'install' | 'upgrade',


### PR DESCRIPTION
## Summary
- Soften first-time SSH failure messaging on the host strip and guide users to fix SSH, then Retry.
- After a successful connection test (or settings save), clear retry backoff and refresh the board automatically.
- Merge Machines **Test connection** / **Install helper** into a progressive flow: test first, then install as the next step.
- Shorten the initial remote retry backoff from 3 minutes to 30 seconds.

Stacked on top of #133 (`hlu/ssh-mix-07`).

## Test plan
- [ ] Configure a bad SSH alias → strip shows recoverable warning copy, not a vague red “connection failed”
- [ ] Fix SSH / run `ssh <alias>` once → **Test connection** succeeds → board strip clears without clicking Retry
- [ ] Save remote settings after SSH works → board refresh starts automatically
- [ ] Successful test reveals **Install helper** (optional) instead of a disabled Install beside Test
- [ ] `go test ./internal/remote/ -run TestSuccessfulAliasTestClearsBackoff`
- [ ] `npx vitest run src/pages/coslash/lib/host-strip.test.ts`

