### PR TITLE
Harden SSH remote collection, handoffs, and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,25 +99,19 @@ coSlash needs at least one local agent session to read. If it finds none, it say
 
 ### Optional Linux session monitoring
 
-In **Settings → Machines**, add one alias from your Mac's existing OpenSSH
-configuration. coSlash runs the system `ssh` client on the Mac, requests the
-host's SFTP subsystem, and parses Claude Code and Codex files locally. It may
-reuse an OpenSSH multiplexed connection through a control socket under
-`~/.coslash/ssh`; it does not edit your SSH config. The Linux host needs only
-its SSH server with SFTP enabled and agent files readable by the SSH user.
+In **Settings → Machines**, use **Add remote host** with an alias from your
+Mac's existing OpenSSH configuration. coSlash checks SSH and SFTP, then installs
+and verifies the matching Linux collector. The helper lives in the SSH user's
+private `~/.coslash/helpers` directory, has no root or network access, and reads
+only supported agent paths. Future coSlash updates replace a helper that it
+previously installed and verified; first-time setup always requires this action.
 
-SFTP is the compatible fallback. After testing the connection, you can choose
-**Install helper**. That action asks for explicit consent before coSlash uploads
-the matching Linux collector embedded in the coSlash release into the SSH
-user's private `~/.coslash/helpers` directory. The app verifies its size,
-digest, platform, owner, and mode before execution. The helper reads only the
-supported agent paths and returns bounded, normalized facts; it has no root
-access, no network access, and does not run your agent CLI. Machines shows
-whether collection is using the helper or SFTP, including any stale or partial
-coverage. An incompatible, blocked, or failed helper never runs silently:
-coSlash keeps the SFTP fallback visible and offers repair or upgrade where
-available. Initial installation and every upgrade require separate consent;
-disabling a machine does not uninstall its helper.
+coSlash uses the system `ssh` client and may reuse a control socket under
+`~/.coslash/ssh`; it never edits your SSH config. SFTP remains the visible
+fallback if a helper cannot run. An offline host is checked promptly and retried
+in the background; use **Retry setup** for an immediate attempt. **Remove**
+stops monitoring locally even when the host is offline and leaves its helper on
+the remote machine.
 
 Remote v1 is monitoring-only. Cards, transcript-derived facts, costs, tokens,
 file-edit summaries, and **Copy handoff** are available. Resume, Start Fresh,

--- a/README.md
+++ b/README.md
@@ -113,11 +113,12 @@ in the background; use **Retry setup** for an immediate attempt. **Remove**
 stops monitoring locally even when the host is offline and leaves its helper on
 the remote machine.
 
-Remote v1 is monitoring-only. Cards, transcript-derived facts, costs, tokens,
-file-edit summaries, and **Copy handoff** are available. Resume, Start Fresh,
-diffs, synthesis, preview, Commands, and sharing remain local-only. A remote
-session can show recent transcript activity while process liveness is unknown;
-coSlash labels those facts separately.
+Remote sessions support **Resume** and **Start fresh with handoff** while their
+SSH host is connected. Cards, transcript-derived facts, costs, tokens,
+file-edit summaries, and **Copy handoff** are also available. Diffs, synthesis,
+preview, Commands, and sharing remain local-only. A remote session can show
+recent transcript activity while process liveness is unknown; coSlash labels
+those facts separately.
 
 ## What you get
 

--- a/collector/cmd/coslash/api.go
+++ b/collector/cmd/coslash/api.go
@@ -238,21 +238,36 @@ func cleanupHandoffs() {
 	}
 }
 
-func handleLaunch(w http.ResponseWriter, r *http.Request, settingsStore *settings.Store) {
+func handleLaunch(w http.ResponseWriter, r *http.Request, settingsStore *settings.Store, remoteManager *remote.Manager) {
 	state := settingsStore.State()
 	if !state.Valid {
 		http.Error(w, state.Error+"; open Settings to repair it", http.StatusConflict)
 		return
 	}
 	query := r.URL.Query()
-	found, err := collector.GetSessionFacts(query.Get("id"))
+	sourceID, err := parseSourceID(query.Get("source"))
 	if err != nil {
-		log.Printf("launch: %v", err)
-		http.Error(w, "could not load session", http.StatusInternalServerError)
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	var found *session.Session
+	alias := ""
+	if sourceID == localSourceID {
+		found, err = collector.GetSessionFacts(query.Get("id"))
+		if err != nil {
+			log.Printf("launch: %v", err)
+			http.Error(w, "could not load session", http.StatusInternalServerError)
+			return
+		}
+	} else {
+		found, alias, _ = remoteManager.LaunchSession(sourceID, query.Get("agent"), query.Get("id"))
+	}
 	if found == nil {
-		http.Error(w, "session not found", http.StatusNotFound)
+		if sourceID == localSourceID {
+			http.Error(w, "session not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "remote host is offline or this session is no longer available", http.StatusConflict)
 		return
 	}
 	handoff, err := readHandoff(w, r)
@@ -262,7 +277,17 @@ func handleLaunch(w http.ResponseWriter, r *http.Request, settingsStore *setting
 		return
 	}
 	mode := query.Get("mode")
-	if err := launch.Terminal(state.Config.Launch.Terminal, found.Agent, found.WorkingDirectory, found.ID, mode, handoff); err != nil {
+	if sourceID != localSourceID {
+		health, testErr := remoteManager.TestAlias(r.Context(), alias)
+		if testErr != nil || health.State != remote.StateOK {
+			http.Error(w, "remote host is offline; wait for it to reconnect", http.StatusConflict)
+			return
+		}
+		err = launch.RemoteTerminal(state.Config.Launch.Terminal, alias, found.Agent, found.WorkingDirectory, found.ID, mode, handoff)
+	} else {
+		err = launch.Terminal(state.Config.Launch.Terminal, found.Agent, found.WorkingDirectory, found.ID, mode, handoff)
+	}
+	if err != nil {
 		log.Printf("launch: %v", err)
 		http.Error(w, "could not launch terminal", http.StatusInternalServerError)
 		return

--- a/collector/cmd/coslash/api.go
+++ b/collector/cmd/coslash/api.go
@@ -260,7 +260,11 @@ func handleLaunch(w http.ResponseWriter, r *http.Request, settingsStore *setting
 			return
 		}
 	} else {
-		found, alias, _ = remoteManager.LaunchSession(sourceID, query.Get("agent"), query.Get("id"))
+		found, alias, err = remoteManager.LaunchSession(sourceID, query.Get("agent"), query.Get("id"))
+		if errors.Is(err, remote.ErrRemoteSessionActive) {
+			http.Error(w, "remote session is already active", http.StatusConflict)
+			return
+		}
 	}
 	if found == nil {
 		if sourceID == localSourceID {

--- a/collector/cmd/coslash/api.go
+++ b/collector/cmd/coslash/api.go
@@ -265,6 +265,10 @@ func handleLaunch(w http.ResponseWriter, r *http.Request, settingsStore *setting
 			http.Error(w, "remote session is already active", http.StatusConflict)
 			return
 		}
+		if errors.Is(err, remote.ErrRemoteSessionUnavailable) {
+			http.Error(w, "remote session details are too large to launch", http.StatusConflict)
+			return
+		}
 	}
 	if found == nil {
 		if sourceID == localSourceID {

--- a/collector/cmd/coslash/api_remote.go
+++ b/collector/cmd/coslash/api_remote.go
@@ -28,6 +28,10 @@ type helperSetupResponse struct {
 	Error   string      `json:"error,omitempty"`
 }
 
+type remoteSetupStatusResponse struct {
+	Phase remote.SetupProgress `json:"phase"`
+}
+
 // helperSetupOutcome is separate from machine collection health. A host may
 // have a healthy SFTP cache while a requested helper action has failed; the
 // setup response must never present that operation as a green success.
@@ -100,7 +104,12 @@ func handleRemoteRetry(w http.ResponseWriter, _ *http.Request, manager *remote.M
 		writeAPIError(w, http.StatusConflict, errCodeRemoteDisabled, "remote disabled")
 		return
 	}
-	health = manager.Retry()
+	var started bool
+	health, started = manager.Retry()
+	if !started {
+		writeAPIError(w, http.StatusTooManyRequests, errCodeRemoteRetryThrottled, "remote refresh is already running; try again shortly")
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
 	_ = json.NewEncoder(w).Encode(machineFromHealth(health))
@@ -133,7 +142,9 @@ func handleRemoteHelperSetup(w http.ResponseWriter, request *http.Request, manag
 	}
 	ctx, cancel := context.WithTimeout(request.Context(), 2*time.Minute)
 	defer cancel()
-	setup, err := manager.SetupHelperForAlias(ctx, body.SSHAlias, remote.Consent{Install: body.Install, Upgrade: body.Upgrade})
+	// The single Add remote host action authorizes replacing a verified older
+	// connector as well as an initial install.
+	setup, err := manager.SetupHelperForAlias(ctx, body.SSHAlias, remote.Consent{Install: body.Install, Upgrade: body.Install || body.Upgrade})
 	if errors.Is(err, remote.ErrHelperAliasMismatch) {
 		writeAPIError(w, http.StatusConflict, "remote_alias_mismatch", "SSH alias changed; save settings and test that host before setting up its helper")
 		return
@@ -182,17 +193,6 @@ func handleRemoteStatus(w http.ResponseWriter, _ *http.Request, manager *remote.
 	writeJSON(w, machineFromHealth(health))
 }
 
-func handleRemoteHelperUninstall(w http.ResponseWriter, request *http.Request, manager *remote.Manager) {
-	health := manager.DiagnosticsHealth()
-	if health.SourceID == "" {
-		writeAPIError(w, http.StatusNotFound, errCodeRemoteNotConfigured, "remote not configured")
-		return
-	}
-	ctx, cancel := context.WithTimeout(request.Context(), 2*time.Minute)
-	defer cancel()
-	if err := manager.UninstallHelper(ctx); err != nil {
-		writeAPIError(w, http.StatusBadGateway, "remote_helper_uninstall_failed", "could not uninstall helper; host settings were kept")
-		return
-	}
-	w.WriteHeader(http.StatusNoContent)
+func handleRemoteSetupStatus(w http.ResponseWriter, _ *http.Request, manager *remote.Manager) {
+	writeJSON(w, remoteSetupStatusResponse{Phase: manager.SetupProgress()})
 }

--- a/collector/cmd/coslash/api_remote.go
+++ b/collector/cmd/coslash/api_remote.go
@@ -28,10 +28,6 @@ type helperSetupResponse struct {
 	Error   string      `json:"error,omitempty"`
 }
 
-type remoteSetupStatusResponse struct {
-	Phase remote.SetupProgress `json:"phase"`
-}
-
 // helperSetupOutcome is separate from machine collection health. A host may
 // have a healthy SFTP cache while a requested helper action has failed; the
 // setup response must never present that operation as a green success.
@@ -191,8 +187,4 @@ func handleRemoteStatus(w http.ResponseWriter, _ *http.Request, manager *remote.
 		return
 	}
 	writeJSON(w, machineFromHealth(health))
-}
-
-func handleRemoteSetupStatus(w http.ResponseWriter, _ *http.Request, manager *remote.Manager) {
-	writeJSON(w, remoteSetupStatusResponse{Phase: manager.SetupProgress()})
 }

--- a/collector/cmd/coslash/api_source.go
+++ b/collector/cmd/coslash/api_source.go
@@ -46,8 +46,6 @@ type machineFact struct {
 	Complete                    bool                     `json:"complete"`
 	Reason                      *remote.Reason           `json:"reason,omitempty"`
 	LastSuccessAtMs             *int64                   `json:"lastSuccessAtMs,omitempty"`
-	LastCheckedAtMs             *int64                   `json:"lastCheckedAtMs,omitempty"`
-	SessionCount                int                      `json:"sessionCount"`
 	CoverageSinceMs             *int64                   `json:"coverageSinceMs,omitempty"`
 	RoundTripMs                 *int64                   `json:"roundTripMs,omitempty"`
 	Coverage                    []remote.AgentCoverage   `json:"coverage,omitempty"`
@@ -70,8 +68,7 @@ func machineFromHealth(health remote.Health) machineFact {
 	return machineFact{
 		SourceID: health.SourceID, Label: health.Label, State: health.State,
 		Complete: health.Complete, Reason: health.Reason,
-		LastSuccessAtMs: health.LastSuccessAtMs, LastCheckedAtMs: health.LastCheckedAtMs,
-		SessionCount: health.SessionCount, CoverageSinceMs: health.CoverageSinceMs,
+		LastSuccessAtMs: health.LastSuccessAtMs, CoverageSinceMs: health.CoverageSinceMs,
 		RoundTripMs: health.RoundTripMs, Coverage: health.Coverage, Error: health.Error,
 		Transport: health.Transport, Helper: health.Helper, Metrics: health.Metrics,
 		HelperInstallationAvailable: health.HelperInstallationAvailable,

--- a/collector/cmd/coslash/api_source.go
+++ b/collector/cmd/coslash/api_source.go
@@ -14,9 +14,10 @@ const (
 	localSourceID    = "local"
 	localSourceLabel = "This Mac"
 
-	errCodeRemoteUnsupported   = "remote_action_unsupported"
-	errCodeRemoteNotConfigured = "remote_not_configured"
-	errCodeRemoteDisabled      = "remote_disabled"
+	errCodeRemoteUnsupported    = "remote_action_unsupported"
+	errCodeRemoteNotConfigured  = "remote_not_configured"
+	errCodeRemoteDisabled       = "remote_disabled"
+	errCodeRemoteRetryThrottled = "remote_retry_throttled"
 )
 
 type apiErrorBody struct {
@@ -45,6 +46,8 @@ type machineFact struct {
 	Complete                    bool                     `json:"complete"`
 	Reason                      *remote.Reason           `json:"reason,omitempty"`
 	LastSuccessAtMs             *int64                   `json:"lastSuccessAtMs,omitempty"`
+	LastCheckedAtMs             *int64                   `json:"lastCheckedAtMs,omitempty"`
+	SessionCount                int                      `json:"sessionCount"`
 	CoverageSinceMs             *int64                   `json:"coverageSinceMs,omitempty"`
 	RoundTripMs                 *int64                   `json:"roundTripMs,omitempty"`
 	Coverage                    []remote.AgentCoverage   `json:"coverage,omitempty"`
@@ -56,6 +59,7 @@ type machineFact struct {
 	HelperProbeState            string                   `json:"helperProbeState,omitempty"`
 	HelperOwnershipRecorded     bool                     `json:"helperOwnershipRecorded"`
 	HelperOwnershipCorrupt      bool                     `json:"helperOwnershipCorrupt"`
+	Refreshing                  bool                     `json:"refreshing,omitempty"`
 }
 
 func localMachineFact() machineFact {
@@ -66,13 +70,15 @@ func machineFromHealth(health remote.Health) machineFact {
 	return machineFact{
 		SourceID: health.SourceID, Label: health.Label, State: health.State,
 		Complete: health.Complete, Reason: health.Reason,
-		LastSuccessAtMs: health.LastSuccessAtMs, CoverageSinceMs: health.CoverageSinceMs,
+		LastSuccessAtMs: health.LastSuccessAtMs, LastCheckedAtMs: health.LastCheckedAtMs,
+		SessionCount: health.SessionCount, CoverageSinceMs: health.CoverageSinceMs,
 		RoundTripMs: health.RoundTripMs, Coverage: health.Coverage, Error: health.Error,
 		Transport: health.Transport, Helper: health.Helper, Metrics: health.Metrics,
 		HelperInstallationAvailable: health.HelperInstallationAvailable,
 		HelperProbeState:            health.HelperProbeState,
 		HelperOwnershipRecorded:     health.HelperOwnershipRecorded,
 		HelperOwnershipCorrupt:      health.HelperOwnershipCorrupt,
+		Refreshing:                  health.Refreshing,
 	}
 }
 

--- a/collector/cmd/coslash/api_source.go
+++ b/collector/cmd/coslash/api_source.go
@@ -36,6 +36,7 @@ type boardSession struct {
 	EligibleForAggregates bool    `json:"eligibleForAggregates"`
 	DisplayStale          bool    `json:"displayStale"`
 	LastSeenStatus        *string `json:"lastSeenStatus,omitempty"`
+	Launchable            bool    `json:"launchable"`
 	session.Session
 }
 
@@ -91,7 +92,8 @@ func boardRemoteSession(value remote.IndexedSession) boardSession {
 		SourceID: value.Key.SourceID, SourceLabel: value.SourceLabel,
 		EligibleForAggregates: value.EligibleForAggregates,
 		DisplayStale:          value.DisplayStale, LastSeenStatus: value.LastSeenStatus,
-		Session: sessionWithJSONCollections(*value.Session),
+		Launchable: value.Launchable,
+		Session:    sessionWithJSONCollections(*value.Session),
 	}
 }
 

--- a/collector/cmd/coslash/main.go
+++ b/collector/cmd/coslash/main.go
@@ -216,10 +216,7 @@ func routes(
 		handleSaveSettings(w, r, settingsStore, mgr, remoteManager)
 	})
 	api.HandleFunc("POST /api/launch", func(w http.ResponseWriter, r *http.Request) {
-		if rejectRemoteSource(w, r) {
-			return
-		}
-		handleLaunch(w, r, settingsStore)
+		handleLaunch(w, r, settingsStore, remoteManager)
 	})
 	api.HandleFunc("POST /api/remote/test", func(w http.ResponseWriter, r *http.Request) {
 		handleRemoteTest(w, r, remoteManager)

--- a/collector/cmd/coslash/main.go
+++ b/collector/cmd/coslash/main.go
@@ -233,8 +233,8 @@ func routes(
 	api.HandleFunc("POST /api/remote/helper/setup", func(w http.ResponseWriter, r *http.Request) {
 		handleRemoteHelperSetup(w, r, remoteManager)
 	})
-	api.HandleFunc("POST /api/remote/helper/uninstall", func(w http.ResponseWriter, r *http.Request) {
-		handleRemoteHelperUninstall(w, r, remoteManager)
+	api.HandleFunc("GET /api/remote/setup/status", func(w http.ResponseWriter, r *http.Request) {
+		handleRemoteSetupStatus(w, r, remoteManager)
 	})
 	api.HandleFunc("GET /api/diagnostics", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, diagnostics.CollectWithRemote(r.Context(), version, false, remoteHealthFact(remoteManager)))

--- a/collector/cmd/coslash/main.go
+++ b/collector/cmd/coslash/main.go
@@ -230,9 +230,6 @@ func routes(
 	api.HandleFunc("POST /api/remote/helper/setup", func(w http.ResponseWriter, r *http.Request) {
 		handleRemoteHelperSetup(w, r, remoteManager)
 	})
-	api.HandleFunc("GET /api/remote/setup/status", func(w http.ResponseWriter, r *http.Request) {
-		handleRemoteSetupStatus(w, r, remoteManager)
-	})
 	api.HandleFunc("GET /api/diagnostics", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, diagnostics.CollectWithRemote(r.Context(), version, false, remoteHealthFact(remoteManager)))
 	})

--- a/collector/cmd/coslash/main_test.go
+++ b/collector/cmd/coslash/main_test.go
@@ -241,6 +241,35 @@ func TestSettingsSaveRestoresOldSettingsWhenOwnershipActionFails(t *testing.T) {
 	}
 }
 
+func TestSettingsSaveRemovesHostWithoutHelperOwnership(t *testing.T) {
+	t.Setenv("COSLASH_HOME", t.TempDir())
+	store := settings.Open()
+	manager := remote.NewManager(remote.Options{Cache: remote.NewCache(t.TempDir())})
+	previous := settings.Defaults()
+	previous.Remote = &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "old-host", Enabled: true}
+	if err := store.Save(previous); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.ApplySettings(previous.Remote); err != nil {
+		t.Fatal(err)
+	}
+	next := previous
+	next.Remote = nil
+	body, err := json.Marshal(map[string]any{"settings": next, "remoteOwnershipAction": "release"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodPut, "http://127.0.0.1/api/settings", bytes.NewReader(body))
+	response := httptest.NewRecorder()
+	handleSaveSettings(response, request, store, synthesis.NewManager(nil), manager)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", response.Code, response.Body.String())
+	}
+	if store.State().Config.Remote != nil {
+		t.Fatalf("remote was not removed: %#v", store.State().Config.Remote)
+	}
+}
+
 func TestSettingsSaveCanExplicitlyRecoverCorruptOwnershipByRemovingHost(t *testing.T) {
 	t.Setenv("COSLASH_HOME", t.TempDir())
 	store := settings.Open()

--- a/collector/internal/launch/launch.go
+++ b/collector/internal/launch/launch.go
@@ -228,7 +228,7 @@ func remoteCLICommand(agent, sessionID, mode, handoff string) (string, error) {
 	case vendors.AgentClaude:
 		return prefix + shellJoin(cli, "--append-system-prompt-file") + " \"$handoff\"" + cleanup, nil
 	case vendors.AgentCodex:
-		return prefix + shellJoin(cli, "-c") + " \"developer_instructions=$(cat \\\"$handoff\\\")\"" + cleanup, nil
+		return prefix + shellJoin(cli, "-c") + " \"developer_instructions=$(cat \"$handoff\")\"" + cleanup, nil
 	case vendors.AgentOpenCode:
 		return prefix + "OPENCODE_CONFIG_CONTENT='{\"instructions\":[\"'\"$handoff\"'\"]}' " + shellJoin(cli) + cleanup, nil
 	}

--- a/collector/internal/launch/launch.go
+++ b/collector/internal/launch/launch.go
@@ -4,6 +4,7 @@
 package launch
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -73,6 +74,33 @@ func Terminal(terminal, agent, workingDirectory, sessionID, mode, handoff string
 		return fmt.Errorf("launch: open %s: %w", adapter.label, err)
 	}
 	return nil
+}
+
+// RemoteTerminal opens the selected local terminal and runs an agent CLI on a
+// configured SSH host.
+func RemoteTerminal(terminal, alias, agent, workingDirectory, sessionID, mode, handoff string) error {
+	if alias == "" {
+		return errors.New("launch: SSH alias is required")
+	}
+	if workingDirectory == "" {
+		return fmt.Errorf("launch: session has no working directory")
+	}
+	adapter, err := terminalFor(terminal)
+	if err != nil {
+		return err
+	}
+	if runtime.GOOS != "darwin" {
+		return fmt.Errorf("launch: opening a terminal is not supported on %s", runtime.GOOS)
+	}
+	if err := adapter.available(); err != nil {
+		return fmt.Errorf("launch: %s is not installed or available; choose another terminal in Settings", adapter.label)
+	}
+	command, err := remoteCLICommand(agent, sessionID, mode, handoff)
+	if err != nil {
+		return err
+	}
+	remoteCommand := "cd " + shellQuote(workingDirectory) + " && " + command
+	return adapter.open(".", shellJoin("ssh", "-tt", alias, remoteCommand))
 }
 
 func Available(terminal string) bool {
@@ -168,6 +196,43 @@ func handoffCommand(agent, cli, handoff string) (string, string, error) {
 		return withCleanup(command, path), path, nil
 	}
 	return "", "", fmt.Errorf("launch: unknown agent %q", agent)
+}
+
+func remoteCLICommand(agent, sessionID, mode, handoff string) (string, error) {
+	cli, err := cliName(agent)
+	if err != nil {
+		return "", err
+	}
+	if mode == ResumeSession {
+		command, _, err := cliCommand(agent, sessionID, mode, "")
+		return command, err
+	}
+	if mode != NewSession {
+		return "", fmt.Errorf("launch: unknown mode %q", mode)
+	}
+	if handoff == "" {
+		return shellJoin(cli), nil
+	}
+	contents := handoffPreamble + handoff
+	if agent == vendors.AgentCodex {
+		contentsBytes, err := json.Marshal(contents)
+		if err != nil {
+			return "", fmt.Errorf("launch: encoding handoff context: %w", err)
+		}
+		contents = string(contentsBytes)
+	}
+	encoded := base64.StdEncoding.EncodeToString([]byte(contents))
+	prefix := "handoff=$(mktemp) || exit 1; printf %s " + shellQuote(encoded) + " | base64 -d > \"$handoff\" || { rm -f \"$handoff\"; exit 1; }; "
+	cleanup := "; rm -f \"$handoff\""
+	switch agent {
+	case vendors.AgentClaude:
+		return prefix + shellJoin(cli, "--append-system-prompt-file") + " \"$handoff\"" + cleanup, nil
+	case vendors.AgentCodex:
+		return prefix + shellJoin(cli, "-c") + " \"developer_instructions=$(cat \\\"$handoff\\\")\"" + cleanup, nil
+	case vendors.AgentOpenCode:
+		return prefix + "OPENCODE_CONFIG_CONTENT='{\"instructions\":[\"'\"$handoff\"'\"]}' " + shellJoin(cli) + cleanup, nil
+	}
+	return "", fmt.Errorf("launch: unknown agent %q", agent)
 }
 
 func handoffDir() string {

--- a/collector/internal/launch/remote_test.go
+++ b/collector/internal/launch/remote_test.go
@@ -1,0 +1,32 @@
+package launch
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/centauri-ai/coslash/collector/internal/vendors"
+)
+
+func TestRemoteCLICommandUsesRemoteHandoffFile(t *testing.T) {
+	command, err := remoteCLICommand(vendors.AgentClaude, "", NewSession, "keep this private")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(command, "mktemp") || !strings.Contains(command, "base64 -d") ||
+		!strings.Contains(command, "'--append-system-prompt-file' \"$handoff\"") {
+		t.Fatalf("command = %q", command)
+	}
+	if strings.Contains(command, "keep this private") {
+		t.Fatalf("command contains the raw handoff: %q", command)
+	}
+}
+
+func TestRemoteCLICommandResumesValidatedSession(t *testing.T) {
+	command, err := remoteCLICommand(vendors.AgentCodex, "01234567-89ab-cdef-0123-456789abcdef", ResumeSession, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if command != "'codex' 'resume' '01234567-89ab-cdef-0123-456789abcdef'" {
+		t.Fatalf("command = %q", command)
+	}
+}

--- a/collector/internal/launch/remote_test.go
+++ b/collector/internal/launch/remote_test.go
@@ -21,6 +21,16 @@ func TestRemoteCLICommandUsesRemoteHandoffFile(t *testing.T) {
 	}
 }
 
+func TestRemoteCodexCLICommandReadsRemoteHandoffFile(t *testing.T) {
+	command, err := remoteCLICommand(vendors.AgentCodex, "", NewSession, "keep this private")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(command, `developer_instructions=$(cat "$handoff")`) || strings.Contains(command, `cat \"$handoff\"`) {
+		t.Fatalf("command = %q", command)
+	}
+}
+
 func TestRemoteCLICommandResumesValidatedSession(t *testing.T) {
 	command, err := remoteCLICommand(vendors.AgentCodex, "01234567-89ab-cdef-0123-456789abcdef", ResumeSession, "")
 	if err != nil {

--- a/collector/internal/remote/cache.go
+++ b/collector/internal/remote/cache.go
@@ -256,7 +256,7 @@ func age(fetchedAtMs int64, now time.Time) time.Duration {
 // stays visible (marked stale) until the first v2 generation commits, and a
 // v1 fingerprint is never reinterpreted as v2 baseline state — the first v2
 // refresh always starts from an empty generation.
-const cacheV2Version = 2
+const cacheV2Version = 3
 const maxCacheV2Bytes = 64 << 20
 
 // CachedFamilyV2 is one durable family entry. Vendor and FamilyID are stored

--- a/collector/internal/remote/health.go
+++ b/collector/internal/remote/health.go
@@ -42,6 +42,8 @@ type Health struct {
 	Complete                    bool              `json:"complete"`
 	Reason                      *Reason           `json:"reason,omitempty"`
 	LastSuccessAtMs             *int64            `json:"lastSuccessAtMs,omitempty"`
+	LastCheckedAtMs             *int64            `json:"lastCheckedAtMs,omitempty"`
+	SessionCount                int               `json:"sessionCount"`
 	CoverageSinceMs             *int64            `json:"coverageSinceMs,omitempty"`
 	RoundTripMs                 *int64            `json:"roundTripMs,omitempty"`
 	Coverage                    []AgentCoverage   `json:"coverage,omitempty"`

--- a/collector/internal/remote/helperexec_test.go
+++ b/collector/internal/remote/helperexec_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/centauri-ai/coslash/collector/internal/remotefacts"
 	"github.com/centauri-ai/coslash/collector/internal/remoteprotocol"
 	"github.com/centauri-ai/coslash/collector/internal/vendors"
 )
@@ -157,7 +158,7 @@ func completeResponse(t *testing.T) (remoteprotocol.Request, remoteprotocol.Gene
 	t.Helper()
 	request := remoteprotocol.Request{
 		RequestID: "req-1", Protocol: remoteprotocol.VersionRange{Min: 1, Max: 1},
-		Schema: remoteprotocol.VersionRange{Min: 1, Max: 1}, ParserVersion: vendors.ParserVersion,
+		Schema: remoteprotocol.VersionRange{Min: remotefacts.SchemaVersion, Max: remotefacts.SchemaVersion}, ParserVersion: vendors.ParserVersion,
 		BaselineMode: remoteprotocol.BaselineKnown, BaselineID: "base-1",
 		CollectedAtMs: 1, Vendors: []string{"codex"}, Limits: remoteprotocol.Limits{
 			MaxRecordBytes: 1024, MaxResponseBytes: 4096, MaxRecords: 10, MaxInventoryFamilies: 10,
@@ -165,7 +166,7 @@ func completeResponse(t *testing.T) (remoteprotocol.Request, remoteprotocol.Gene
 	}
 	baseline := remoteprotocol.Generation{BaselineID: "base-1"}
 	records := []remoteprotocol.Record{
-		{Type: remoteprotocol.RecordHandshake, ProtocolVersion: 1, RequestID: "req-1", Sequence: 1, BaselineID: "base-1", SchemaVersion: 1, ParserVersion: vendors.ParserVersion},
+		{Type: remoteprotocol.RecordHandshake, ProtocolVersion: 1, RequestID: "req-1", Sequence: 1, BaselineID: "base-1", SchemaVersion: remotefacts.SchemaVersion, ParserVersion: vendors.ParserVersion},
 		{Type: remoteprotocol.RecordVendorComplete, ProtocolVersion: 1, RequestID: "req-1", Sequence: 2, Vendor: "codex", EnumerationComplete: true, InventoryComplete: true, Inventory: []string{}},
 		{Type: remoteprotocol.RecordRequestComplete, ProtocolVersion: 1, RequestID: "req-1", Sequence: 3},
 	}

--- a/collector/internal/remote/helpermanager.go
+++ b/collector/internal/remote/helpermanager.go
@@ -260,11 +260,6 @@ func (manager *Manager) runHelperDiscovery(ctx context.Context, config settings.
 			}
 		}
 	}
-	if result.CanExecute && autoUpdate && previousVersion != "" && previousVersion != result.Artifact.Version && lifecycle.Remote != nil {
-		if previousPath, pathErr := helperPath(previousVersion); pathErr == nil {
-			_ = lifecycle.Remote.RemoveExact(probeCtx, previousPath)
-		}
-	}
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
 	if manager.cfg == nil || manager.cfg.ID != config.ID || manager.cfg.SSHAlias != config.SSHAlias || ctx.Err() != nil {
@@ -297,6 +292,11 @@ func (manager *Manager) runHelperDiscovery(ctx context.Context, config settings.
 			} else {
 				manager.helperVersion = result.Artifact.Version
 				manager.helperProbe = helperProbeReady
+				if autoUpdate && previousVersion != "" && previousVersion != result.Artifact.Version && lifecycle.Remote != nil {
+					if previousPath, pathErr := helperPath(previousVersion); pathErr == nil {
+						_ = lifecycle.Remote.RemoveExact(probeCtx, previousPath)
+					}
+				}
 			}
 		} else {
 			manager.helperTarget = nil
@@ -308,24 +308,10 @@ func (manager *Manager) runHelperDiscovery(ctx context.Context, config settings.
 	manager.maybeStartRefreshLocked(manager.lastRequestedMs, false)
 }
 
-// SetupHelper performs a consented setup or repair. It is the only Manager
-// method that can create a helper target; refreshes only execute that stored,
-// verified target.
-func (manager *Manager) SetupHelper(ctx context.Context, consent Consent) Health {
-	health, _ := manager.setupHelper(ctx, "", consent)
-	return health
-}
-
 // SetupHelperForAlias binds consented setup to the alias the user tested. It
 // rejects an unsaved settings draft before a lifecycle can contact a host.
 func (manager *Manager) SetupHelperForAlias(ctx context.Context, alias string, consent Consent) (Health, error) {
 	return manager.setupHelper(ctx, alias, consent)
-}
-
-func (manager *Manager) SetupProgress() SetupProgress {
-	manager.mu.Lock()
-	defer manager.mu.Unlock()
-	return manager.setupProgress
 }
 
 func (manager *Manager) setupHelper(ctx context.Context, expectedAlias string, consent Consent) (Health, error) {
@@ -352,12 +338,10 @@ func (manager *Manager) setupHelper(ctx context.Context, expectedAlias string, c
 	// release this mutex while uploading the helper, so ApplySettings must not
 	// replace the alias in that interval.
 	manager.helperSetup = true
-	manager.setupProgress = SetupProgressChecking
 	manager.mu.Unlock()
 	defer func() {
 		manager.mu.Lock()
 		manager.helperSetup = false
-		manager.setupProgress = SetupProgressIdle
 		manager.mu.Unlock()
 	}()
 
@@ -387,20 +371,13 @@ func (manager *Manager) setupHelper(ctx context.Context, expectedAlias string, c
 		manager.mu.Unlock()
 		return health, nil
 	}
-	lifecycle.Progress = manager.setSetupProgress
 	result := lifecycle.SetupWithLoader(ctx, document, consent, provider.LoadArtifact)
 	activeLifecycle := lifecycle
 	if retryableSetupTransportFailure(result) {
 		manager.resetControlMaster(config.SSHAlias)
 		if retryLifecycle, retryErr := factory(config.SSHAlias); retryErr == nil {
-			retryLifecycle.Progress = manager.setSetupProgress
 			result = retryLifecycle.SetupWithLoader(ctx, document, consent, provider.LoadArtifact)
 			activeLifecycle = retryLifecycle
-		}
-	}
-	if result.CanExecute && previousVersion != "" && previousVersion != result.Artifact.Version && activeLifecycle.Remote != nil {
-		if previousPath, pathErr := helperPath(previousVersion); pathErr == nil {
-			_ = activeLifecycle.Remote.RemoveExact(ctx, previousPath)
 		}
 	}
 	manager.mu.Lock()
@@ -420,19 +397,16 @@ func (manager *Manager) setupHelper(ctx context.Context, expectedAlias string, c
 		manager.helperTarget = &helperTarget{path: result.Path, version: result.Artifact.Version, state: result.State, artifact: result.Artifact}
 		manager.helperVersion = result.Artifact.Version
 		manager.helperProbe = helperProbeReady
+		if previousVersion != "" && previousVersion != result.Artifact.Version && activeLifecycle.Remote != nil {
+			if previousPath, pathErr := helperPath(previousVersion); pathErr == nil {
+				_ = activeLifecycle.Remote.RemoveExact(ctx, previousPath)
+			}
+		}
 	} else {
 		manager.helperTarget = nil
 		manager.helperProbe = helperProbeFallback
 	}
 	return manager.healthLocked(manager.lastRequestedMs), nil
-}
-
-func (manager *Manager) setSetupProgress(progress SetupProgress) {
-	manager.mu.Lock()
-	defer manager.mu.Unlock()
-	if manager.helperSetup {
-		manager.setupProgress = progress
-	}
 }
 
 func retryableSetupTransportFailure(result LifecycleResult) bool {

--- a/collector/internal/remote/helpermanager.go
+++ b/collector/internal/remote/helpermanager.go
@@ -222,16 +222,18 @@ func (manager *Manager) InspectHelper() Health {
 }
 
 func (manager *Manager) runHelperDiscovery(ctx context.Context, config settings.RemoteSettings) {
+	probeCtx, cancel := context.WithTimeout(ctx, DefaultConnectTimeout)
+	defer cancel()
 	manager.mu.Lock()
 	provider, factory := manager.releaseProvider, manager.lifecycleFactory
 	manager.mu.Unlock()
-	document, err := provider.LoadMetadata(ctx)
+	document, err := provider.LoadMetadata(probeCtx)
 	var result LifecycleResult
 	if err == nil {
 		var lifecycle Lifecycle
 		lifecycle, err = factory(config.SSHAlias)
 		if err == nil {
-			result = lifecycle.SetupWithLoader(ctx, document, Consent{}, provider.LoadArtifact)
+			result = lifecycle.SetupWithLoader(probeCtx, document, Consent{}, provider.LoadArtifact)
 		}
 	}
 	manager.mu.Lock()
@@ -240,6 +242,14 @@ func (manager *Manager) runHelperDiscovery(ctx context.Context, config settings.
 		return
 	}
 	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || sshErrorStderr(err) != "" {
+			manager.lastCheckedAt = int64Ptr(manager.now().UnixMilli())
+			manager.helperProbe = helperProbeFallback
+			status := unavailableHelperStatus(err)
+			manager.helper = &status
+			manager.applyFailureLocked(classifyError(err), sshErrorStderr(err))
+			return
+		}
 		status := unavailableHelperStatus(err)
 		manager.helper = &status
 		manager.helperProbe = helperProbeFallback
@@ -283,6 +293,12 @@ func (manager *Manager) SetupHelperForAlias(ctx context.Context, alias string, c
 	return manager.setupHelper(ctx, alias, consent)
 }
 
+func (manager *Manager) SetupProgress() SetupProgress {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	return manager.setupProgress
+}
+
 func (manager *Manager) setupHelper(ctx context.Context, expectedAlias string, consent Consent) (Health, error) {
 	manager.mu.Lock()
 	if manager.cfg == nil {
@@ -300,16 +316,19 @@ func (manager *Manager) setupHelper(ctx context.Context, expectedAlias string, c
 		return health, ErrHelperSetupInProgress
 	}
 	config := *manager.cfg
+	previousVersion := manager.helperVersion
 	provider, factory := manager.releaseProvider, manager.lifecycleFactory
 	// Keep this host identity reserved until setup has either recorded
 	// ownership or finished without installing anything. SetupWithLoader can
 	// release this mutex while uploading the helper, so ApplySettings must not
 	// replace the alias in that interval.
 	manager.helperSetup = true
+	manager.setupProgress = SetupProgressChecking
 	manager.mu.Unlock()
 	defer func() {
 		manager.mu.Lock()
 		manager.helperSetup = false
+		manager.setupProgress = SetupProgressIdle
 		manager.mu.Unlock()
 	}()
 
@@ -339,7 +358,22 @@ func (manager *Manager) setupHelper(ctx context.Context, expectedAlias string, c
 		manager.mu.Unlock()
 		return health, nil
 	}
+	lifecycle.Progress = manager.setSetupProgress
 	result := lifecycle.SetupWithLoader(ctx, document, consent, provider.LoadArtifact)
+	activeLifecycle := lifecycle
+	if retryableSetupTransportFailure(result) {
+		manager.resetControlMaster(config.SSHAlias)
+		if retryLifecycle, retryErr := factory(config.SSHAlias); retryErr == nil {
+			retryLifecycle.Progress = manager.setSetupProgress
+			result = retryLifecycle.SetupWithLoader(ctx, document, consent, provider.LoadArtifact)
+			activeLifecycle = retryLifecycle
+		}
+	}
+	if result.CanExecute && previousVersion != "" && previousVersion != result.Artifact.Version && activeLifecycle.Remote != nil {
+		if previousPath, pathErr := helperPath(previousVersion); pathErr == nil {
+			_ = activeLifecycle.Remote.RemoveExact(ctx, previousPath)
+		}
+	}
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
 	if manager.cfg == nil || manager.cfg.ID != config.ID || manager.cfg.SSHAlias != config.SSHAlias {
@@ -362,6 +396,26 @@ func (manager *Manager) setupHelper(ctx context.Context, expectedAlias string, c
 		manager.helperProbe = helperProbeFallback
 	}
 	return manager.healthLocked(manager.lastRequestedMs), nil
+}
+
+func (manager *Manager) setSetupProgress(progress SetupProgress) {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if manager.helperSetup {
+		manager.setupProgress = progress
+	}
+}
+
+func retryableSetupTransportFailure(result LifecycleResult) bool {
+	if result.CanExecute || result.State != LifecycleSFTP || result.Reason == nil {
+		return false
+	}
+	if errors.Is(result.Reason, ErrHelperNoExec) || errors.Is(result.Reason, ErrHelperVerification) ||
+		errors.Is(result.Reason, ErrUnsupportedHelperPlatform) {
+		return false
+	}
+	return errors.Is(result.Reason, context.DeadlineExceeded) || sshErrorStderr(result.Reason) != "" ||
+		classifyError(result.Reason) == ReasonConnectionFailed
 }
 
 // ReleaseHelperOwnership explicitly forgets local ownership without modifying
@@ -507,6 +561,9 @@ func (manager *Manager) ValidateSettingsChangeWithOwnershipAction(next *settings
 	}
 	if action != OwnershipActionRelease && action != OwnershipActionUninstall {
 		return ErrHelperOwnershipConflict
+	}
+	if next == nil && action == OwnershipActionRelease {
+		return nil
 	}
 	if manager.cfg == nil || (manager.helperVersion == "" && !manager.helperOwnershipCorrupt) {
 		return ErrHelperOwnershipConflict

--- a/collector/internal/remote/helpermanager.go
+++ b/collector/internal/remote/helpermanager.go
@@ -189,10 +189,8 @@ func NewProductionManager() (*Manager, error) {
 	}), nil
 }
 
-// startHelperDiscoveryLocked starts only a read-only verification pass. The
-// Lifecycle receives empty consent, so it can authenticate metadata, probe the
-// platform, inspect files, and negotiate capabilities but can never upload or
-// modify a remote helper.
+// startHelperDiscoveryLocked verifies a helper or updates one previously
+// installed with this source's recorded ownership.
 func (manager *Manager) startHelperDiscoveryLocked() {
 	if manager.helperProbe != helperProbeUnknown || manager.cfg == nil || manager.lifeCtx == nil {
 		return
@@ -207,11 +205,15 @@ func (manager *Manager) startHelperDiscoveryLocked() {
 	status := HelperStatus{State: LifecycleSFTP}
 	manager.helper = &status
 	config := *manager.cfg
-	go manager.runHelperDiscovery(manager.lifeCtx, config)
+	autoUpdate := manager.helperVersion != "" && !manager.helperOwnershipCorrupt
+	if autoUpdate {
+		manager.helperSetup = true
+	}
+	go manager.runHelperDiscovery(manager.lifeCtx, config, autoUpdate)
 }
 
-// InspectHelper starts (or reports) the non-mutating discovery pass for the
-// setup screen. It never waits on SSH while holding the manager lock.
+// InspectHelper starts (or reports) the background helper check for the setup
+// screen. It never waits on SSH while holding the manager lock.
 func (manager *Manager) InspectHelper() Health {
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
@@ -221,19 +223,42 @@ func (manager *Manager) InspectHelper() Health {
 	return manager.healthLocked(manager.lastRequestedMs)
 }
 
-func (manager *Manager) runHelperDiscovery(ctx context.Context, config settings.RemoteSettings) {
+func (manager *Manager) runHelperDiscovery(ctx context.Context, config settings.RemoteSettings, autoUpdate bool) {
+	if autoUpdate {
+		defer func() {
+			manager.mu.Lock()
+			manager.helperSetup = false
+			manager.mu.Unlock()
+		}()
+	}
 	probeCtx, cancel := context.WithTimeout(ctx, DefaultConnectTimeout)
 	defer cancel()
 	manager.mu.Lock()
-	provider, factory := manager.releaseProvider, manager.lifecycleFactory
+	provider, factory, previousVersion := manager.releaseProvider, manager.lifecycleFactory, manager.helperVersion
 	manager.mu.Unlock()
 	document, err := provider.LoadMetadata(probeCtx)
 	var result LifecycleResult
+	var lifecycle Lifecycle
 	if err == nil {
-		var lifecycle Lifecycle
 		lifecycle, err = factory(config.SSHAlias)
 		if err == nil {
-			result = lifecycle.SetupWithLoader(probeCtx, document, Consent{}, provider.LoadArtifact)
+			consent := Consent{}
+			if autoUpdate {
+				consent = Consent{Install: true, Upgrade: true}
+			}
+			result = lifecycle.SetupWithLoader(probeCtx, document, consent, provider.LoadArtifact)
+			if autoUpdate && retryableSetupTransportFailure(result) {
+				manager.resetControlMaster(config.SSHAlias)
+				if retryLifecycle, retryErr := factory(config.SSHAlias); retryErr == nil {
+					result = retryLifecycle.SetupWithLoader(probeCtx, document, consent, provider.LoadArtifact)
+					lifecycle = retryLifecycle
+				}
+			}
+		}
+	}
+	if result.CanExecute && autoUpdate && previousVersion != "" && previousVersion != result.Artifact.Version && lifecycle.Remote != nil {
+		if previousPath, pathErr := helperPath(previousVersion); pathErr == nil {
+			_ = lifecycle.Remote.RemoveExact(probeCtx, previousPath)
 		}
 	}
 	manager.mu.Lock()

--- a/collector/internal/remote/helpermanager.go
+++ b/collector/internal/remote/helpermanager.go
@@ -207,7 +207,7 @@ func (manager *Manager) startHelperDiscoveryLocked() {
 	config := *manager.cfg
 	autoUpdate := manager.helperVersion != "" && !manager.helperOwnershipCorrupt
 	if autoUpdate {
-		manager.helperSetup = true
+		manager.helperAutoSetup = true
 	}
 	go manager.runHelperDiscovery(manager.lifeCtx, config, autoUpdate)
 }
@@ -227,7 +227,7 @@ func (manager *Manager) runHelperDiscovery(ctx context.Context, config settings.
 	if autoUpdate {
 		defer func() {
 			manager.mu.Lock()
-			manager.helperSetup = false
+			manager.helperAutoSetup = false
 			manager.mu.Unlock()
 		}()
 	}
@@ -261,22 +261,26 @@ func (manager *Manager) runHelperDiscovery(ctx context.Context, config settings.
 		}
 	}
 	manager.mu.Lock()
-	defer manager.mu.Unlock()
 	if manager.cfg == nil || manager.cfg.ID != config.ID || manager.cfg.SSHAlias != config.SSHAlias || ctx.Err() != nil {
+		manager.mu.Unlock()
 		return
 	}
+	var removeRemote LifecycleRemote
+	removePath := ""
+	refreshAfterDiscovery := true
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) || sshErrorStderr(err) != "" {
 			manager.lastCheckedAt = int64Ptr(manager.now().UnixMilli())
 			manager.helperProbe = helperProbeFallback
 			status := unavailableHelperStatus(err)
 			manager.helper = &status
-			manager.applyFailureLocked(classifyError(err), sshErrorStderr(err))
-			return
+			manager.nextHelperProbeAt = manager.now().Add(RemoteRetryInterval)
+			refreshAfterDiscovery = false
+		} else {
+			status := unavailableHelperStatus(err)
+			manager.helper = &status
+			manager.helperProbe = helperProbeFallback
 		}
-		status := unavailableHelperStatus(err)
-		manager.helper = &status
-		manager.helperProbe = helperProbeFallback
 	} else {
 		status := lifecycleStatus(result)
 		manager.helper = &status
@@ -292,9 +296,10 @@ func (manager *Manager) runHelperDiscovery(ctx context.Context, config settings.
 			} else {
 				manager.helperVersion = result.Artifact.Version
 				manager.helperProbe = helperProbeReady
+				manager.nextHelperProbeAt = time.Time{}
 				if autoUpdate && previousVersion != "" && previousVersion != result.Artifact.Version && lifecycle.Remote != nil {
 					if previousPath, pathErr := helperPath(previousVersion); pathErr == nil {
-						_ = lifecycle.Remote.RemoveExact(probeCtx, previousPath)
+						removeRemote, removePath = lifecycle.Remote, previousPath
 					}
 				}
 			}
@@ -302,10 +307,19 @@ func (manager *Manager) runHelperDiscovery(ctx context.Context, config settings.
 			manager.helperTarget = nil
 			manager.helperProbe = helperProbeFallback
 		}
+		if autoUpdate && retryableSetupTransportFailure(result) {
+			manager.nextHelperProbeAt = manager.now().Add(RemoteRetryInterval)
+		}
 	}
 	// The first ListView window was retained while discovery ran. Only now may
 	// the normal refresh choose helper or explicit SFTP fallback.
-	manager.maybeStartRefreshLocked(manager.lastRequestedMs, false)
+	if refreshAfterDiscovery {
+		manager.maybeStartRefreshLocked(manager.lastRequestedMs, false)
+	}
+	manager.mu.Unlock()
+	if removeRemote != nil {
+		_ = removeRemote.RemoveExact(probeCtx, removePath)
+	}
 }
 
 // SetupHelperForAlias binds consented setup to the alias the user tested. It
@@ -325,10 +339,10 @@ func (manager *Manager) setupHelper(ctx context.Context, expectedAlias string, c
 		manager.mu.Unlock()
 		return health, ErrHelperAliasMismatch
 	}
-	if manager.helperSetup {
+	if manager.helperSetup || manager.helperAutoSetup {
 		health := manager.healthLocked(manager.lastRequestedMs)
 		manager.mu.Unlock()
-		return health, ErrHelperSetupInProgress
+		return health, nil
 	}
 	config := *manager.cfg
 	previousVersion := manager.helperVersion
@@ -381,9 +395,10 @@ func (manager *Manager) setupHelper(ctx context.Context, expectedAlias string, c
 		}
 	}
 	manager.mu.Lock()
-	defer manager.mu.Unlock()
 	if manager.cfg == nil || manager.cfg.ID != config.ID || manager.cfg.SSHAlias != config.SSHAlias {
-		return manager.healthLocked(manager.lastRequestedMs), nil
+		health := manager.healthLocked(manager.lastRequestedMs)
+		manager.mu.Unlock()
+		return health, nil
 	}
 	status := lifecycleStatus(result)
 	manager.helper = &status
@@ -392,21 +407,33 @@ func (manager *Manager) setupHelper(ctx context.Context, expectedAlias string, c
 			status = unavailableHelperStatus(fmt.Errorf("%w: %v", ErrHelperInstallation, err))
 			manager.helper = &status
 			manager.helperTarget = nil
-			return manager.healthLocked(manager.lastRequestedMs), nil
+			health := manager.healthLocked(manager.lastRequestedMs)
+			manager.mu.Unlock()
+			return health, nil
 		}
 		manager.helperTarget = &helperTarget{path: result.Path, version: result.Artifact.Version, state: result.State, artifact: result.Artifact}
 		manager.helperVersion = result.Artifact.Version
 		manager.helperProbe = helperProbeReady
+		var removeRemote LifecycleRemote
+		removePath := ""
 		if previousVersion != "" && previousVersion != result.Artifact.Version && activeLifecycle.Remote != nil {
 			if previousPath, pathErr := helperPath(previousVersion); pathErr == nil {
-				_ = activeLifecycle.Remote.RemoveExact(ctx, previousPath)
+				removeRemote, removePath = activeLifecycle.Remote, previousPath
 			}
 		}
+		health := manager.healthLocked(manager.lastRequestedMs)
+		manager.mu.Unlock()
+		if removeRemote != nil {
+			_ = removeRemote.RemoveExact(ctx, removePath)
+		}
+		return health, nil
 	} else {
 		manager.helperTarget = nil
 		manager.helperProbe = helperProbeFallback
 	}
-	return manager.healthLocked(manager.lastRequestedMs), nil
+	health := manager.healthLocked(manager.lastRequestedMs)
+	manager.mu.Unlock()
+	return health, nil
 }
 
 func retryableSetupTransportFailure(result LifecycleResult) bool {

--- a/collector/internal/remote/helpermanager.go
+++ b/collector/internal/remote/helpermanager.go
@@ -231,7 +231,11 @@ func (manager *Manager) runHelperDiscovery(ctx context.Context, config settings.
 			manager.mu.Unlock()
 		}()
 	}
-	probeCtx, cancel := context.WithTimeout(ctx, DefaultConnectTimeout)
+	timeout := DefaultConnectTimeout
+	if autoUpdate {
+		timeout = DefaultHelperAutoUpdateTimeout
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	manager.mu.Lock()
 	provider, factory, previousVersion := manager.releaseProvider, manager.lifecycleFactory, manager.helperVersion

--- a/collector/internal/remote/lifecycle.go
+++ b/collector/internal/remote/lifecycle.go
@@ -487,8 +487,8 @@ func (lifecycle Lifecycle) VerifyExecution(ctx context.Context, path string, art
 }
 
 // Setup authenticates metadata before platform lookup or any remote mutation.
-// Consent is per action: initial install and later upgrades are separate, so an
-// old consent cannot silently install fresh executable code.
+// New hosts require installation consent; a recorded helper owner can consent
+// to its replacement when the app updates.
 // Setup is retained for focused lifecycle tests. Production callers must use
 // SetupWithLoader so an arm64 host never downloads amd64 bytes (or vice versa)
 // before its platform is known.

--- a/collector/internal/remote/lifecycle.go
+++ b/collector/internal/remote/lifecycle.go
@@ -442,25 +442,8 @@ type compatibleHelper struct {
 }
 
 type Lifecycle struct {
-	Remote   LifecycleRemote
-	Trust    TrustStore
-	Progress func(SetupProgress)
-}
-
-type SetupProgress string
-
-const (
-	SetupProgressIdle      SetupProgress = "idle"
-	SetupProgressChecking  SetupProgress = "checking"
-	SetupProgressPreparing SetupProgress = "preparing"
-	SetupProgressUploading SetupProgress = "uploading"
-	SetupProgressVerifying SetupProgress = "verifying"
-)
-
-func (lifecycle Lifecycle) reportProgress(progress SetupProgress) {
-	if lifecycle.Progress != nil {
-		lifecycle.Progress(progress)
-	}
+	Remote LifecycleRemote
+	Trust  TrustStore
 }
 
 // VerifyExecution revalidates all executable-file invariants immediately
@@ -499,7 +482,6 @@ func (lifecycle Lifecycle) Setup(ctx context.Context, document SignedReleaseMeta
 }
 
 func (lifecycle Lifecycle) SetupWithLoader(ctx context.Context, document SignedReleaseMetadata, consent Consent, load ArtifactLoader) LifecycleResult {
-	lifecycle.reportProgress(SetupProgressChecking)
 	metadata, err := lifecycle.Trust.Verify(document)
 	if err != nil {
 		return lifecycleFailure(LifecycleVerificationError, err)
@@ -520,7 +502,6 @@ func (lifecycle Lifecycle) SetupWithLoader(ctx context.Context, document SignedR
 	}
 	normalized.UID = platform.UID
 	platform = normalized
-	lifecycle.reportProgress(SetupProgressPreparing)
 	artifact, err := metadata.Select(platform)
 	if err != nil {
 		state := LifecycleUnsupported
@@ -597,7 +578,6 @@ func (lifecycle Lifecycle) SetupWithLoader(ctx context.Context, document SignedR
 	if err := verifyLocalArtifact(artifact, artifactBytes); err != nil {
 		return lifecycleFailure(LifecycleVerificationError, err)
 	}
-	lifecycle.reportProgress(SetupProgressUploading)
 	temporary, _ := helperTemporaryPath(artifact.Version)
 	installed, err := lifecycle.Remote.Install(ctx, InstallRequest{
 		Artifact: artifact, Bytes: slices.Clone(artifactBytes), Destination: target,
@@ -616,12 +596,8 @@ func (lifecycle Lifecycle) SetupWithLoader(ctx context.Context, document SignedR
 		}
 		return lifecycleFailure(LifecycleVerificationError, err)
 	}
-	lifecycle.reportProgress(SetupProgressVerifying)
 	result := lifecycle.capabilityResult(ctx, target, artifact, LifecycleReady)
 	if result.CanExecute {
-		if previous != nil {
-			_ = lifecycle.Remote.RemoveExact(ctx, previous.path)
-		}
 		return result
 	}
 	_ = lifecycle.Remote.RemoveExact(ctx, target)

--- a/collector/internal/remote/lifecycle.go
+++ b/collector/internal/remote/lifecycle.go
@@ -442,8 +442,25 @@ type compatibleHelper struct {
 }
 
 type Lifecycle struct {
-	Remote LifecycleRemote
-	Trust  TrustStore
+	Remote   LifecycleRemote
+	Trust    TrustStore
+	Progress func(SetupProgress)
+}
+
+type SetupProgress string
+
+const (
+	SetupProgressIdle      SetupProgress = "idle"
+	SetupProgressChecking  SetupProgress = "checking"
+	SetupProgressPreparing SetupProgress = "preparing"
+	SetupProgressUploading SetupProgress = "uploading"
+	SetupProgressVerifying SetupProgress = "verifying"
+)
+
+func (lifecycle Lifecycle) reportProgress(progress SetupProgress) {
+	if lifecycle.Progress != nil {
+		lifecycle.Progress(progress)
+	}
 }
 
 // VerifyExecution revalidates all executable-file invariants immediately
@@ -482,6 +499,7 @@ func (lifecycle Lifecycle) Setup(ctx context.Context, document SignedReleaseMeta
 }
 
 func (lifecycle Lifecycle) SetupWithLoader(ctx context.Context, document SignedReleaseMetadata, consent Consent, load ArtifactLoader) LifecycleResult {
+	lifecycle.reportProgress(SetupProgressChecking)
 	metadata, err := lifecycle.Trust.Verify(document)
 	if err != nil {
 		return lifecycleFailure(LifecycleVerificationError, err)
@@ -502,6 +520,7 @@ func (lifecycle Lifecycle) SetupWithLoader(ctx context.Context, document SignedR
 	}
 	normalized.UID = platform.UID
 	platform = normalized
+	lifecycle.reportProgress(SetupProgressPreparing)
 	artifact, err := metadata.Select(platform)
 	if err != nil {
 		state := LifecycleUnsupported
@@ -578,6 +597,7 @@ func (lifecycle Lifecycle) SetupWithLoader(ctx context.Context, document SignedR
 	if err := verifyLocalArtifact(artifact, artifactBytes); err != nil {
 		return lifecycleFailure(LifecycleVerificationError, err)
 	}
+	lifecycle.reportProgress(SetupProgressUploading)
 	temporary, _ := helperTemporaryPath(artifact.Version)
 	installed, err := lifecycle.Remote.Install(ctx, InstallRequest{
 		Artifact: artifact, Bytes: slices.Clone(artifactBytes), Destination: target,
@@ -596,8 +616,12 @@ func (lifecycle Lifecycle) SetupWithLoader(ctx context.Context, document SignedR
 		}
 		return lifecycleFailure(LifecycleVerificationError, err)
 	}
+	lifecycle.reportProgress(SetupProgressVerifying)
 	result := lifecycle.capabilityResult(ctx, target, artifact, LifecycleReady)
 	if result.CanExecute {
+		if previous != nil {
+			_ = lifecycle.Remote.RemoveExact(ctx, previous.path)
+		}
 		return result
 	}
 	_ = lifecycle.Remote.RemoveExact(ctx, target)

--- a/collector/internal/remote/lifecycle_ssh.go
+++ b/collector/internal/remote/lifecycle_ssh.go
@@ -181,7 +181,7 @@ func (remote *SSHLifecycleRemote) runStagedInstaller(ctx context.Context, stagin
 	if command == nil {
 		command = exec.CommandContext
 	}
-	runCtx, cancel := context.WithTimeout(ctx, limits.Deadline)
+	runCtx, cancel := context.WithTimeout(ctx, min(limits.Deadline, DefaultHelperInstallTimeout))
 	defer cancel()
 	args := []string{
 		"-T", "-o", "BatchMode=yes", "-o", "ConnectTimeout=" + strconv.Itoa(int(limits.ConnectTimeout.Seconds())),

--- a/collector/internal/remote/lifecycle_test.go
+++ b/collector/internal/remote/lifecycle_test.go
@@ -42,7 +42,7 @@ func TestLifecycleDeprecatedHelperIsReusedUntilUpgradeConsent(t *testing.T) {
 	}
 	result = lifecycleFor(remote).Setup(context.Background(), remote.document, content, Consent{Upgrade: true})
 	currentPath, _ := helperPath(current.Version)
-	if result.State != LifecycleReady || remote.files[path].Path != "" || remote.files[currentPath].Path == "" {
+	if result.State != LifecycleReady || remote.files[path].Path == "" || remote.files[currentPath].Path == "" {
 		t.Fatalf("upgrade result = %#v, files = %#v", result, remote.files)
 	}
 }

--- a/collector/internal/remote/lifecycle_test.go
+++ b/collector/internal/remote/lifecycle_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/centauri-ai/coslash/collector/internal/remotefacts"
 	"github.com/centauri-ai/coslash/collector/internal/remoteprotocol"
 )
 
@@ -41,7 +42,7 @@ func TestLifecycleDeprecatedHelperIsReusedUntilUpgradeConsent(t *testing.T) {
 	}
 	result = lifecycleFor(remote).Setup(context.Background(), remote.document, content, Consent{Upgrade: true})
 	currentPath, _ := helperPath(current.Version)
-	if result.State != LifecycleReady || remote.files[path].Path == "" || remote.files[currentPath].Path == "" {
+	if result.State != LifecycleReady || remote.files[path].Path != "" || remote.files[currentPath].Path == "" {
 		t.Fatalf("upgrade result = %#v, files = %#v", result, remote.files)
 	}
 }
@@ -276,7 +277,7 @@ func lifecycleFixture(t *testing.T) (*fakeLifecycleRemote, Artifact, []byte) {
 	t.Helper()
 	arch := "amd64"
 	content := syntheticELF(arch)
-	artifact := Artifact{Version: "v1", OS: "linux", Arch: arch, Size: int64(len(content)), SHA256: digest(content), Protocol: remoteprotocol.VersionRange{Min: 1, Max: 1}, Schema: remoteprotocol.VersionRange{Min: 1, Max: 1}, Current: true}
+	artifact := Artifact{Version: "v1", OS: "linux", Arch: arch, Size: int64(len(content)), SHA256: digest(content), Protocol: remoteprotocol.VersionRange{Min: 1, Max: 1}, Schema: remoteprotocol.VersionRange{Min: remotefacts.SchemaVersion, Max: remotefacts.SchemaVersion}, Current: true}
 	capabilities := compatibleCapabilities()
 	capabilities.Arch = arch
 	remote := &fakeLifecycleRemote{root: t.TempDir(), platform: Platform{OS: "linux", Arch: arch, UID: 501}, files: map[string]RemoteFile{}, capabilities: capabilities}
@@ -318,7 +319,7 @@ func lifecycleFor(remote *fakeLifecycleRemote) Lifecycle {
 }
 
 func compatibleCapabilities() remoteprotocol.Capabilities {
-	return remoteprotocol.Capabilities{Protocol: remoteprotocol.VersionRange{Min: 1, Max: 1}, Schema: remoteprotocol.VersionRange{Min: 1, Max: 1}, ParserVersion: "parsers-1", OS: "linux", Arch: "amd64"}
+	return remoteprotocol.Capabilities{Protocol: remoteprotocol.VersionRange{Min: 1, Max: 1}, Schema: remoteprotocol.VersionRange{Min: remotefacts.SchemaVersion, Max: remotefacts.SchemaVersion}, ParserVersion: "parsers-1", OS: "linux", Arch: "amd64"}
 }
 
 func remoteFile(path string, artifact Artifact, uid uint32) RemoteFile {

--- a/collector/internal/remote/limits.go
+++ b/collector/internal/remote/limits.go
@@ -11,6 +11,9 @@ const (
 	DefaultConnectTimeout = 7 * time.Second
 	// Helper activation is a small fixed command, unlike collection.
 	DefaultHelperInstallTimeout = 15 * time.Second
+	// A previously approved helper can update in the background after a new
+	// coSlash release. Its SSH handshake remains bounded by DefaultConnectTimeout.
+	DefaultHelperAutoUpdateTimeout = 2 * time.Minute
 	// Covers Claude and Codex over one SFTP session; large remote trees need headroom.
 	DefaultDeadline       = 3 * time.Minute
 	DefaultMaxFileBytes   = 32 << 20

--- a/collector/internal/remote/limits.go
+++ b/collector/internal/remote/limits.go
@@ -6,7 +6,11 @@ import (
 )
 
 const (
-	DefaultConnectTimeout = 60 * time.Second
+	// A host that cannot complete an SSH handshake promptly is unavailable for
+	// the board. Collection itself retains DefaultDeadline after it connects.
+	DefaultConnectTimeout = 7 * time.Second
+	// Helper activation is a small fixed command, unlike collection.
+	DefaultHelperInstallTimeout = 15 * time.Second
 	// Covers Claude and Codex over one SFTP session; large remote trees need headroom.
 	DefaultDeadline       = 3 * time.Minute
 	DefaultMaxFileBytes   = 32 << 20
@@ -15,11 +19,9 @@ const (
 	DefaultMaxDepth       = 16
 	DefaultMaxStderrBytes = 8 << 10
 
-	FreshnessInterval = 3 * time.Minute
-	// Short first retry so fixing SSH (keys/host) recovers the board without a
-	// long wait or a manual Retry click; later failures still back off hard.
-	InitialRetryBackoff = 30 * time.Second
-	MaxRetryBackoff     = 30 * time.Minute
+	FreshnessInterval   = 3 * time.Minute
+	RemoteRetryInterval = 3 * time.Minute
+	ManualRetryCooldown = 2 * time.Second
 	ActivityWindowMs    = 2 * 60_000
 	MaxDiagnosticBytes  = 2 << 10
 	MaxErrorCopyBytes   = 256

--- a/collector/internal/remote/manager.go
+++ b/collector/internal/remote/manager.go
@@ -436,6 +436,24 @@ func (manager *Manager) DiagnosticsHealth() Health {
 	return manager.healthLocked(manager.lastRequestedMs)
 }
 
+// LaunchSession returns the current remote session and SSH alias only while
+// the host's most recent collection completed successfully.
+func (manager *Manager) LaunchSession(sourceID, agent, sessionID string) (*session.Session, string, bool) {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if manager.cfg == nil || !manager.cfg.Enabled || manager.cfg.ID != sourceID ||
+		(manager.state != StateOK && manager.state != StateLimited) {
+		return nil, "", false
+	}
+	for _, item := range manager.sessions {
+		if item.Agent == agent && item.ID == sessionID && item.WorkingDirectory != "" {
+			copy := *item
+			return &copy, manager.cfg.SSHAlias, true
+		}
+	}
+	return nil, "", false
+}
+
 // SetupAliasMatches reports whether alias is the currently persisted remote
 // target. SetupHelperForAlias repeats this check while taking its immutable
 // configuration snapshot; this fast check lets the HTTP handler reject an

--- a/collector/internal/remote/manager.go
+++ b/collector/internal/remote/manager.go
@@ -15,11 +15,12 @@ import (
 )
 
 var (
-	ErrInvalidRemoteSettings   = errors.New("invalid remote settings")
-	ErrHelperOwnershipConflict = errors.New("helper ownership must be explicitly released or uninstalled before changing SSH alias")
-	ErrHelperAliasMismatch     = errors.New("helper setup alias does not match configured SSH alias")
-	ErrHelperSetupInProgress   = errors.New("helper setup is running for the configured SSH alias")
-	ErrRemoteSessionActive     = errors.New("remote session already has an active writer")
+	ErrInvalidRemoteSettings    = errors.New("invalid remote settings")
+	ErrHelperOwnershipConflict  = errors.New("helper ownership must be explicitly released or uninstalled before changing SSH alias")
+	ErrHelperAliasMismatch      = errors.New("helper setup alias does not match configured SSH alias")
+	ErrHelperSetupInProgress    = errors.New("helper setup is running for the configured SSH alias")
+	ErrRemoteSessionActive      = errors.New("remote session already has an active writer")
+	ErrRemoteSessionUnavailable = errors.New("remote session details are unavailable")
 )
 
 type SessionKey struct {
@@ -35,6 +36,7 @@ type IndexedSession struct {
 	EligibleForAggregates bool
 	DisplayStale          bool
 	LastSeenStatus        *string
+	Launchable            bool
 }
 
 type remoteSessionKey struct{ Agent, ID string }
@@ -101,6 +103,7 @@ type Manager struct {
 	lastRequestedMs        int64
 	failures               int
 	nextRetryAt            time.Time
+	nextHelperProbeAt      time.Time
 	lastManualRetryAt      time.Time
 	lastSuccessAt          *int64
 	lastCheckedAt          *int64
@@ -110,6 +113,7 @@ type Manager struct {
 	helperVerify           helperVerifyFunc
 	resetControlMaster     func(string)
 	helperSetup            bool
+	helperAutoSetup        bool
 	helperVersion          string
 	helperOwnershipCorrupt bool
 	helperProbe            helperProbeState
@@ -360,7 +364,7 @@ func (manager *Manager) ListView(remoteSinceMs int64) ListResult {
 		return ListResult{Health: manager.healthLocked(remoteSinceMs)}
 	}
 	if manager.helperProbe == helperProbeFallback && manager.helperVersion != "" &&
-		!manager.nextRetryAt.IsZero() && !manager.now().Before(manager.nextRetryAt) {
+		!manager.nextHelperProbeAt.IsZero() && !manager.now().Before(manager.nextHelperProbeAt) {
 		manager.helperProbe = helperProbeUnknown
 	}
 	if manager.helperProbe == helperProbeUnknown {
@@ -446,7 +450,10 @@ func (manager *Manager) LaunchSession(sourceID, agent, sessionID string) (*sessi
 		return nil, "", nil
 	}
 	for _, item := range manager.sessions {
-		if item.Agent == agent && item.ID == sessionID && item.WorkingDirectory != "" {
+		if item.Agent == agent && item.ID == sessionID {
+			if item.WorkingDirectory == "" {
+				return nil, "", ErrRemoteSessionUnavailable
+			}
 			if item.Status != nil && *item.Status == "busy" {
 				return nil, "", ErrRemoteSessionActive
 			}
@@ -739,6 +746,7 @@ func (manager *Manager) sessionsLocked(remoteSinceMs int64) []IndexedSession {
 			SourceLabel: manager.cfg.SSHAlias, Session: item,
 			EligibleForAggregates: eligible,
 			DisplayStale:          globalStale || manager.familyStale[remoteSessionKey{Agent: item.Agent, ID: item.ID}],
+			Launchable:            item.WorkingDirectory != "",
 		}
 		if indexed.DisplayStale {
 			indexed.LastSeenStatus = item.Status

--- a/collector/internal/remote/manager.go
+++ b/collector/internal/remote/manager.go
@@ -19,6 +19,7 @@ var (
 	ErrHelperOwnershipConflict = errors.New("helper ownership must be explicitly released or uninstalled before changing SSH alias")
 	ErrHelperAliasMismatch     = errors.New("helper setup alias does not match configured SSH alias")
 	ErrHelperSetupInProgress   = errors.New("helper setup is running for the configured SSH alias")
+	ErrRemoteSessionActive     = errors.New("remote session already has an active writer")
 )
 
 type SessionKey struct {
@@ -438,20 +439,23 @@ func (manager *Manager) DiagnosticsHealth() Health {
 
 // LaunchSession returns the current remote session and SSH alias only while
 // the host's most recent collection completed successfully.
-func (manager *Manager) LaunchSession(sourceID, agent, sessionID string) (*session.Session, string, bool) {
+func (manager *Manager) LaunchSession(sourceID, agent, sessionID string) (*session.Session, string, error) {
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
 	if manager.cfg == nil || !manager.cfg.Enabled || manager.cfg.ID != sourceID ||
 		(manager.state != StateOK && manager.state != StateLimited) {
-		return nil, "", false
+		return nil, "", nil
 	}
 	for _, item := range manager.sessions {
 		if item.Agent == agent && item.ID == sessionID && item.WorkingDirectory != "" {
+			if item.Status != nil && *item.Status == "busy" {
+				return nil, "", ErrRemoteSessionActive
+			}
 			copy := *item
-			return &copy, manager.cfg.SSHAlias, true
+			return &copy, manager.cfg.SSHAlias, nil
 		}
 	}
-	return nil, "", false
+	return nil, "", nil
 }
 
 // SetupAliasMatches reports whether alias is the currently persisted remote

--- a/collector/internal/remote/manager.go
+++ b/collector/internal/remote/manager.go
@@ -110,7 +110,6 @@ type Manager struct {
 	helperVerify           helperVerifyFunc
 	resetControlMaster     func(string)
 	helperSetup            bool
-	setupProgress          SetupProgress
 	helperVersion          string
 	helperOwnershipCorrupt bool
 	helperProbe            helperProbeState

--- a/collector/internal/remote/manager.go
+++ b/collector/internal/remote/manager.go
@@ -359,6 +359,10 @@ func (manager *Manager) ListView(remoteSinceMs int64) ListResult {
 	if !manager.cfg.Enabled {
 		return ListResult{Health: manager.healthLocked(remoteSinceMs)}
 	}
+	if manager.helperProbe == helperProbeFallback && manager.helperVersion != "" &&
+		!manager.nextRetryAt.IsZero() && !manager.now().Before(manager.nextRetryAt) {
+		manager.helperProbe = helperProbeUnknown
+	}
 	if manager.helperProbe == helperProbeUnknown {
 		manager.startHelperDiscoveryLocked()
 	}

--- a/collector/internal/remote/manager.go
+++ b/collector/internal/remote/manager.go
@@ -100,12 +100,16 @@ type Manager struct {
 	lastRequestedMs        int64
 	failures               int
 	nextRetryAt            time.Time
+	lastManualRetryAt      time.Time
 	lastSuccessAt          *int64
+	lastCheckedAt          *int64
 	transport              Transport
 	helper                 *HelperStatus
 	helperTarget           *helperTarget
 	helperVerify           helperVerifyFunc
+	resetControlMaster     func(string)
 	helperSetup            bool
+	setupProgress          SetupProgress
 	helperVersion          string
 	helperOwnershipCorrupt bool
 	helperProbe            helperProbeState
@@ -120,6 +124,7 @@ type Options struct {
 	// Supplying it is useful for deterministic manager tests.
 	HelperRefresh               helperRefreshFunc
 	HelperVerify                helperVerifyFunc
+	ResetControlMaster          func(string)
 	ReleaseProvider             HelperReleaseProvider
 	LifecycleFactory            lifecycleFactory
 	Trust                       TrustStore
@@ -176,10 +181,15 @@ func NewManager(options Options) *Manager {
 			return lifecycle.VerifyExecution(ctx, target.path, target.artifact)
 		}
 	}
+	resetControlMaster := options.ResetControlMaster
+	if resetControlMaster == nil {
+		resetControlMaster = exitControlMasterBestEffort
+	}
 	return &Manager{
 		cache: cache, now: now, refresh: refresh, helperRefresh: helperRefresh, test: test,
-		helperVerify:    helperVerify,
-		releaseProvider: options.ReleaseProvider, lifecycleFactory: factory,
+		helperVerify:       helperVerify,
+		resetControlMaster: resetControlMaster,
+		releaseProvider:    options.ReleaseProvider, lifecycleFactory: factory,
 		trust:                       options.Trust,
 		helperInstallationAvailable: options.HelperInstallationAvailable,
 		state:                       StateDisabled, complete: true, transport: TransportSFTP,
@@ -276,6 +286,7 @@ func (manager *Manager) ApplySettings(remote *settings.RemoteSettings) error {
 		manager.complete = false
 		manager.failures = 0
 		manager.nextRetryAt = time.Time{}
+		manager.lastManualRetryAt = time.Time{}
 		manager.helperTarget = nil
 		manager.helperProbe = helperProbeUnknown
 		// Initial collection waits for ListView's first requested window
@@ -361,14 +372,21 @@ func (manager *Manager) ListView(remoteSinceMs int64) ListResult {
 	return ListResult{Sessions: manager.sessionsLocked(remoteSinceMs), Health: manager.healthLocked(remoteSinceMs)}
 }
 
-func (manager *Manager) Retry() Health {
+// Retry starts one manual refresh unless another one is running or the
+// caller retried too recently. The bool reports whether a refresh started.
+func (manager *Manager) Retry() (Health, bool) {
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
 	if manager.cfg == nil || !manager.cfg.Enabled {
-		return manager.healthLocked(manager.lastRequestedMs)
+		return manager.healthLocked(manager.lastRequestedMs), false
 	}
+	if manager.refreshing || (!manager.lastManualRetryAt.IsZero() &&
+		manager.now().Sub(manager.lastManualRetryAt) < ManualRetryCooldown) {
+		return manager.healthLocked(manager.lastRequestedMs), false
+	}
+	manager.lastManualRetryAt = manager.now()
 	manager.maybeStartRefreshLocked(manager.lastRequestedMs, true)
-	return manager.healthLocked(manager.lastRequestedMs)
+	return manager.healthLocked(manager.lastRequestedMs), true
 }
 
 func (manager *Manager) TestAlias(ctx context.Context, alias string) (Health, error) {
@@ -404,6 +422,7 @@ func (manager *Manager) recoverAfterSuccessfulTest(alias string) {
 	}
 	manager.failures = 0
 	manager.nextRetryAt = time.Time{}
+	manager.lastManualRetryAt = time.Time{}
 	manager.maybeStartRefreshLocked(manager.lastRequestedMs, true)
 }
 
@@ -460,6 +479,7 @@ func (manager *Manager) removeLocked() error {
 	manager.failures = 0
 	manager.nextRetryAt = time.Time{}
 	manager.lastSuccessAt = nil
+	manager.lastCheckedAt = nil
 	manager.transport = TransportSFTP
 	manager.helper = nil
 	manager.helperTarget = nil
@@ -485,6 +505,7 @@ func (manager *Manager) loadCacheLocked() error {
 		manager.sessions = composeFromGeneration(toGeneration(v2), nullReadSource{}, nil, 0)
 		manager.familyStale = staleSessions(v2)
 		manager.lastSuccessAt = int64Ptr(v2.FetchedAtMs)
+		manager.lastCheckedAt = int64Ptr(v2.FetchedAtMs)
 		return nil
 	}
 	legacy, ok, err := manager.cache.Load(manager.cfg.ID)
@@ -510,6 +531,7 @@ func (manager *Manager) loadCacheLocked() error {
 	manager.sessions = legacy.sessions()
 	manager.familyStale = nil
 	manager.lastSuccessAt = int64Ptr(legacy.FetchedAtMs)
+	manager.lastCheckedAt = int64Ptr(legacy.FetchedAtMs)
 	return nil
 }
 
@@ -580,6 +602,7 @@ func (manager *Manager) runRefresh(
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
 	manager.refreshing = false
+	manager.lastCheckedAt = int64Ptr(fetchedAt)
 	if manager.cfg == nil || manager.cfg.ID != config.ID || !manager.cfg.Enabled || errors.Is(ctx.Err(), context.Canceled) {
 		return
 	}
@@ -709,6 +732,8 @@ func (manager *Manager) healthLocked(remoteSinceMs int64) Health {
 		Complete: manager.complete, Reason: manager.reason, Error: manager.errorCopy,
 		Refreshing:      manager.refreshing,
 		LastSuccessAtMs: manager.lastSuccessAt,
+		LastCheckedAtMs: manager.lastCheckedAt,
+		SessionCount:    len(manager.sessionsLocked(remoteSinceMs)),
 		Transport:       manager.transport, Helper: manager.helper, Metrics: manager.metrics,
 		HelperInstallationAvailable: manager.helperInstallationAvailable,
 		HelperProbeState:            string(manager.helperProbe),
@@ -855,9 +880,5 @@ func classifyError(err error) Reason {
 }
 
 func retryBackoff(failures int) time.Duration {
-	if failures <= 1 {
-		return InitialRetryBackoff
-	}
-	delay := InitialRetryBackoff << min(failures-1, 6)
-	return min(delay, MaxRetryBackoff)
+	return RemoteRetryInterval
 }

--- a/collector/internal/remote/manager_test.go
+++ b/collector/internal/remote/manager_test.go
@@ -577,7 +577,9 @@ func TestHelperTestAcceptsEmptySuccessfulCollectionWithoutRewritingBoardState(t 
 		t.Fatalf("setup health = %#v", health)
 	}
 	manager.mu.Lock()
-	manager.snapshot = &CachedSnapshotV2{Version: cacheV2Version, CoverageSinceMs: now.UnixMilli()}
+	manager.snapshot = &CachedSnapshotV2{
+		Version: cacheV2Version, CoverageSinceMs: now.UnixMilli(), FetchedAtMs: now.UnixMilli(),
+	}
 	manager.sessions = []*session.Session{{Agent: vendors.AgentClaude, ID: "cached"}}
 	manager.state = StateStale
 	manager.reason = reasonPtr(ReasonInitialRefresh)

--- a/collector/internal/remote/manager_test.go
+++ b/collector/internal/remote/manager_test.go
@@ -442,6 +442,119 @@ func TestRestartDiscoversAndReusesVerifiedHelperWithoutInstall(t *testing.T) {
 	}
 }
 
+func TestRestartAutomaticallyUpdatesAnOwnedHelper(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("COSLASH_HOME", home)
+	remote, current, content := lifecycleFixture(t)
+	cache := NewCache(filepath.Join(home, "remote-cache"))
+	options := Options{
+		Cache: cache, Now: time.Now,
+		ReleaseProvider:             fixedHelperRelease{document: remote.document, content: content},
+		LifecycleFactory:            func(string) (Lifecycle, error) { return lifecycleFor(remote), nil },
+		HelperInstallationAvailable: true,
+		HelperRefresh: func(context.Context, string, int64, time.Time, CachedSnapshotV2, helperTarget) (refreshOutcome, error) {
+			return refreshOutcome{Snapshot: CachedSnapshotV2{Version: cacheV2Version}}, nil
+		},
+	}
+	config := &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}
+	first := NewManager(options)
+	if err := first.ApplySettings(config); err != nil {
+		t.Fatal(err)
+	}
+	if health := first.SetupHelper(context.Background(), Consent{Install: true}); health.Helper == nil || !health.Helper.Compatible {
+		t.Fatalf("initial setup health = %#v", health)
+	}
+
+	previous := current
+	previous.Current = false
+	updated := current
+	updated.Version = "v2"
+	remote.document = signDocument(t, ReleaseMetadata{
+		Sequence: 2, ExpiresAtUnix: time.Now().Add(time.Hour).Unix(), Artifacts: []Artifact{updated, previous},
+	})
+	options.ReleaseProvider = fixedHelperRelease{document: remote.document, content: content}
+	restarted := NewManager(options)
+	if err := restarted.ApplySettings(config); err != nil {
+		t.Fatal(err)
+	}
+	restarted.ListView(time.Now().Add(-time.Hour).UnixMilli())
+	waitUntil(t, func() bool {
+		restarted.mu.Lock()
+		defer restarted.mu.Unlock()
+		return restarted.helperProbe == helperProbeReady && !restarted.helperSetup
+	})
+	if remote.installs != 2 || remote.removed != "~/.coslash/helpers/v1/coslash-helper" {
+		t.Fatalf("installs=%d removed=%q", remote.installs, remote.removed)
+	}
+	if health := restarted.DiagnosticsHealth(); health.Helper == nil || !health.Helper.Compatible || health.Helper.Version != "v2" {
+		t.Fatalf("updated health = %#v", health)
+	}
+	ownership, owned, err := cache.LoadHelperOwnership(config.ID)
+	if err != nil || !owned || ownership.Version != "v2" {
+		t.Fatalf("ownership = %#v, owned=%v, err=%v", ownership, owned, err)
+	}
+}
+
+func TestAutomaticUpdateRetriesWhenTheRemoteReturns(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("COSLASH_HOME", home)
+	now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+	remote, current, content := lifecycleFixture(t)
+	cache := NewCache(filepath.Join(home, "remote-cache"))
+	options := Options{
+		Cache: cache, Now: func() time.Time { return now },
+		ReleaseProvider:             fixedHelperRelease{document: remote.document, content: content},
+		LifecycleFactory:            func(string) (Lifecycle, error) { return lifecycleFor(remote), nil },
+		HelperInstallationAvailable: true,
+		Refresh: func(context.Context, string, int64, time.Time, CachedSnapshotV2) (refreshOutcome, error) {
+			return refreshOutcome{}, context.DeadlineExceeded
+		},
+	}
+	config := &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}
+	first := NewManager(options)
+	if err := first.ApplySettings(config); err != nil {
+		t.Fatal(err)
+	}
+	if health := first.SetupHelper(context.Background(), Consent{Install: true}); health.Helper == nil || !health.Helper.Compatible {
+		t.Fatalf("initial setup health = %#v", health)
+	}
+
+	previous := current
+	previous.Current = false
+	updated := current
+	updated.Version = "v2"
+	remote.document = signDocument(t, ReleaseMetadata{
+		Sequence: 2, ExpiresAtUnix: time.Now().Add(time.Hour).Unix(), Artifacts: []Artifact{updated, previous},
+	})
+	remote.probeErr = context.DeadlineExceeded
+	options.ReleaseProvider = fixedHelperRelease{document: remote.document, content: content}
+	restarted := NewManager(options)
+	if err := restarted.ApplySettings(config); err != nil {
+		t.Fatal(err)
+	}
+	restarted.ListView(0)
+	waitUntil(t, func() bool {
+		restarted.mu.Lock()
+		defer restarted.mu.Unlock()
+		return restarted.helperProbe == helperProbeFallback && !restarted.refreshing
+	})
+	if remote.installs != 1 {
+		t.Fatalf("offline update installs = %d", remote.installs)
+	}
+
+	now = now.Add(RemoteRetryInterval)
+	remote.probeErr = nil
+	restarted.ListView(0)
+	waitUntil(t, func() bool {
+		restarted.mu.Lock()
+		defer restarted.mu.Unlock()
+		return restarted.helperProbe == helperProbeReady && !restarted.helperSetup
+	})
+	if remote.installs != 2 {
+		t.Fatalf("returned remote installs = %d", remote.installs)
+	}
+}
+
 func TestHelperTestAcceptsEmptySuccessfulCollectionWithoutRewritingBoardState(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("COSLASH_HOME", home)

--- a/collector/internal/remote/manager_test.go
+++ b/collector/internal/remote/manager_test.go
@@ -495,6 +495,38 @@ func TestRestartAutomaticallyUpdatesAnOwnedHelper(t *testing.T) {
 	}
 }
 
+func TestLaunchSessionRequiresCurrentHealthyRemote(t *testing.T) {
+	manager := NewManager(Options{})
+	config := &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}
+	if err := manager.ApplySettings(config); err != nil {
+		t.Fatal(err)
+	}
+	manager.mu.Lock()
+	manager.state = StateOK
+	manager.complete = true
+	manager.sessions = []*session.Session{{Agent: vendors.AgentCodex, ID: "session", WorkingDirectory: "/workspace"}}
+	manager.mu.Unlock()
+	found, alias, ok := manager.LaunchSession(config.ID, vendors.AgentCodex, "session")
+	if !ok || alias != config.SSHAlias || found == nil || found.WorkingDirectory != "/workspace" {
+		t.Fatalf("launch session = %#v, %q, %v", found, alias, ok)
+	}
+	if _, _, ok := manager.LaunchSession(config.ID, vendors.AgentCodex, "missing"); ok {
+		t.Fatal("missing session was launchable")
+	}
+	manager.mu.Lock()
+	manager.state = StateLimited
+	manager.mu.Unlock()
+	if _, _, ok := manager.LaunchSession(config.ID, vendors.AgentCodex, "session"); !ok {
+		t.Fatal("connected limited remote was not launchable")
+	}
+	manager.mu.Lock()
+	manager.state = StateStale
+	manager.mu.Unlock()
+	if _, _, ok := manager.LaunchSession(config.ID, vendors.AgentCodex, "session"); ok {
+		t.Fatal("stale remote was launchable")
+	}
+}
+
 func TestAutomaticUpdateRetriesWhenTheRemoteReturns(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("COSLASH_HOME", home)
@@ -569,6 +601,7 @@ func TestHelperTestAcceptsEmptySuccessfulCollectionWithoutRewritingBoardState(t 
 			return refreshOutcome{Snapshot: CachedSnapshotV2{}}, nil
 		},
 	})
+	t.Cleanup(manager.Shutdown)
 	config := &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}
 	if err := manager.ApplySettings(config); err != nil {
 		t.Fatal(err)

--- a/collector/internal/remote/manager_test.go
+++ b/collector/internal/remote/manager_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/centauri-ai/coslash/collector/internal/remotefacts"
 	"github.com/centauri-ai/coslash/collector/internal/remoteprotocol"
 	"github.com/centauri-ai/coslash/collector/internal/session"
 	"github.com/centauri-ai/coslash/collector/internal/settings"
@@ -147,18 +148,103 @@ func TestHardFailureFallsBackToStaleWhenCacheExists(t *testing.T) {
 	manager.mu.Unlock()
 }
 
-func TestRetryBackoffReachesMaximum(t *testing.T) {
-	if got := retryBackoff(7); got != MaxRetryBackoff {
-		t.Fatalf("retryBackoff(7) = %v, want %v", got, MaxRetryBackoff)
+func TestRetryBackoffUsesRemoteRetryInterval(t *testing.T) {
+	if got := retryBackoff(1); got != RemoteRetryInterval {
+		t.Fatalf("retryBackoff(1) = %v, want %v", got, RemoteRetryInterval)
 	}
-	if got := retryBackoff(8); got != MaxRetryBackoff {
-		t.Fatalf("retryBackoff(8) = %v, want %v", got, MaxRetryBackoff)
+	if got := retryBackoff(8); got != RemoteRetryInterval {
+		t.Fatalf("retryBackoff(8) = %v, want %v", got, RemoteRetryInterval)
+	}
+}
+
+func TestRetryAllowsOneRefreshAndThrottlesRapidManualRequests(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("COSLASH_HOME", home)
+	now := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	release := make(chan struct{})
+	manager := NewManager(Options{
+		Cache: NewCache(filepath.Join(home, "remote-cache")),
+		Now:   func() time.Time { return now },
+		Refresh: func(context.Context, string, int64, time.Time, CachedSnapshotV2) (refreshOutcome, error) {
+			<-release
+			return refreshOutcome{}, context.DeadlineExceeded
+		},
+	})
+	if err := manager.ApplySettings(&settings.RemoteSettings{
+		ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, started := manager.Retry(); !started {
+		t.Fatal("first manual retry did not start")
+	}
+	if _, started := manager.Retry(); started {
+		t.Fatal("manual retry started while another refresh was running")
+	}
+	close(release)
+	waitUntil(t, func() bool {
+		manager.mu.Lock()
+		defer manager.mu.Unlock()
+		return !manager.refreshing
+	})
+	if _, started := manager.Retry(); started {
+		t.Fatal("manual retry ignored its cooldown")
+	}
+	now = now.Add(ManualRetryCooldown)
+	if _, started := manager.Retry(); !started {
+		t.Fatal("manual retry did not start after cooldown")
+	}
+}
+
+func TestOfflineHelperDiscoveryDoesNotStartSecondRefresh(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("COSLASH_HOME", home)
+	now := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	var refreshes atomic.Int32
+	manager := NewManager(Options{
+		Cache:                       NewCache(filepath.Join(home, "remote-cache")),
+		Now:                         func() time.Time { return now },
+		ReleaseProvider:             deadlineHelperRelease{},
+		LifecycleFactory:            func(string) (Lifecycle, error) { return Lifecycle{}, nil },
+		HelperInstallationAvailable: true,
+		Refresh: func(context.Context, string, int64, time.Time, CachedSnapshotV2) (refreshOutcome, error) {
+			refreshes.Add(1)
+			return refreshOutcome{}, nil
+		},
+	})
+	if err := manager.ApplySettings(&settings.RemoteSettings{
+		ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	manager.ListView(0)
+	waitUntil(t, func() bool {
+		manager.mu.Lock()
+		defer manager.mu.Unlock()
+		return manager.helperProbe == helperProbeFallback && !manager.refreshing
+	})
+	if refreshes.Load() != 0 {
+		t.Fatalf("offline discovery started %d collection refreshes", refreshes.Load())
+	}
+	health := manager.DiagnosticsHealth()
+	if health.State != StateError || health.LastCheckedAtMs == nil {
+		t.Fatalf("offline discovery health = %#v", health)
 	}
 }
 
 type fixedHelperRelease struct {
 	document SignedReleaseMetadata
 	content  []byte
+}
+
+type deadlineHelperRelease struct{}
+
+func (deadlineHelperRelease) LoadMetadata(context.Context) (SignedReleaseMetadata, error) {
+	return SignedReleaseMetadata{}, context.DeadlineExceeded
+}
+
+func (deadlineHelperRelease) LoadArtifact(context.Context, Artifact) ([]byte, error) {
+	return nil, context.DeadlineExceeded
 }
 
 type blockingHelperRelease struct {
@@ -558,6 +644,63 @@ func TestSetupBlocksAliasChangeUntilItRecordsOwnership(t *testing.T) {
 	}
 }
 
+func TestSetupRetriesTransportFailureWithFreshControlMaster(t *testing.T) {
+	first, _, content := lifecycleFixture(t)
+	first.installErr = wrapSSHError(errors.New("install failed"), "Connection reset by peer")
+	second, _, _ := lifecycleFixture(t)
+	var factories, resets int
+	manager := NewManager(Options{
+		Cache: NewCache(t.TempDir()), ReleaseProvider: fixedHelperRelease{document: first.document, content: content},
+		LifecycleFactory: func(string) (Lifecycle, error) {
+			factories++
+			if factories == 1 {
+				return lifecycleFor(first), nil
+			}
+			return lifecycleFor(second), nil
+		},
+		ResetControlMaster:          func(string) { resets++ },
+		HelperInstallationAvailable: true,
+	})
+	config := &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}
+	if err := manager.ApplySettings(config); err != nil {
+		t.Fatal(err)
+	}
+	health, err := manager.SetupHelperForAlias(context.Background(), config.SSHAlias, Consent{Install: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resets != 1 || factories != 2 || health.Helper == nil || !health.Helper.Compatible {
+		t.Fatalf("resets=%d factories=%d health=%#v", resets, factories, health)
+	}
+}
+
+func TestSetupRemovesPriorOwnedHelperAfterVerification(t *testing.T) {
+	remote, _, content := lifecycleFixture(t)
+	cache := NewCache(t.TempDir())
+	config := &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}
+	if err := cache.StoreHelperVersion(config.ID, "v0", config.SSHAlias); err != nil {
+		t.Fatal(err)
+	}
+	manager := NewManager(Options{
+		Cache: cache, ReleaseProvider: fixedHelperRelease{document: remote.document, content: content},
+		LifecycleFactory:            func(string) (Lifecycle, error) { return lifecycleFor(remote), nil },
+		HelperInstallationAvailable: true,
+	})
+	if err := manager.ApplySettings(config); err != nil {
+		t.Fatal(err)
+	}
+	health, err := manager.SetupHelperForAlias(context.Background(), config.SSHAlias, Consent{Install: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if health.Helper == nil || !health.Helper.Compatible {
+		t.Fatalf("setup health = %#v", health)
+	}
+	if remote.removed != "~/.coslash/helpers/v0/coslash-helper" {
+		t.Fatalf("removed = %q", remote.removed)
+	}
+}
+
 func TestHealthReportsRecordedOwnershipEvenWhenNoHelperVersionIsInspectable(t *testing.T) {
 	cache := NewCache(t.TempDir())
 	manager := NewManager(Options{Cache: cache})
@@ -665,7 +808,7 @@ func TestSetupFetchesOnlyTheSelectedArchitectureArtifact(t *testing.T) {
 			remote.platform.Arch = arch
 			remote.capabilities.Arch = arch
 			content := syntheticELF(arch)
-			artifact := Artifact{Version: "v1", OS: "linux", Arch: arch, Size: int64(len(content)), SHA256: digest(content), Protocol: remoteprotocol.VersionRange{Min: 1, Max: 1}, Schema: remoteprotocol.VersionRange{Min: 1, Max: 1}, Current: true}
+			artifact := Artifact{Version: "v1", OS: "linux", Arch: arch, Size: int64(len(content)), SHA256: digest(content), Protocol: remoteprotocol.VersionRange{Min: 1, Max: 1}, Schema: remoteprotocol.VersionRange{Min: remotefacts.SchemaVersion, Max: remotefacts.SchemaVersion}, Current: true}
 			remote.document = signDocument(t, ReleaseMetadata{Sequence: 1, ExpiresAtUnix: time.Now().Add(time.Hour).Unix(), Artifacts: []Artifact{artifact}})
 			provider := &architectureRelease{document: remote.document, content: map[string][]byte{arch: content}}
 			manager := NewManager(Options{

--- a/collector/internal/remote/manager_test.go
+++ b/collector/internal/remote/manager_test.go
@@ -506,24 +506,32 @@ func TestLaunchSessionRequiresCurrentHealthyRemote(t *testing.T) {
 	manager.complete = true
 	manager.sessions = []*session.Session{{Agent: vendors.AgentCodex, ID: "session", WorkingDirectory: "/workspace"}}
 	manager.mu.Unlock()
-	found, alias, ok := manager.LaunchSession(config.ID, vendors.AgentCodex, "session")
-	if !ok || alias != config.SSHAlias || found == nil || found.WorkingDirectory != "/workspace" {
-		t.Fatalf("launch session = %#v, %q, %v", found, alias, ok)
+	found, alias, err := manager.LaunchSession(config.ID, vendors.AgentCodex, "session")
+	if err != nil || alias != config.SSHAlias || found == nil || found.WorkingDirectory != "/workspace" {
+		t.Fatalf("launch session = %#v, %q, %v", found, alias, err)
 	}
-	if _, _, ok := manager.LaunchSession(config.ID, vendors.AgentCodex, "missing"); ok {
+	if found, _, err := manager.LaunchSession(config.ID, vendors.AgentCodex, "missing"); found != nil || err != nil {
 		t.Fatal("missing session was launchable")
 	}
 	manager.mu.Lock()
 	manager.state = StateLimited
 	manager.mu.Unlock()
-	if _, _, ok := manager.LaunchSession(config.ID, vendors.AgentCodex, "session"); !ok {
+	if found, _, err := manager.LaunchSession(config.ID, vendors.AgentCodex, "session"); found == nil || err != nil {
 		t.Fatal("connected limited remote was not launchable")
 	}
 	manager.mu.Lock()
 	manager.state = StateStale
 	manager.mu.Unlock()
-	if _, _, ok := manager.LaunchSession(config.ID, vendors.AgentCodex, "session"); ok {
+	if found, _, err := manager.LaunchSession(config.ID, vendors.AgentCodex, "session"); found != nil || err != nil {
 		t.Fatal("stale remote was launchable")
+	}
+	busy := "busy"
+	manager.mu.Lock()
+	manager.state = StateOK
+	manager.sessions[0].Status = &busy
+	manager.mu.Unlock()
+	if _, _, err := manager.LaunchSession(config.ID, vendors.AgentCodex, "session"); !errors.Is(err, ErrRemoteSessionActive) {
+		t.Fatalf("active session error = %v", err)
 	}
 }
 

--- a/collector/internal/remote/manager_test.go
+++ b/collector/internal/remote/manager_test.go
@@ -227,7 +227,7 @@ func TestOfflineHelperDiscoveryDoesNotStartSecondRefresh(t *testing.T) {
 		t.Fatalf("offline discovery started %d collection refreshes", refreshes.Load())
 	}
 	health := manager.DiagnosticsHealth()
-	if health.State != StateError || health.LastCheckedAtMs == nil {
+	if health.State != StateConnecting || health.LastCheckedAtMs == nil {
 		t.Fatalf("offline discovery health = %#v", health)
 	}
 }
@@ -512,6 +512,12 @@ func TestLaunchSessionRequiresCurrentHealthyRemote(t *testing.T) {
 	}
 	if found, _, err := manager.LaunchSession(config.ID, vendors.AgentCodex, "missing"); found != nil || err != nil {
 		t.Fatal("missing session was launchable")
+	}
+	manager.mu.Lock()
+	manager.sessions = append(manager.sessions, &session.Session{Agent: vendors.AgentCodex, ID: "compacted"})
+	manager.mu.Unlock()
+	if _, _, err := manager.LaunchSession(config.ID, vendors.AgentCodex, "compacted"); !errors.Is(err, ErrRemoteSessionUnavailable) {
+		t.Fatalf("compacted session error = %v", err)
 	}
 	manager.mu.Lock()
 	manager.state = StateLimited

--- a/collector/internal/remote/manager_test.go
+++ b/collector/internal/remote/manager_test.go
@@ -317,7 +317,7 @@ func TestManagerUsesOnlyLifecycleVerifiedHelperAndDoesNotSilentlyFallback(t *tes
 	if err := manager.ApplySettings(&settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}); err != nil {
 		t.Fatal(err)
 	}
-	health := manager.SetupHelper(context.Background(), Consent{Install: true})
+	health, _ := manager.setupHelper(context.Background(), "", Consent{Install: true})
 	if health.Helper == nil || !health.Helper.Compatible || health.Helper.Version != artifact.Version {
 		t.Fatalf("setup health = %#v", health)
 	}
@@ -355,7 +355,7 @@ func TestManagerReverifiesHelperBeforeEveryRefresh(t *testing.T) {
 	if err := manager.ApplySettings(config); err != nil {
 		t.Fatal(err)
 	}
-	if health := manager.SetupHelper(context.Background(), Consent{Install: true}); health.Helper == nil || !health.Helper.Compatible {
+	if health, _ := manager.setupHelper(context.Background(), "", Consent{Install: true}); health.Helper == nil || !health.Helper.Compatible {
 		t.Fatalf("setup health = %#v", health)
 	}
 
@@ -417,7 +417,7 @@ func TestRestartDiscoversAndReusesVerifiedHelperWithoutInstall(t *testing.T) {
 	if err := first.ApplySettings(config); err != nil {
 		t.Fatal(err)
 	}
-	if health := first.SetupHelper(context.Background(), Consent{Install: true}); health.Helper == nil || !health.Helper.Compatible {
+	if health, _ := first.setupHelper(context.Background(), "", Consent{Install: true}); health.Helper == nil || !health.Helper.Compatible {
 		t.Fatalf("initial setup health = %#v", health)
 	}
 	if remote.installs != 1 {
@@ -461,7 +461,7 @@ func TestRestartAutomaticallyUpdatesAnOwnedHelper(t *testing.T) {
 	if err := first.ApplySettings(config); err != nil {
 		t.Fatal(err)
 	}
-	if health := first.SetupHelper(context.Background(), Consent{Install: true}); health.Helper == nil || !health.Helper.Compatible {
+	if health, _ := first.setupHelper(context.Background(), "", Consent{Install: true}); health.Helper == nil || !health.Helper.Compatible {
 		t.Fatalf("initial setup health = %#v", health)
 	}
 
@@ -555,7 +555,7 @@ func TestAutomaticUpdateRetriesWhenTheRemoteReturns(t *testing.T) {
 	if err := first.ApplySettings(config); err != nil {
 		t.Fatal(err)
 	}
-	if health := first.SetupHelper(context.Background(), Consent{Install: true}); health.Helper == nil || !health.Helper.Compatible {
+	if health, _ := first.setupHelper(context.Background(), "", Consent{Install: true}); health.Helper == nil || !health.Helper.Compatible {
 		t.Fatalf("initial setup health = %#v", health)
 	}
 
@@ -614,7 +614,7 @@ func TestHelperTestAcceptsEmptySuccessfulCollectionWithoutRewritingBoardState(t 
 	if err := manager.ApplySettings(config); err != nil {
 		t.Fatal(err)
 	}
-	if health := manager.SetupHelper(context.Background(), Consent{Install: true}); health.Helper == nil || !health.Helper.Compatible {
+	if health, _ := manager.setupHelper(context.Background(), "", Consent{Install: true}); health.Helper == nil || !health.Helper.Compatible {
 		t.Fatalf("setup health = %#v", health)
 	}
 	manager.mu.Lock()
@@ -699,7 +699,7 @@ func TestHelperTestFailureDoesNotPoisonRefreshOrTransport(t *testing.T) {
 	if err := manager.ApplySettings(config); err != nil {
 		t.Fatal(err)
 	}
-	if health := manager.SetupHelper(context.Background(), Consent{Install: true}); health.Helper == nil || !health.Helper.Compatible {
+	if health, _ := manager.setupHelper(context.Background(), "", Consent{Install: true}); health.Helper == nil || !health.Helper.Compatible {
 		t.Fatalf("setup health = %#v", health)
 	}
 	manager.mu.Lock()
@@ -925,7 +925,7 @@ func TestInterruptedUninstallRetainsHostOwnershipAndHelper(t *testing.T) {
 	if err := manager.ApplySettings(config); err != nil {
 		t.Fatal(err)
 	}
-	if health := manager.SetupHelper(context.Background(), Consent{Install: true}); health.Helper == nil || !health.Helper.Compatible {
+	if health, _ := manager.setupHelper(context.Background(), "", Consent{Install: true}); health.Helper == nil || !health.Helper.Compatible {
 		t.Fatalf("setup health = %#v", health)
 	}
 	remote.removeErr = context.DeadlineExceeded
@@ -975,7 +975,7 @@ func TestSetupFetchesOnlyTheSelectedArchitectureArtifact(t *testing.T) {
 			if err := manager.ApplySettings(&settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}); err != nil {
 				t.Fatal(err)
 			}
-			if health := manager.SetupHelper(context.Background(), Consent{Install: true}); health.Helper == nil || !health.Helper.Compatible {
+			if health, _ := manager.setupHelper(context.Background(), "", Consent{Install: true}); health.Helper == nil || !health.Helper.Compatible {
 				t.Fatalf("setup health = %#v", health)
 			}
 			if provider.requested != arch {

--- a/collector/internal/remote/sftp.go
+++ b/collector/internal/remote/sftp.go
@@ -155,12 +155,15 @@ func ensureControlMaster(ctx context.Context, alias string, options OpenOptions)
 	if err != nil {
 		return err
 	}
-	if err := runSSHCommand(ctx, options, checkArgs); err == nil {
+	limits := options.Limits.withDefaults()
+	checkCtx, cancelCheck := context.WithTimeout(ctx, limits.ConnectTimeout)
+	err = runSSHCommand(checkCtx, options, checkArgs)
+	cancelCheck()
+	if err == nil {
 		return nil
 	} else if errors.Is(err, ErrStderrLimit) || ctx.Err() != nil {
 		return err
 	}
-	limits := options.Limits.withDefaults()
 	startArgs, err := controlMasterStartArgs(alias, int(limits.ConnectTimeout.Seconds()))
 	if err != nil {
 		return err
@@ -287,7 +290,28 @@ func OpenSession(ctx context.Context, alias string, options OpenOptions) (*Sessi
 		cancel()
 		return nil, fmt.Errorf("start SSH: %w", err)
 	}
-	client, err := sftp.NewClientPipe(stdout, stdin)
+	type clientResult struct {
+		client *sftp.Client
+		err    error
+	}
+	opened := make(chan clientResult, 1)
+	go func() {
+		client, openErr := sftp.NewClientPipe(stdout, stdin)
+		opened <- clientResult{client: client, err: openErr}
+	}()
+	handshakeCtx, cancelHandshake := context.WithTimeout(ctx, limits.ConnectTimeout)
+	var client *sftp.Client
+	select {
+	case result := <-opened:
+		cancelHandshake()
+		client, err = result.client, result.err
+	case <-handshakeCtx.Done():
+		cancelHandshake()
+		_ = stdin.Close()
+		cancel()
+		_ = cmd.Wait()
+		return nil, handshakeCtx.Err()
+	}
 	if err != nil {
 		_ = stdin.Close()
 		cancel()

--- a/collector/internal/remotefacts/README.md
+++ b/collector/internal/remotefacts/README.md
@@ -1,27 +1,29 @@
-# Remote family facts v1
+# Remote family facts v2
 
 This package is the transport-independent input to shared session composition.
 It is deliberately separate from both the SSH NDJSON protocol and
 `session-snapshot/v1`.
 
-## Privacy allowlist
+## Remote display data
 
-Only these source facts cross the remote boundary:
+Remote collection carries the session fields used by the local board and
+inspector, including prompts, summaries, commands, todo items, digest entries,
+file-edit summaries, subagent details, repository and working-directory facts,
+and Git status. The local coSlash cache persists these details with mode 0600.
+
+Family identity and incremental-refresh metadata remain separately bounded:
 
 - vendor, family/session IDs, parent ID, and opaque spawn key;
 - bounded name, status hint, branch, entrypoint, and model;
 - start/activity/duration, in-turn/stopped, bounded counts, token totals, and
   cost converted deterministically to integer micro-USD;
-- spawn completion/turn, human command **labels** (never command text), approved
+- spawn completion/turn, command labels and text, approved
   name/live metadata, opaque file comparison keys with size/mtime, and bounded
   Codex key-to-session/parent header mappings used only for warm discovery.
 
-The adapter excludes by construction: `LogPath`, working directory, repository,
-edited paths, file edit rows, raw commands, prompts, summary, digest/tool output,
-todos, commits, environment/git probe facts, synthesis, transcript rows, and
-absolute paths. Fingerprint keys are comparison data; consumers must never open
-them as paths. The reflection test makes additions to the source model require a
-new decision.
+The adapter still excludes `LogPath`, transcript rows, and fingerprint paths.
+Fingerprint keys are comparison data; consumers must never open them as paths.
+The reflection test makes additions to the source model require a new decision.
 
 ## Required fields and bounds
 

--- a/collector/internal/remotefacts/facts.go
+++ b/collector/internal/remotefacts/facts.go
@@ -4,6 +4,7 @@
 package remotefacts
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -16,7 +17,7 @@ import (
 )
 
 const (
-	SchemaVersion = 1
+	SchemaVersion = 2
 
 	MaxIDBytes          = 200
 	MaxDisplayBytes     = 280
@@ -68,26 +69,28 @@ type Family struct {
 }
 
 type Session struct {
-	ID                 string       `json:"id"`
-	ParentID           string       `json:"parent_id,omitempty"`
-	SpawnKey           string       `json:"spawn_key,omitempty"`
-	Name               string       `json:"name,omitempty"`
-	StatusHint         string       `json:"status_hint,omitempty"`
-	Branch             string       `json:"branch,omitempty"`
-	Entrypoint         string       `json:"entrypoint,omitempty"`
-	StartedAtMs        int64        `json:"started_at_ms"`
-	LastActivityAtMs   int64        `json:"last_activity_at_ms"`
-	DurationMs         *int         `json:"duration_ms,omitempty"`
-	Stopped            bool         `json:"stopped,omitempty"`
-	InTurn             bool         `json:"in_turn,omitempty"`
-	Model              string       `json:"model,omitempty"`
-	ContextTokens      *int         `json:"context_tokens,omitempty"`
-	ContextWindow      *int         `json:"context_window,omitempty"`
-	Counts             Counts       `json:"counts"`
-	Usage              []ModelUsage `json:"usage"`
-	RecordedCostMicros *int64       `json:"recorded_cost_micro_usd,omitempty"`
-	Spawns             []Spawn      `json:"spawns"`
-	CommandLabels      []string     `json:"command_labels"`
+	ID                 string                    `json:"id"`
+	ParentID           string                    `json:"parent_id,omitempty"`
+	SpawnKey           string                    `json:"spawn_key,omitempty"`
+	Name               string                    `json:"name,omitempty"`
+	StatusHint         string                    `json:"status_hint,omitempty"`
+	Branch             string                    `json:"branch,omitempty"`
+	Entrypoint         string                    `json:"entrypoint,omitempty"`
+	StartedAtMs        int64                     `json:"started_at_ms"`
+	LastActivityAtMs   int64                     `json:"last_activity_at_ms"`
+	DurationMs         *int                      `json:"duration_ms,omitempty"`
+	Stopped            bool                      `json:"stopped,omitempty"`
+	InTurn             bool                      `json:"in_turn,omitempty"`
+	Model              string                    `json:"model,omitempty"`
+	ContextTokens      *int                      `json:"context_tokens,omitempty"`
+	ContextWindow      *int                      `json:"context_window,omitempty"`
+	Counts             Counts                    `json:"counts"`
+	Usage              []ModelUsage              `json:"usage"`
+	RecordedCostMicros *int64                    `json:"recorded_cost_micro_usd,omitempty"`
+	Spawns             []Spawn                   `json:"spawns"`
+	CommandLabels      []string                  `json:"command_labels"`
+	Commands           []session.SubagentCommand `json:"commands"`
+	Display            session.Session           `json:"display"`
 }
 
 type Counts struct {
@@ -310,6 +313,10 @@ func validateSession(s Session) error {
 			return errors.New("command label exceeds limit")
 		}
 	}
+	encoded, err := json.Marshal(s)
+	if err != nil || len(encoded) > 900<<10 {
+		return errors.New("session display exceeds limit")
+	}
 	return nil
 }
 
@@ -363,14 +370,12 @@ func validateOptionalCount(value *int) error {
 	return nil
 }
 
-// FromParsed creates a deterministic family replacement and applies the wire
-// allowlist. It intentionally drops paths, prompts, digest/tool text, commands,
-// file edits, repository data, environment data, and synthesis.
+// FromParsed creates a deterministic family replacement for remote display.
 func FromParsed(vendor, familyID, parserVersion, state, staleReason string, parsed []*vendors.ParsedSession, metadata *vendors.SessionMetadata, fingerprints []vendors.FileFingerprint, headerMappings ...[]HeaderMapping) (Family, error) {
 	f := Family{SchemaVersion: SchemaVersion, ParserVersion: parserVersion, Vendor: vendor, FamilyID: familyID, State: state, StaleReason: truncate(staleReason, MaxDisplayBytes)}
 	for _, p := range parsed {
 		s := p.Session
-		fact := Session{ID: s.ID, ParentID: p.ParentID, SpawnKey: p.SpawnKey, Name: truncate(p.Name, MaxDisplayBytes), Branch: optional(s.Branch, MaxDisplayBytes), Entrypoint: optional(s.Entrypoint, MaxDisplayBytes), StartedAtMs: s.StartedAt, LastActivityAtMs: s.LastActivityTime, DurationMs: cloneInt(s.DurationMs), Stopped: p.Stopped, InTurn: p.InTurn, Model: optional(s.Model, MaxModelBytes), ContextTokens: cloneInt(s.ContextTokens), ContextWindow: cloneInt(s.ContextWindow), Counts: Counts{EditedFiles: s.EditedFileCount, Turns: s.Turns, ToolUses: s.ToolUses, Errors: s.Errors, Compactions: s.Compactions, PullRequests: s.PullRequests}}
+		fact := Session{ID: s.ID, ParentID: p.ParentID, SpawnKey: p.SpawnKey, Name: truncate(p.Name, MaxDisplayBytes), Branch: optional(s.Branch, MaxDisplayBytes), Entrypoint: optional(s.Entrypoint, MaxDisplayBytes), StartedAtMs: s.StartedAt, LastActivityAtMs: s.LastActivityTime, DurationMs: cloneInt(s.DurationMs), Stopped: p.Stopped, InTurn: p.InTurn, Model: optional(s.Model, MaxModelBytes), ContextTokens: cloneInt(s.ContextTokens), ContextWindow: cloneInt(s.ContextWindow), Counts: Counts{EditedFiles: s.EditedFileCount, Turns: s.Turns, ToolUses: s.ToolUses, Errors: s.Errors, Compactions: s.Compactions, PullRequests: s.PullRequests}, Display: *s}
 		if p.StatusHint != nil {
 			fact.StatusHint = truncate(*p.StatusHint, MaxDisplayBytes)
 		}
@@ -399,6 +404,7 @@ func FromParsed(vendor, familyID, parserVersion, state, staleReason string, pars
 		for _, command := range p.Commands {
 			fact.CommandLabels = append(fact.CommandLabels, truncate(command.Label, MaxDisplayBytes))
 		}
+		fact.Commands = append([]session.SubagentCommand(nil), p.Commands...)
 		f.Sessions = append(f.Sessions, fact)
 	}
 	sort.Slice(f.Sessions, func(i, j int) bool { return f.Sessions[i].ID < f.Sessions[j].ID })
@@ -439,7 +445,18 @@ func (f Family) Parsed() ([]*vendors.ParsedSession, *vendors.SessionMetadata, er
 	}
 	parsed := make([]*vendors.ParsedSession, 0, len(f.Sessions))
 	for _, fact := range f.Sessions {
-		s := &session.Session{Agent: f.Vendor, ID: fact.ID, Branch: pointer(fact.Branch), DurationMs: cloneInt(fact.DurationMs), Tokens: map[string]session.ModelTokens{}, StartedAt: fact.StartedAtMs, LastActivityTime: fact.LastActivityAtMs, Entrypoint: pointer(fact.Entrypoint), EditedFileCount: fact.Counts.EditedFiles, SessionDetails: session.SessionDetails{Model: pointer(fact.Model), ContextTokens: cloneInt(fact.ContextTokens), ContextWindow: cloneInt(fact.ContextWindow), Turns: fact.Counts.Turns, ToolUses: fact.Counts.ToolUses, Errors: fact.Counts.Errors, Compactions: fact.Counts.Compactions, PullRequests: fact.Counts.PullRequests}}
+		s, err := cloneDisplay(fact.Display)
+		if err != nil {
+			return nil, nil, err
+		}
+		s.Agent, s.ID = f.Vendor, fact.ID
+		s.Branch, s.DurationMs = pointer(fact.Branch), cloneInt(fact.DurationMs)
+		s.StartedAt, s.LastActivityTime = fact.StartedAtMs, fact.LastActivityAtMs
+		s.Entrypoint, s.EditedFileCount = pointer(fact.Entrypoint), fact.Counts.EditedFiles
+		s.Model, s.ContextTokens, s.ContextWindow = pointer(fact.Model), cloneInt(fact.ContextTokens), cloneInt(fact.ContextWindow)
+		s.Turns, s.ToolUses, s.Errors = fact.Counts.Turns, fact.Counts.ToolUses, fact.Counts.Errors
+		s.Compactions, s.PullRequests = fact.Counts.Compactions, fact.Counts.PullRequests
+		s.Tokens = map[string]session.ModelTokens{}
 		for _, usage := range fact.Usage {
 			s.Tokens[usage.Model] = session.ModelTokens{InputTokens: usage.InputTokens, OutputTokens: usage.OutputTokens, CacheCreationInputTokens: usage.CacheCreationInputTokens, CacheCreation1hInputTokens: usage.CacheCreation1hInputTokens, CacheReadInputTokens: usage.CacheReadInputTokens, Cost: float64(usage.CostMicroUSD) / 1_000_000}
 		}
@@ -451,9 +468,7 @@ func (f Family) Parsed() ([]*vendors.ParsedSession, *vendors.SessionMetadata, er
 		for _, spawn := range fact.Spawns {
 			p.Spawns[spawn.Key] = vendors.SpawnState{Turn: cloneInt(spawn.Turn), Completed: spawn.Completed}
 		}
-		for _, label := range fact.CommandLabels {
-			p.Commands = append(p.Commands, session.SubagentCommand{Label: label})
-		}
+		p.Commands = append(p.Commands, fact.Commands...)
 		parsed = append(parsed, p)
 	}
 	metadata := vendors.EmptySessionMetadata()
@@ -464,6 +479,18 @@ func (f Family) Parsed() ([]*vendors.ParsedSession, *vendors.SessionMetadata, er
 		metadata.Live[value.ID] = value.Status
 	}
 	return parsed, metadata, nil
+}
+
+func cloneDisplay(value session.Session) (*session.Session, error) {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	var clone session.Session
+	if err := json.Unmarshal(encoded, &clone); err != nil {
+		return nil, err
+	}
+	return &clone, nil
 }
 
 func truncate(value string, limit int) string {

--- a/collector/internal/remotefacts/facts.go
+++ b/collector/internal/remotefacts/facts.go
@@ -29,6 +29,7 @@ const (
 	MaxSpawnsPerSession = 256
 	MaxCommands         = 128
 	MaxNesting          = 8
+	MaxFamilyBytes      = 900 << 10 // Leaves room for the changed-family record envelope.
 	MaxCount            = 1_000_000_000
 	MaxCostMicroUSD     = int64(1_000_000_000_000_000)
 	MaxTimestampMs      = int64(32_503_680_000_000) // year 3000
@@ -247,6 +248,10 @@ func Validate(f Family) error {
 		}
 		previous = mapping.Key
 	}
+	encoded, err := json.Marshal(f)
+	if err != nil || len(encoded) > MaxFamilyBytes {
+		return errors.New("family exceeds limit")
+	}
 	return nil
 }
 
@@ -436,7 +441,47 @@ func FromParsed(vendor, familyID, parserVersion, state, staleReason string, pars
 		f.HeaderMappings = append([]HeaderMapping(nil), headerMappings[0]...)
 		sort.Slice(f.HeaderMappings, func(i, j int) bool { return f.HeaderMappings[i].Key < f.HeaderMappings[j].Key })
 	}
+	compact(&f)
 	return f, Validate(f)
+}
+
+func compact(f *Family) {
+	if familyFits(*f) {
+		return
+	}
+	for i := range f.Sessions {
+		display := &f.Sessions[i].Display
+		display.Summary = nil
+		display.FirstPrompt = nil
+		display.DeclaredGoal = nil
+		display.Synthesis = nil
+		display.Commands = nil
+		display.Commits = nil
+		display.Todos = nil
+		display.Digest = nil
+		display.FileEdits = nil
+		display.Subagents = nil
+		f.Sessions[i].Commands = nil
+	}
+	if familyFits(*f) {
+		return
+	}
+	for i := range f.Sessions {
+		f.Sessions[i].Display = session.Session{}
+		f.Sessions[i].Usage = nil
+		f.Sessions[i].Spawns = nil
+		f.Sessions[i].CommandLabels = nil
+	}
+	if familyFits(*f) {
+		return
+	}
+	f.Metadata = Metadata{}
+	f.HeaderMappings = nil
+}
+
+func familyFits(f Family) bool {
+	encoded, err := json.Marshal(f)
+	return err == nil && len(encoded) <= MaxFamilyBytes
 }
 
 func (f Family) Parsed() ([]*vendors.ParsedSession, *vendors.SessionMetadata, error) {

--- a/collector/internal/remotefacts/facts_test.go
+++ b/collector/internal/remotefacts/facts_test.go
@@ -61,32 +61,28 @@ func TestValidateHeaderMappingsMustReferenceFingerprint(t *testing.T) {
 	}
 }
 
-func TestParsedRoundTripPreservesApprovedCompositionFacts(t *testing.T) {
-	model, branch, status := "gpt-5", "main", "waiting"
+func TestParsedRoundTripPreservesSessionDetails(t *testing.T) {
+	model, branch, status, prompt := "gpt-5", "main", "waiting", "ship the fix"
 	cost := 1.25
 	turn := 3
 	parsed := []*vendors.ParsedSession{{
-		Session: &session.Session{Agent: "codex", ID: "root", Branch: &branch, StartedAt: 10, LastActivityTime: 20, Tokens: map[string]session.ModelTokens{"gpt-5": {InputTokens: 2, OutputTokens: 3, Cost: .5}}, SessionDetails: session.SessionDetails{Model: &model, Turns: 4}},
+		Session: &session.Session{Agent: "codex", ID: "root", Summary: &prompt, WorkingDirectory: "/workspace", Branch: &branch, Repository: &branch, StartedAt: 10, LastActivityTime: 20, Tokens: map[string]session.ModelTokens{"gpt-5": {InputTokens: 2, OutputTokens: 3, Cost: .5}}, SessionDetails: session.SessionDetails{Model: &model, Turns: 4, FirstPrompt: &prompt, Commands: []string{"go test ./..."}, Commits: []string{"abc123 fix"}, Todos: []session.Todo{{Text: "test", Done: true}}, Digest: []session.DigestEntry{{Turn: 1, Category: session.DigestUser, Description: prompt}}, FileEdits: []session.FileEdit{{Path: "main.go", Additions: 1}}}},
 		Name:    "safe name", StatusHint: &status, RecordedCost: &cost, Spawns: map[string]vendors.SpawnState{"spawn": {Turn: &turn, Completed: true}}, Commands: []session.SubagentCommand{{Label: "tests", Command: "SECRET RAW COMMAND"}},
 	}}
 	f, err := FromParsed("codex", "root", "parser-v1", StateComplete, "", parsed, vendors.EmptySessionMetadata(), []vendors.FileFingerprint{{Key: "opaque", Size: 1, ModifiedAtMs: 2}})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if reflect.ValueOf(f).String() == "SECRET RAW COMMAND" {
-		t.Fatal("raw command crossed boundary")
-	}
 	got, _, err := f.Parsed()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got[0].Session.ID != "root" || got[0].Name != "safe name" || got[0].Commands[0].Label != "tests" || got[0].Commands[0].Command != "" || *got[0].RecordedCost != cost {
+	if got[0].Session.ID != "root" || got[0].Session.WorkingDirectory != "/workspace" || *got[0].Session.FirstPrompt != prompt || got[0].Session.Commands[0] != "go test ./..." || got[0].Session.FileEdits[0].Path != "main.go" || got[0].Name != "safe name" || got[0].Commands[0].Label != "tests" || got[0].Commands[0].Command != "SECRET RAW COMMAND" || *got[0].RecordedCost != cost {
 		t.Fatalf("round trip = %#v", got[0])
 	}
 }
 
-// This reviewed census keeps new ParsedSession and Session fields excluded by
-// default until their privacy decision is explicit here and in FromParsed.
+// This reviewed census requires an explicit decision for every source field.
 func TestFieldPrivacyAllowlistIsComplete(t *testing.T) {
 	assertCensus(t, reflect.TypeOf(vendors.ParsedSession{}), map[string]bool{
 		"Session": true, "LogPath": false, "LogModifiedAtMs": false,
@@ -94,19 +90,19 @@ func TestFieldPrivacyAllowlistIsComplete(t *testing.T) {
 		"Commands": true, "Name": true, "InTurn": true, "StatusHint": true, "RecordedCost": true,
 	})
 	assertCensus(t, reflect.TypeOf(session.Session{}), map[string]bool{
-		"Agent": true, "ID": true, "Name": false, "Summary": false, "Status": false,
-		"WorkingDirectory": false, "Branch": true, "Repository": false, "RepositoryLocalOnly": false,
-		"EditedFileCount": true, "DurationMs": true, "Tokens": true, "Cost": false,
-		"UnpricedModels": false, "Subagents": false, "StartedAt": true, "LastActivityTime": true,
-		"Entrypoint": true, "CommitLog": false, "SessionDetails": true,
+		"Agent": true, "ID": true, "Name": true, "Summary": true, "Status": true,
+		"WorkingDirectory": true, "Branch": true, "Repository": true, "RepositoryLocalOnly": true,
+		"EditedFileCount": true, "DurationMs": true, "Tokens": true, "Cost": true,
+		"UnpricedModels": true, "Subagents": true, "StartedAt": true, "LastActivityTime": true,
+		"Entrypoint": true, "CommitLog": true, "SessionDetails": true,
 	})
 	assertCensus(t, reflect.TypeOf(session.SessionDetails{}), map[string]bool{
 		"Model": true, "ContextTokens": true, "ContextWindow": true, "Turns": true,
-		"ToolUses": true, "Errors": true, "Compactions": true, "FirstPrompt": false,
-		"Commands": false, "Commits": false, "PullRequests": true, "Todos": false,
-		"Digest": false, "FileEdits": false, "Git": false, "GitProbed": false,
-		"LastEditAt": false, "Synthesis": false, "SynthesisPending": false,
-		"DeclaredGoal": false, "CompactionSeed": false,
+		"ToolUses": true, "Errors": true, "Compactions": true, "FirstPrompt": true,
+		"Commands": true, "Commits": true, "PullRequests": true, "Todos": true,
+		"Digest": true, "FileEdits": true, "Git": true, "GitProbed": true,
+		"LastEditAt": true, "Synthesis": true, "SynthesisPending": true,
+		"DeclaredGoal": true, "CompactionSeed": true,
 	})
 }
 

--- a/collector/internal/remotefacts/facts_test.go
+++ b/collector/internal/remotefacts/facts_test.go
@@ -1,6 +1,7 @@
 package remotefacts
 
 import (
+	"encoding/json"
 	"reflect"
 	"strings"
 	"testing"
@@ -16,6 +17,25 @@ func validFamily() Family {
 		Sessions:     []Session{{ID: "root", StartedAtMs: 1, LastActivityAtMs: 2, Usage: []ModelUsage{}, Spawns: []Spawn{}, CommandLabels: []string{}}},
 		Metadata:     Metadata{Names: []MetadataName{}, Live: []MetadataLive{}},
 		Fingerprints: []Fingerprint{{Key: "opaque-1", Size: 12, ModifiedAtMs: 2}},
+	}
+}
+
+func TestFromParsedCompactsOversizedFamily(t *testing.T) {
+	large := strings.Repeat("x", 600<<10)
+	parsed := []*vendors.ParsedSession{
+		{Session: &session.Session{ID: "root", StartedAt: 1, LastActivityTime: 2, Summary: &large}},
+		{Session: &session.Session{ID: "child", StartedAt: 1, LastActivityTime: 2, Summary: &large}, ParentID: "root"},
+	}
+	f, err := FromParsed("codex", "root", "parser-v1", StateComplete, "", parsed, vendors.EmptySessionMetadata(), []vendors.FileFingerprint{{Key: "opaque", Size: 1, ModifiedAtMs: 2}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(encoded) > MaxFamilyBytes || len(f.Sessions) != 2 {
+		t.Fatalf("family has %d sessions and is %d bytes", len(f.Sessions), len(encoded))
 	}
 }
 

--- a/collector/internal/remotehelper/remotehelper_test.go
+++ b/collector/internal/remotehelper/remotehelper_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/centauri-ai/coslash/collector/internal/remotefacts"
 	"github.com/centauri-ai/coslash/collector/internal/remoteprotocol"
 	"github.com/centauri-ai/coslash/collector/internal/vendors"
 )
@@ -129,7 +130,7 @@ func TestEmitterReportsNegotiatedOutputLimit(t *testing.T) {
 func validRequest() remoteprotocol.Request {
 	return remoteprotocol.Request{
 		RequestID: "req-1", Protocol: remoteprotocol.VersionRange{Min: 1, Max: 1},
-		Schema: remoteprotocol.VersionRange{Min: 1, Max: 1}, ParserVersion: vendors.ParserVersion,
+		Schema: remoteprotocol.VersionRange{Min: remotefacts.SchemaVersion, Max: remotefacts.SchemaVersion}, ParserVersion: vendors.ParserVersion,
 		BaselineMode: remoteprotocol.BaselineKnown, BaselineID: "base-1",
 		CollectedAtMs: time.Now().UnixMilli(), Vendors: []string{"codex"},
 		Limits: remoteprotocol.Limits{MaxRecordBytes: remoteprotocol.MaxRecordBytes,

--- a/collector/internal/remoteinstall/install_linux.go
+++ b/collector/internal/remoteinstall/install_linux.go
@@ -67,7 +67,7 @@ func install(source *os.File, home, release, expectedSHA256 string, beforeWrite 
 	}
 
 	directoryFD := homeFD
-	for _, component := range []string{".local", "lib", "coslash", "helpers", release} {
+	for _, component := range []string{".coslash", "helpers", release} {
 		next, err := openOrCreateDirectory(directoryFD, component, uint32(os.Geteuid()))
 		if directoryFD != homeFD {
 			unix.Close(directoryFD)

--- a/collector/internal/remoteinstall/install_linux_test.go
+++ b/collector/internal/remoteinstall/install_linux_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestInstallKeepsOpenedVersionDirectoryAcrossIntermediateSwap(t *testing.T) {
 	home := t.TempDir()
-	versionDir := filepath.Join(home, ".local", "lib", "coslash", "helpers", "v1")
+	versionDir := filepath.Join(home, ".coslash", "helpers", "v1")
 	// All components exist before the operation begins, just as they do in the
 	// replacement attack.
 	if err := os.MkdirAll(versionDir, 0o700); err != nil {

--- a/collector/internal/remoteprotocol/protocol_test.go
+++ b/collector/internal/remoteprotocol/protocol_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/centauri-ai/coslash/collector/internal/remotefacts"
+	"github.com/centauri-ai/coslash/collector/internal/session"
+	"github.com/centauri-ai/coslash/collector/internal/vendors"
 )
 
 func request() Request {
@@ -15,6 +17,21 @@ func request() Request {
 		panic(err)
 	}
 	return r
+}
+
+func TestChangedFamilyWithMultipleLargeDisplaysFitsRecordLimit(t *testing.T) {
+	large := strings.Repeat("x", 600<<10)
+	family, err := remotefacts.FromParsed("codex", "root", "parser-v1", remotefacts.StateComplete, "", []*vendors.ParsedSession{
+		{Session: &session.Session{ID: "root", StartedAt: 1, LastActivityTime: 2, Summary: &large}},
+		{Session: &session.Session{ID: "child", StartedAt: 1, LastActivityTime: 2, Summary: &large}, ParentID: "root"},
+	}, vendors.EmptySessionMetadata(), []vendors.FileFingerprint{{Key: "opaque", Size: 1, ModifiedAtMs: 2}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := Record{Type: RecordChanged, ProtocolVersion: ProtocolVersion, RequestID: strings.Repeat("r", remotefacts.MaxIDBytes), Sequence: MaxRecords, Vendor: "codex", FamilyID: "root", Fingerprint: strings.Repeat("f", remotefacts.MaxIDBytes), Family: &family}
+	if size := encodedSize(record); size > MaxRecordBytes {
+		t.Fatalf("changed family record is %d bytes, limit is %d", size, MaxRecordBytes)
+	}
 }
 
 func family() remotefacts.Family {

--- a/collector/internal/remoteprotocol/protocol_test.go
+++ b/collector/internal/remoteprotocol/protocol_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func request() Request {
-	r, err := BuildRequest(Request{RequestID: "req-1", Protocol: VersionRange{1, 1}, Schema: VersionRange{1, 1}, ParserVersion: "parser-v1", BaselineID: "base-1", SinceMs: 1, CollectedAtMs: 2, Vendors: []string{"codex"}, Limits: Limits{MaxRecordBytes: MaxRecordBytes, MaxResponseBytes: MaxResponseBytes, MaxRecords: 100, MaxInventoryFamilies: 100}}, []KnownFamily{})
+	r, err := BuildRequest(Request{RequestID: "req-1", Protocol: VersionRange{1, 1}, Schema: VersionRange{remotefacts.SchemaVersion, remotefacts.SchemaVersion}, ParserVersion: "parser-v1", BaselineID: "base-1", SinceMs: 1, CollectedAtMs: 2, Vendors: []string{"codex"}, Limits: Limits{MaxRecordBytes: MaxRecordBytes, MaxResponseBytes: MaxResponseBytes, MaxRecords: 100, MaxInventoryFamilies: 100}}, []KnownFamily{})
 	if err != nil {
 		panic(err)
 	}
@@ -18,11 +18,11 @@ func request() Request {
 }
 
 func family() remotefacts.Family {
-	return remotefacts.Family{SchemaVersion: 1, ParserVersion: "parser-v1", Vendor: "codex", FamilyID: "root", State: "complete", Sessions: []remotefacts.Session{{ID: "root", StartedAtMs: 1, LastActivityAtMs: 2, Usage: []remotefacts.ModelUsage{}, Spawns: []remotefacts.Spawn{}, CommandLabels: []string{}}}, Metadata: remotefacts.Metadata{Names: []remotefacts.MetadataName{}, Live: []remotefacts.MetadataLive{}}, Fingerprints: []remotefacts.Fingerprint{{Key: "opaque", Size: 1, ModifiedAtMs: 2}}}
+	return remotefacts.Family{SchemaVersion: remotefacts.SchemaVersion, ParserVersion: "parser-v1", Vendor: "codex", FamilyID: "root", State: "complete", Sessions: []remotefacts.Session{{ID: "root", StartedAtMs: 1, LastActivityAtMs: 2, Usage: []remotefacts.ModelUsage{}, Spawns: []remotefacts.Spawn{}, CommandLabels: []string{}}}, Metadata: remotefacts.Metadata{Names: []remotefacts.MetadataName{}, Live: []remotefacts.MetadataLive{}}, Fingerprints: []remotefacts.Fingerprint{{Key: "opaque", Size: 1, ModifiedAtMs: 2}}}
 }
 
 func handshake(r Request) Record {
-	return Record{Type: RecordHandshake, ProtocolVersion: 1, RequestID: r.RequestID, Sequence: 1, BaselineID: r.BaselineID, SchemaVersion: 1, ParserVersion: "parser-v1"}
+	return Record{Type: RecordHandshake, ProtocolVersion: 1, RequestID: r.RequestID, Sequence: 1, BaselineID: r.BaselineID, SchemaVersion: remotefacts.SchemaVersion, ParserVersion: "parser-v1"}
 }
 
 func TestBuildRequestOverflowUsesNoBaselineWithoutPartialFingerprints(t *testing.T) {

--- a/docs/data-and-privacy.md
+++ b/docs/data-and-privacy.md
@@ -25,17 +25,16 @@ coSlash creates the storage directory with mode `0700` and persistent files with
 
 ## Optional SSH/SFTP access and helper installation
 
-When one remote machine is enabled, the Mac's system `ssh` client uses the saved
-OpenSSH alias and requests SFTP. SFTP collection runs no coSlash code on Linux.
-After a connection test, the user may explicitly consent to install the optional
-collector helper. Preview releases authenticate the embedded helper through the
-containing coSlash archive checksum, then verify its exact digest and platform
-before uploading a versioned executable to
+When a remote machine is added, the Mac's system `ssh` client uses the saved
+OpenSSH alias and requests SFTP. The setup action explicitly authorizes the
+first optional collector-helper installation. coSlash verifies the embedded
+helper's digest and platform before uploading a versioned executable to
 `~/.coslash/helpers/<version>/coslash-helper`, owned by the SSH user with mode
-`0700`. The helper has no root access or network access, reads only the same
-fixed allowlist below, and streams bounded normalized facts back to the Mac.
-No path, command, prompt, transcript row, cache, or handoff supplied by the Mac
-can choose files the helper opens.
+`0700`. Later coSlash releases may automatically replace only that previously
+verified helper. The helper has no root or network access, reads only the fixed
+allowlist below, and streams bounded normalized facts back to the Mac. No path,
+command, prompt, transcript row, cache, or handoff supplied by the Mac can
+choose files the helper opens.
 
 Builds without authenticated embedded helper assets disable the install action
 explicitly. They continue using SFTP and never upload an unverified helper.
@@ -110,11 +109,8 @@ Synthesis is off until you enable and save it in Settings. Disable it there to s
 
 Disabling a remote machine stops refreshes and hides its cards but retains its
 normalized last-good cache and any optional helper; it does not change Linux.
-**Remove host only** deletes the source's `~/.coslash/remotes/<source-id>`
-directory and deliberately leaves a previously installed helper in place.
-**Uninstall helper and remove** first removes only the exact verified helper
-version, then deletes local host settings and cache. If the remote uninstall
-fails, coSlash keeps the local host configuration so you can retry or explicitly
-choose remove-only; it never silently forgets helper ownership.
+**Remove** deletes the local host configuration and cache even if the host is
+offline. It deliberately leaves any previously installed helper in place on the
+remote machine.
 
 To remove all coSlash data, quit coSlash and delete `~/.coslash` (or your `COSLASH_HOME`). `coslash doctor --json` and **Copy diagnostics** exclude transcript contents, prompts, and session names.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -6,25 +6,20 @@ Start with `coslash doctor`. It checks session sources, agent CLIs, and storage.
 
 Create at least one local Claude Code or Codex session, then reload. Run `coslash doctor` for unreadable or missing sources. In the UI, select **All** vendors and time windows and clear search.
 
-For a remote machine, use **Settings → Machines → Test connection**. coSlash
+For a remote machine, choose **Settings → Machines → Add remote host**. coSlash
 uses the Mac's existing OpenSSH configuration, so first run `ssh <alias>` in
 Terminal if the host key or authentication still needs confirmation. The Linux
-SSH server must enable an SFTP subsystem and the SSH user must be able to read
-the Claude/Codex paths listed in [Data and privacy](data-and-privacy.md). No
-coSlash installation or agent CLI is required on Linux for SFTP collection. The
-test verifies that SSH authentication and the SFTP subsystem can open and close
-successfully. Readability of the allowed Claude/Codex roots is checked during
-the subsequent collection refresh.
+SSH server must enable SFTP and the SSH user must be able to read the
+Claude/Codex paths listed in [Data and privacy](data-and-privacy.md). Setup
+checks the connection, installs the digest-verified helper, and verifies it.
 
-The optional **Install helper** action needs explicit consent and installs the
-digest-verified collector embedded in the coSlash release, owned by the SSH
-user under `~/.coslash/helpers`. If it is unavailable, blocked
-by a `noexec` mount, unsupported, incompatible, revoked, or fails verification,
-coSlash does not execute it and continues with visibly labeled SFTP collection.
-Use **Upgrade helper** or **Install helper** only after reviewing the consent
-copy. Never paste remote stderr into a bug report; **Copy diagnostics** includes
-only bounded structured transport, version, timing, byte-count, and coverage
-facts.
+If setup fails, **Retry setup** tries again. A host that does not answer SSH is
+shown offline after a short check and retried in the background. coSlash uses
+SFTP when the helper is unavailable, blocked by a `noexec` mount, unsupported,
+or fails verification. Future coSlash releases automatically update only helpers
+that coSlash previously installed and verified. Never paste remote stderr into a
+bug report; **Copy diagnostics** contains bounded structured transport, version,
+timing, byte-count, and coverage facts.
 
 `SFTP subsystem unavailable` means ordinary SSH may work while SFTP is disabled
 by `sshd_config` or account policy. `Agent data is not readable` means the SSH
@@ -32,10 +27,8 @@ account connected but lacks file permissions. `No Claude or Codex data found`
 means the allowed roots are absent or empty. A stale banner keeps the last-good
 cards visible; **Retry** starts an immediate bounded refresh.
 
-To remove a remote host, choose **Remove host only** to leave the optional
-helper installed, or **Uninstall helper and remove**. The latter completes its
-exact remote uninstall before coSlash removes local settings. If it fails, use
-Retry or choose remove-only explicitly.
+To remove a remote host, choose **Remove**. It stops local monitoring even if
+the host is offline and leaves its optional helper installed on the host.
 
 ## coSlash will not start
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -56,8 +56,9 @@ Launching requires macOS, a recorded working directory, the agent CLI, and the t
 
 A fresh agent waiting silently is expected: handoff context is marked as background, and the agent waits for your next message.
 
-Remote sessions are monitoring-only, so Resume and Start Fresh are intentionally
-hidden. Use **Copy handoff** and continue manually where appropriate.
+Remote Resume and Start fresh require a live SSH connection and a recorded
+working directory. They are disabled while the host is offline; wait for it to
+reconnect, then try again.
 
 ## Report a bug
 

--- a/frontend/src/pages/coslash/components/SessionInspector.tsx
+++ b/frontend/src/pages/coslash/components/SessionInspector.tsx
@@ -354,10 +354,11 @@ function LaunchError({ message }: { message: string | null }) {
 
 function ResumeSessionButton({ detail }: { detail: SessionDetail }) {
   const { launch, launchError } = useLaunchTerminal(detail);
+  const disabled = !isLocalSession(detail) && (detail.displayStale || detail.launchable === false);
 
   return (
     <div className="flex flex-col gap-1">
-      <Button className="bg-brand w-fit p-2 text-xs" onClick={() => launch('resume')}>
+      <Button className="bg-brand w-fit p-2 text-xs" onClick={() => launch('resume')} disabled={disabled}>
         <PlayIcon />
         <span>Resume</span>
       </Button>
@@ -376,6 +377,7 @@ function StartNewSessionButton({
   onCopy: () => void;
 }) {
   const { launch, launchError } = useLaunchTerminal(detail);
+  const disabled = !isLocalSession(detail) && (detail.displayStale || detail.launchable === false);
 
   const startNewSession = () => {
     onCopy();
@@ -384,7 +386,7 @@ function StartNewSessionButton({
 
   return (
     <div className="flex flex-col gap-1">
-      <Button className="bg-brand w-fit p-2 text-xs" onClick={startNewSession}>
+      <Button className="bg-brand w-fit p-2 text-xs" onClick={startNewSession} disabled={disabled}>
         <TerminalIcon />
         <span>Start fresh with handoff</span>
       </Button>

--- a/frontend/src/pages/coslash/components/SessionInspector.tsx
+++ b/frontend/src/pages/coslash/components/SessionInspector.tsx
@@ -419,7 +419,7 @@ function HandoffSection({ detail }: { detail: SessionDetail }) {
       </div>
 
       <div className="flex flex-wrap items-center gap-2">
-        {isLocalSession(detail) && <StartNewSessionButton detail={detail} brief={brief} onCopy={copyBrief} />}
+        <StartNewSessionButton detail={detail} brief={brief} onCopy={copyBrief} />
         <Button variant="outline" className="w-fit p-2 text-xs" onClick={copyBrief}>
           <span>Copy handoff</span>
         </Button>
@@ -427,8 +427,8 @@ function HandoffSection({ detail }: { detail: SessionDetail }) {
       </div>
       {!isLocalSession(detail) && (
         <div className="text-muted-foreground text-xs">
-          Monitoring only · Copy handoff uses available remote facts. Resume, Start Fresh, file diffs,
-          synthesis, Hub sharing, and command history are unavailable.
+          Remote handoffs and launch actions use available remote facts. File diffs, synthesis, Hub sharing,
+          and command history are unavailable.
         </div>
       )}
     </div>
@@ -990,10 +990,16 @@ function InspectorFooter({ detail }: { detail: SessionDetail }) {
 
   if (!isLocalSession(detail)) {
     return (
-      <SheetFooter className="bg-muted border-t">
-        <span className="text-muted-foreground text-xs">
-          Remote liveness may be unknown; transcript recency is shown separately.
-        </span>
+      <SheetFooter className="bg-muted flex-row items-center justify-between gap-4 border-t">
+        <div className="flex min-w-0 flex-col">
+          <span className="text-xs">Resume this exact remote session</span>
+          <span className="text-muted-foreground text-xs font-light">
+            Reopens this session in {getVendor(detail.agent).label} on {detail.sourceLabel} via SSH.
+          </span>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <ResumeSessionButton detail={detail} />
+        </div>
       </SheetFooter>
     );
   }

--- a/frontend/src/pages/coslash/hooks/use-launch-terminal.ts
+++ b/frontend/src/pages/coslash/hooks/use-launch-terminal.ts
@@ -1,11 +1,10 @@
 import { useState } from 'react';
 import { apiFetch, readApiError } from '@/pages/coslash/lib/api';
-import { isLocalSource, type SessionIdentity } from '@/pages/coslash/lib/session';
+import type { SessionIdentity } from '@/pages/coslash/lib/session';
 
 export type LaunchMode = 'resume' | 'new';
 
 export function launchRequestPath(session: SessionIdentity, mode: LaunchMode): string {
-  if (!isLocalSource(session.sourceId)) throw new Error('remote launch unsupported');
   return `/api/launch?${new URLSearchParams({
     source: session.sourceId,
     agent: session.agent,

--- a/frontend/src/pages/coslash/lib/handoff.test.ts
+++ b/frontend/src/pages/coslash/lib/handoff.test.ts
@@ -68,13 +68,13 @@ describe('handoffBrief', () => {
 });
 
 describe('launchRequestPath', () => {
-  it('includes the full local source-aware key and rejects remote launch', () => {
+  it('includes the full source-aware key for local and remote launches', () => {
     expect(launchRequestPath({ sourceId: LOCAL_SOURCE_ID, agent: 'codex', id: 'abc' }, 'resume')).toBe(
       '/api/launch?source=local&agent=codex&id=abc&mode=resume',
     );
-    expect(() =>
-      launchRequestPath({ sourceId: 'r_0123456789abcdef', agent: 'claude', id: 'xyz' }, 'new'),
-    ).toThrow('remote launch unsupported');
+    expect(launchRequestPath({ sourceId: 'r_0123456789abcdef', agent: 'claude', id: 'xyz' }, 'new')).toBe(
+      '/api/launch?source=r_0123456789abcdef&agent=claude&id=xyz&mode=new',
+    );
   });
 });
 

--- a/frontend/src/pages/coslash/lib/machines.ts
+++ b/frontend/src/pages/coslash/lib/machines.ts
@@ -71,6 +71,7 @@ export type MachineFact = {
   helperProbeState?: 'unknown' | 'probing' | 'ready' | 'fallback';
   helperOwnershipRecorded?: boolean;
   helperOwnershipCorrupt?: boolean;
+  refreshing?: boolean;
 };
 
 export type HelperFact = {
@@ -224,6 +225,10 @@ export function decodeMachineFact(value: unknown): MachineFact {
   if (raw.helperOwnershipCorrupt != null) {
     if (typeof raw.helperOwnershipCorrupt !== 'boolean') throw new Error('Invalid machine fact');
     fact.helperOwnershipCorrupt = raw.helperOwnershipCorrupt;
+  }
+  if (raw.refreshing != null) {
+    if (typeof raw.refreshing !== 'boolean') throw new Error('Invalid machine fact');
+    fact.refreshing = raw.refreshing;
   }
   return fact;
 }

--- a/frontend/src/pages/coslash/lib/remote-api.test.ts
+++ b/frontend/src/pages/coslash/lib/remote-api.test.ts
@@ -9,6 +9,7 @@ const connectingMachine = {
 };
 
 const readyMachine = { ...connectingMachine, state: 'ok', complete: true };
+const refreshingMachine = { ...readyMachine, refreshing: true };
 
 describe('retryRemoteRefreshAndWait', () => {
   afterEach(() => {
@@ -35,5 +36,26 @@ describe('retryRemoteRefreshAndWait', () => {
     await expect(result).resolves.toEqual(readyMachine);
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/remote/retry');
     expect(fetchMock.mock.calls[1]?.[0]).toBe('/api/remote/status');
+  });
+
+  it('waits for a refresh even when cached health remains ok', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('window', {
+      location: { hash: '', pathname: '/', search: '' },
+      history: { state: null, replaceState: vi.fn() },
+      sessionStorage: { getItem: vi.fn(() => null), setItem: vi.fn() },
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json(refreshingMachine, { status: 202 }))
+      .mockResolvedValueOnce(Response.json(refreshingMachine))
+      .mockResolvedValueOnce(Response.json(readyMachine));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = retryRemoteRefreshAndWait();
+    await vi.advanceTimersByTimeAsync(800);
+
+    await expect(result).resolves.toEqual(readyMachine);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 });

--- a/frontend/src/pages/coslash/lib/remote-api.ts
+++ b/frontend/src/pages/coslash/lib/remote-api.ts
@@ -53,7 +53,7 @@ const REMOTE_REFRESH_POLL_INTERVAL_MS = 400;
 // reload the board, so it does not remain on the transient "connecting" view.
 export async function retryRemoteRefreshAndWait(): Promise<MachineFact> {
   let { machine } = await retryRemoteRefresh();
-  while (machine.state === 'connecting') {
+  while (machine.state === 'connecting' || machine.refreshing) {
     await new Promise<void>((resolve) => setTimeout(resolve, REMOTE_REFRESH_POLL_INTERVAL_MS));
     machine = await remoteStatus();
   }
@@ -107,11 +107,4 @@ export async function remoteStatus(): Promise<MachineFact> {
     throw new Error(apiError?.error || `Remote status failed (${response.status})`);
   }
   return decodeMachineFact(await response.json());
-}
-
-export async function uninstallRemoteHelper(): Promise<void> {
-  const response = await apiFetch('/api/remote/helper/uninstall', { method: 'POST' });
-  if (response.ok) return;
-  const apiError = await readApiError(response);
-  throw new Error(apiError?.error || `Helper uninstall failed (${response.status})`);
 }

--- a/frontend/src/pages/coslash/lib/session.ts
+++ b/frontend/src/pages/coslash/lib/session.ts
@@ -39,6 +39,7 @@ export type Session = {
   sourceLabel: string;
   eligibleForAggregates: boolean;
   displayStale: boolean;
+  launchable?: boolean;
   lastSeenStatus?: string;
   agent: string;
   id: string;


### PR DESCRIPTION
## Context

Remote sessions need complete inspection data, while SSH monitoring and connector setup must recover predictably from unavailable hosts and stale connections.

## Changes

- Preserve full remote session facts and commands for remote inspection.
- Keep complete multi-session families within the protocol record size limit by compacting oversized display details.
- Pass remote Codex handoff context correctly when launching a new session.
- Wire remote Start Fresh and Resume controls to the SSH launch path.
- Add machine health, connection freshness, cached-history age, and setup-progress API data.
- Bound SSH connection attempts and retry once after clearing a stale control connection.
- Install and verify the connector at its canonical path, then safely replace only the previously owned version.
- Allow local removal of an SSH host even when it is unreachable.

## Test

- `go test ./...` — passed
- `go vet ./...` — passed
- `gofmt -l ./cmd ./internal` — clean
- `git diff --check` — passed
- `npm test` — passed
- `npm run lint` — passed with existing warnings
- `npm run format:check` — passed
- `npm run build` — passed
- Manual: verified a multi-session changed-family record with 1.2 MiB of source display data remains under the 1 MiB protocol limit.