### PR TITLE
Fix remote Codex handoff quoting

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,25 +99,19 @@ coSlash needs at least one local agent session to read. If it finds none, it say
 
 ### Optional Linux session monitoring
 
-In **Settings → Machines**, add one alias from your Mac's existing OpenSSH
-configuration. coSlash runs the system `ssh` client on the Mac, requests the
-host's SFTP subsystem, and parses Claude Code and Codex files locally. It may
-reuse an OpenSSH multiplexed connection through a control socket under
-`~/.coslash/ssh`; it does not edit your SSH config. The Linux host needs only
-its SSH server with SFTP enabled and agent files readable by the SSH user.
+In **Settings → Machines**, use **Add remote host** with an alias from your
+Mac's existing OpenSSH configuration. coSlash checks SSH and SFTP, then installs
+and verifies the matching Linux collector. The helper lives in the SSH user's
+private `~/.coslash/helpers` directory, has no root or network access, and reads
+only supported agent paths. Future coSlash updates replace a helper that it
+previously installed and verified; first-time setup always requires this action.
 
-SFTP is the compatible fallback. After testing the connection, you can choose
-**Install helper**. That action asks for explicit consent before coSlash uploads
-the matching Linux collector embedded in the coSlash release into the SSH
-user's private `~/.coslash/helpers` directory. The app verifies its size,
-digest, platform, owner, and mode before execution. The helper reads only the
-supported agent paths and returns bounded, normalized facts; it has no root
-access, no network access, and does not run your agent CLI. Machines shows
-whether collection is using the helper or SFTP, including any stale or partial
-coverage. An incompatible, blocked, or failed helper never runs silently:
-coSlash keeps the SFTP fallback visible and offers repair or upgrade where
-available. Initial installation and every upgrade require separate consent;
-disabling a machine does not uninstall its helper.
+coSlash uses the system `ssh` client and may reuse a control socket under
+`~/.coslash/ssh`; it never edits your SSH config. SFTP remains the visible
+fallback if a helper cannot run. An offline host is checked promptly and retried
+in the background; use **Retry setup** for an immediate attempt. **Remove**
+stops monitoring locally even when the host is offline and leaves its helper on
+the remote machine.
 
 Remote v1 is monitoring-only. Cards, transcript-derived facts, costs, tokens,
 file-edit summaries, and **Copy handoff** are available. Resume, Start Fresh,

--- a/README.md
+++ b/README.md
@@ -113,11 +113,12 @@ in the background; use **Retry setup** for an immediate attempt. **Remove**
 stops monitoring locally even when the host is offline and leaves its helper on
 the remote machine.
 
-Remote v1 is monitoring-only. Cards, transcript-derived facts, costs, tokens,
-file-edit summaries, and **Copy handoff** are available. Resume, Start Fresh,
-diffs, synthesis, preview, Commands, and sharing remain local-only. A remote
-session can show recent transcript activity while process liveness is unknown;
-coSlash labels those facts separately.
+Remote sessions support **Resume** and **Start fresh with handoff** while their
+SSH host is connected. Cards, transcript-derived facts, costs, tokens,
+file-edit summaries, and **Copy handoff** are also available. Diffs, synthesis,
+preview, Commands, and sharing remain local-only. A remote session can show
+recent transcript activity while process liveness is unknown; coSlash labels
+those facts separately.
 
 ## What you get
 

--- a/collector/cmd/coslash/api.go
+++ b/collector/cmd/coslash/api.go
@@ -238,21 +238,36 @@ func cleanupHandoffs() {
 	}
 }
 
-func handleLaunch(w http.ResponseWriter, r *http.Request, settingsStore *settings.Store) {
+func handleLaunch(w http.ResponseWriter, r *http.Request, settingsStore *settings.Store, remoteManager *remote.Manager) {
 	state := settingsStore.State()
 	if !state.Valid {
 		http.Error(w, state.Error+"; open Settings to repair it", http.StatusConflict)
 		return
 	}
 	query := r.URL.Query()
-	found, err := collector.GetSessionFacts(query.Get("id"))
+	sourceID, err := parseSourceID(query.Get("source"))
 	if err != nil {
-		log.Printf("launch: %v", err)
-		http.Error(w, "could not load session", http.StatusInternalServerError)
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	var found *session.Session
+	alias := ""
+	if sourceID == localSourceID {
+		found, err = collector.GetSessionFacts(query.Get("id"))
+		if err != nil {
+			log.Printf("launch: %v", err)
+			http.Error(w, "could not load session", http.StatusInternalServerError)
+			return
+		}
+	} else {
+		found, alias, _ = remoteManager.LaunchSession(sourceID, query.Get("agent"), query.Get("id"))
+	}
 	if found == nil {
-		http.Error(w, "session not found", http.StatusNotFound)
+		if sourceID == localSourceID {
+			http.Error(w, "session not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "remote host is offline or this session is no longer available", http.StatusConflict)
 		return
 	}
 	handoff, err := readHandoff(w, r)
@@ -262,7 +277,17 @@ func handleLaunch(w http.ResponseWriter, r *http.Request, settingsStore *setting
 		return
 	}
 	mode := query.Get("mode")
-	if err := launch.Terminal(state.Config.Launch.Terminal, found.Agent, found.WorkingDirectory, found.ID, mode, handoff); err != nil {
+	if sourceID != localSourceID {
+		health, testErr := remoteManager.TestAlias(r.Context(), alias)
+		if testErr != nil || health.State != remote.StateOK {
+			http.Error(w, "remote host is offline; wait for it to reconnect", http.StatusConflict)
+			return
+		}
+		err = launch.RemoteTerminal(state.Config.Launch.Terminal, alias, found.Agent, found.WorkingDirectory, found.ID, mode, handoff)
+	} else {
+		err = launch.Terminal(state.Config.Launch.Terminal, found.Agent, found.WorkingDirectory, found.ID, mode, handoff)
+	}
+	if err != nil {
 		log.Printf("launch: %v", err)
 		http.Error(w, "could not launch terminal", http.StatusInternalServerError)
 		return

--- a/collector/cmd/coslash/api.go
+++ b/collector/cmd/coslash/api.go
@@ -260,7 +260,11 @@ func handleLaunch(w http.ResponseWriter, r *http.Request, settingsStore *setting
 			return
 		}
 	} else {
-		found, alias, _ = remoteManager.LaunchSession(sourceID, query.Get("agent"), query.Get("id"))
+		found, alias, err = remoteManager.LaunchSession(sourceID, query.Get("agent"), query.Get("id"))
+		if errors.Is(err, remote.ErrRemoteSessionActive) {
+			http.Error(w, "remote session is already active", http.StatusConflict)
+			return
+		}
 	}
 	if found == nil {
 		if sourceID == localSourceID {

--- a/collector/cmd/coslash/main.go
+++ b/collector/cmd/coslash/main.go
@@ -216,10 +216,7 @@ func routes(
 		handleSaveSettings(w, r, settingsStore, mgr, remoteManager)
 	})
 	api.HandleFunc("POST /api/launch", func(w http.ResponseWriter, r *http.Request) {
-		if rejectRemoteSource(w, r) {
-			return
-		}
-		handleLaunch(w, r, settingsStore)
+		handleLaunch(w, r, settingsStore, remoteManager)
 	})
 	api.HandleFunc("POST /api/remote/test", func(w http.ResponseWriter, r *http.Request) {
 		handleRemoteTest(w, r, remoteManager)

--- a/collector/internal/launch/launch.go
+++ b/collector/internal/launch/launch.go
@@ -228,7 +228,7 @@ func remoteCLICommand(agent, sessionID, mode, handoff string) (string, error) {
 	case vendors.AgentClaude:
 		return prefix + shellJoin(cli, "--append-system-prompt-file") + " \"$handoff\"" + cleanup, nil
 	case vendors.AgentCodex:
-		return prefix + shellJoin(cli, "-c") + " \"developer_instructions=$(cat \\\"$handoff\\\")\"" + cleanup, nil
+		return prefix + shellJoin(cli, "-c") + " \"developer_instructions=$(cat \"$handoff\")\"" + cleanup, nil
 	case vendors.AgentOpenCode:
 		return prefix + "OPENCODE_CONFIG_CONTENT='{\"instructions\":[\"'\"$handoff\"'\"]}' " + shellJoin(cli) + cleanup, nil
 	}

--- a/collector/internal/launch/launch.go
+++ b/collector/internal/launch/launch.go
@@ -4,6 +4,7 @@
 package launch
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -73,6 +74,33 @@ func Terminal(terminal, agent, workingDirectory, sessionID, mode, handoff string
 		return fmt.Errorf("launch: open %s: %w", adapter.label, err)
 	}
 	return nil
+}
+
+// RemoteTerminal opens the selected local terminal and runs an agent CLI on a
+// configured SSH host.
+func RemoteTerminal(terminal, alias, agent, workingDirectory, sessionID, mode, handoff string) error {
+	if alias == "" {
+		return errors.New("launch: SSH alias is required")
+	}
+	if workingDirectory == "" {
+		return fmt.Errorf("launch: session has no working directory")
+	}
+	adapter, err := terminalFor(terminal)
+	if err != nil {
+		return err
+	}
+	if runtime.GOOS != "darwin" {
+		return fmt.Errorf("launch: opening a terminal is not supported on %s", runtime.GOOS)
+	}
+	if err := adapter.available(); err != nil {
+		return fmt.Errorf("launch: %s is not installed or available; choose another terminal in Settings", adapter.label)
+	}
+	command, err := remoteCLICommand(agent, sessionID, mode, handoff)
+	if err != nil {
+		return err
+	}
+	remoteCommand := "cd " + shellQuote(workingDirectory) + " && " + command
+	return adapter.open(".", shellJoin("ssh", "-tt", alias, remoteCommand))
 }
 
 func Available(terminal string) bool {
@@ -168,6 +196,43 @@ func handoffCommand(agent, cli, handoff string) (string, string, error) {
 		return withCleanup(command, path), path, nil
 	}
 	return "", "", fmt.Errorf("launch: unknown agent %q", agent)
+}
+
+func remoteCLICommand(agent, sessionID, mode, handoff string) (string, error) {
+	cli, err := cliName(agent)
+	if err != nil {
+		return "", err
+	}
+	if mode == ResumeSession {
+		command, _, err := cliCommand(agent, sessionID, mode, "")
+		return command, err
+	}
+	if mode != NewSession {
+		return "", fmt.Errorf("launch: unknown mode %q", mode)
+	}
+	if handoff == "" {
+		return shellJoin(cli), nil
+	}
+	contents := handoffPreamble + handoff
+	if agent == vendors.AgentCodex {
+		contentsBytes, err := json.Marshal(contents)
+		if err != nil {
+			return "", fmt.Errorf("launch: encoding handoff context: %w", err)
+		}
+		contents = string(contentsBytes)
+	}
+	encoded := base64.StdEncoding.EncodeToString([]byte(contents))
+	prefix := "handoff=$(mktemp) || exit 1; printf %s " + shellQuote(encoded) + " | base64 -d > \"$handoff\" || { rm -f \"$handoff\"; exit 1; }; "
+	cleanup := "; rm -f \"$handoff\""
+	switch agent {
+	case vendors.AgentClaude:
+		return prefix + shellJoin(cli, "--append-system-prompt-file") + " \"$handoff\"" + cleanup, nil
+	case vendors.AgentCodex:
+		return prefix + shellJoin(cli, "-c") + " \"developer_instructions=$(cat \\\"$handoff\\\")\"" + cleanup, nil
+	case vendors.AgentOpenCode:
+		return prefix + "OPENCODE_CONFIG_CONTENT='{\"instructions\":[\"'\"$handoff\"'\"]}' " + shellJoin(cli) + cleanup, nil
+	}
+	return "", fmt.Errorf("launch: unknown agent %q", agent)
 }
 
 func handoffDir() string {

--- a/collector/internal/launch/remote_test.go
+++ b/collector/internal/launch/remote_test.go
@@ -1,0 +1,32 @@
+package launch
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/centauri-ai/coslash/collector/internal/vendors"
+)
+
+func TestRemoteCLICommandUsesRemoteHandoffFile(t *testing.T) {
+	command, err := remoteCLICommand(vendors.AgentClaude, "", NewSession, "keep this private")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(command, "mktemp") || !strings.Contains(command, "base64 -d") ||
+		!strings.Contains(command, "'--append-system-prompt-file' \"$handoff\"") {
+		t.Fatalf("command = %q", command)
+	}
+	if strings.Contains(command, "keep this private") {
+		t.Fatalf("command contains the raw handoff: %q", command)
+	}
+}
+
+func TestRemoteCLICommandResumesValidatedSession(t *testing.T) {
+	command, err := remoteCLICommand(vendors.AgentCodex, "01234567-89ab-cdef-0123-456789abcdef", ResumeSession, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if command != "'codex' 'resume' '01234567-89ab-cdef-0123-456789abcdef'" {
+		t.Fatalf("command = %q", command)
+	}
+}

--- a/collector/internal/launch/remote_test.go
+++ b/collector/internal/launch/remote_test.go
@@ -21,6 +21,19 @@ func TestRemoteCLICommandUsesRemoteHandoffFile(t *testing.T) {
 	}
 }
 
+func TestRemoteCodexHandoffReadsTemporaryFile(t *testing.T) {
+	command, err := remoteCLICommand(vendors.AgentCodex, "", NewSession, "keep this private")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(command, `developer_instructions=$(cat "$handoff")`) {
+		t.Fatalf("command = %q", command)
+	}
+	if strings.Contains(command, `cat \"$handoff\"`) {
+		t.Fatalf("command quotes the handoff path literally: %q", command)
+	}
+}
+
 func TestRemoteCLICommandResumesValidatedSession(t *testing.T) {
 	command, err := remoteCLICommand(vendors.AgentCodex, "01234567-89ab-cdef-0123-456789abcdef", ResumeSession, "")
 	if err != nil {

--- a/collector/internal/remote/helpermanager.go
+++ b/collector/internal/remote/helpermanager.go
@@ -189,10 +189,8 @@ func NewProductionManager() (*Manager, error) {
 	}), nil
 }
 
-// startHelperDiscoveryLocked starts only a read-only verification pass. The
-// Lifecycle receives empty consent, so it can authenticate metadata, probe the
-// platform, inspect files, and negotiate capabilities but can never upload or
-// modify a remote helper.
+// startHelperDiscoveryLocked verifies a helper or updates one previously
+// installed with this source's recorded ownership.
 func (manager *Manager) startHelperDiscoveryLocked() {
 	if manager.helperProbe != helperProbeUnknown || manager.cfg == nil || manager.lifeCtx == nil {
 		return
@@ -207,11 +205,15 @@ func (manager *Manager) startHelperDiscoveryLocked() {
 	status := HelperStatus{State: LifecycleSFTP}
 	manager.helper = &status
 	config := *manager.cfg
-	go manager.runHelperDiscovery(manager.lifeCtx, config)
+	autoUpdate := manager.helperVersion != "" && !manager.helperOwnershipCorrupt
+	if autoUpdate {
+		manager.helperSetup = true
+	}
+	go manager.runHelperDiscovery(manager.lifeCtx, config, autoUpdate)
 }
 
-// InspectHelper starts (or reports) the non-mutating discovery pass for the
-// setup screen. It never waits on SSH while holding the manager lock.
+// InspectHelper starts (or reports) the background helper check for the setup
+// screen. It never waits on SSH while holding the manager lock.
 func (manager *Manager) InspectHelper() Health {
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
@@ -221,19 +223,42 @@ func (manager *Manager) InspectHelper() Health {
 	return manager.healthLocked(manager.lastRequestedMs)
 }
 
-func (manager *Manager) runHelperDiscovery(ctx context.Context, config settings.RemoteSettings) {
+func (manager *Manager) runHelperDiscovery(ctx context.Context, config settings.RemoteSettings, autoUpdate bool) {
+	if autoUpdate {
+		defer func() {
+			manager.mu.Lock()
+			manager.helperSetup = false
+			manager.mu.Unlock()
+		}()
+	}
 	probeCtx, cancel := context.WithTimeout(ctx, DefaultConnectTimeout)
 	defer cancel()
 	manager.mu.Lock()
-	provider, factory := manager.releaseProvider, manager.lifecycleFactory
+	provider, factory, previousVersion := manager.releaseProvider, manager.lifecycleFactory, manager.helperVersion
 	manager.mu.Unlock()
 	document, err := provider.LoadMetadata(probeCtx)
 	var result LifecycleResult
+	var lifecycle Lifecycle
 	if err == nil {
-		var lifecycle Lifecycle
 		lifecycle, err = factory(config.SSHAlias)
 		if err == nil {
-			result = lifecycle.SetupWithLoader(probeCtx, document, Consent{}, provider.LoadArtifact)
+			consent := Consent{}
+			if autoUpdate {
+				consent = Consent{Install: true, Upgrade: true}
+			}
+			result = lifecycle.SetupWithLoader(probeCtx, document, consent, provider.LoadArtifact)
+			if autoUpdate && retryableSetupTransportFailure(result) {
+				manager.resetControlMaster(config.SSHAlias)
+				if retryLifecycle, retryErr := factory(config.SSHAlias); retryErr == nil {
+					result = retryLifecycle.SetupWithLoader(probeCtx, document, consent, provider.LoadArtifact)
+					lifecycle = retryLifecycle
+				}
+			}
+		}
+	}
+	if result.CanExecute && autoUpdate && previousVersion != "" && previousVersion != result.Artifact.Version && lifecycle.Remote != nil {
+		if previousPath, pathErr := helperPath(previousVersion); pathErr == nil {
+			_ = lifecycle.Remote.RemoveExact(probeCtx, previousPath)
 		}
 	}
 	manager.mu.Lock()

--- a/collector/internal/remote/helpermanager.go
+++ b/collector/internal/remote/helpermanager.go
@@ -231,7 +231,11 @@ func (manager *Manager) runHelperDiscovery(ctx context.Context, config settings.
 			manager.mu.Unlock()
 		}()
 	}
-	probeCtx, cancel := context.WithTimeout(ctx, DefaultConnectTimeout)
+	timeout := DefaultConnectTimeout
+	if autoUpdate {
+		timeout = DefaultHelperAutoUpdateTimeout
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	manager.mu.Lock()
 	provider, factory, previousVersion := manager.releaseProvider, manager.lifecycleFactory, manager.helperVersion

--- a/collector/internal/remote/lifecycle.go
+++ b/collector/internal/remote/lifecycle.go
@@ -487,8 +487,8 @@ func (lifecycle Lifecycle) VerifyExecution(ctx context.Context, path string, art
 }
 
 // Setup authenticates metadata before platform lookup or any remote mutation.
-// Consent is per action: initial install and later upgrades are separate, so an
-// old consent cannot silently install fresh executable code.
+// New hosts require installation consent; a recorded helper owner can consent
+// to its replacement when the app updates.
 // Setup is retained for focused lifecycle tests. Production callers must use
 // SetupWithLoader so an arm64 host never downloads amd64 bytes (or vice versa)
 // before its platform is known.

--- a/collector/internal/remote/limits.go
+++ b/collector/internal/remote/limits.go
@@ -11,6 +11,9 @@ const (
 	DefaultConnectTimeout = 7 * time.Second
 	// Helper activation is a small fixed command, unlike collection.
 	DefaultHelperInstallTimeout = 15 * time.Second
+	// A previously approved helper can update in the background after a new
+	// coSlash release. Its SSH handshake remains bounded by DefaultConnectTimeout.
+	DefaultHelperAutoUpdateTimeout = 2 * time.Minute
 	// Covers Claude and Codex over one SFTP session; large remote trees need headroom.
 	DefaultDeadline       = 3 * time.Minute
 	DefaultMaxFileBytes   = 32 << 20

--- a/collector/internal/remote/manager.go
+++ b/collector/internal/remote/manager.go
@@ -436,6 +436,24 @@ func (manager *Manager) DiagnosticsHealth() Health {
 	return manager.healthLocked(manager.lastRequestedMs)
 }
 
+// LaunchSession returns the current remote session and SSH alias only while
+// the host's most recent collection completed successfully.
+func (manager *Manager) LaunchSession(sourceID, agent, sessionID string) (*session.Session, string, bool) {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if manager.cfg == nil || !manager.cfg.Enabled || manager.cfg.ID != sourceID ||
+		(manager.state != StateOK && manager.state != StateLimited) {
+		return nil, "", false
+	}
+	for _, item := range manager.sessions {
+		if item.Agent == agent && item.ID == sessionID && item.WorkingDirectory != "" {
+			copy := *item
+			return &copy, manager.cfg.SSHAlias, true
+		}
+	}
+	return nil, "", false
+}
+
 // SetupAliasMatches reports whether alias is the currently persisted remote
 // target. SetupHelperForAlias repeats this check while taking its immutable
 // configuration snapshot; this fast check lets the HTTP handler reject an

--- a/collector/internal/remote/manager.go
+++ b/collector/internal/remote/manager.go
@@ -19,6 +19,7 @@ var (
 	ErrHelperOwnershipConflict = errors.New("helper ownership must be explicitly released or uninstalled before changing SSH alias")
 	ErrHelperAliasMismatch     = errors.New("helper setup alias does not match configured SSH alias")
 	ErrHelperSetupInProgress   = errors.New("helper setup is running for the configured SSH alias")
+	ErrRemoteSessionActive     = errors.New("remote session already has an active writer")
 )
 
 type SessionKey struct {
@@ -438,20 +439,23 @@ func (manager *Manager) DiagnosticsHealth() Health {
 
 // LaunchSession returns the current remote session and SSH alias only while
 // the host's most recent collection completed successfully.
-func (manager *Manager) LaunchSession(sourceID, agent, sessionID string) (*session.Session, string, bool) {
+func (manager *Manager) LaunchSession(sourceID, agent, sessionID string) (*session.Session, string, error) {
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
 	if manager.cfg == nil || !manager.cfg.Enabled || manager.cfg.ID != sourceID ||
 		(manager.state != StateOK && manager.state != StateLimited) {
-		return nil, "", false
+		return nil, "", nil
 	}
 	for _, item := range manager.sessions {
 		if item.Agent == agent && item.ID == sessionID && item.WorkingDirectory != "" {
+			if item.Status != nil && *item.Status == "busy" {
+				return nil, "", ErrRemoteSessionActive
+			}
 			copy := *item
-			return &copy, manager.cfg.SSHAlias, true
+			return &copy, manager.cfg.SSHAlias, nil
 		}
 	}
-	return nil, "", false
+	return nil, "", nil
 }
 
 // SetupAliasMatches reports whether alias is the currently persisted remote

--- a/collector/internal/remote/manager.go
+++ b/collector/internal/remote/manager.go
@@ -359,6 +359,10 @@ func (manager *Manager) ListView(remoteSinceMs int64) ListResult {
 	if !manager.cfg.Enabled {
 		return ListResult{Health: manager.healthLocked(remoteSinceMs)}
 	}
+	if manager.helperProbe == helperProbeFallback && manager.helperVersion != "" &&
+		!manager.nextRetryAt.IsZero() && !manager.now().Before(manager.nextRetryAt) {
+		manager.helperProbe = helperProbeUnknown
+	}
 	if manager.helperProbe == helperProbeUnknown {
 		manager.startHelperDiscoveryLocked()
 	}

--- a/collector/internal/remote/manager_test.go
+++ b/collector/internal/remote/manager_test.go
@@ -577,7 +577,9 @@ func TestHelperTestAcceptsEmptySuccessfulCollectionWithoutRewritingBoardState(t 
 		t.Fatalf("setup health = %#v", health)
 	}
 	manager.mu.Lock()
-	manager.snapshot = &CachedSnapshotV2{Version: cacheV2Version, CoverageSinceMs: now.UnixMilli()}
+	manager.snapshot = &CachedSnapshotV2{
+		Version: cacheV2Version, CoverageSinceMs: now.UnixMilli(), FetchedAtMs: now.UnixMilli(),
+	}
 	manager.sessions = []*session.Session{{Agent: vendors.AgentClaude, ID: "cached"}}
 	manager.state = StateStale
 	manager.reason = reasonPtr(ReasonInitialRefresh)

--- a/collector/internal/remote/manager_test.go
+++ b/collector/internal/remote/manager_test.go
@@ -442,6 +442,119 @@ func TestRestartDiscoversAndReusesVerifiedHelperWithoutInstall(t *testing.T) {
 	}
 }
 
+func TestRestartAutomaticallyUpdatesAnOwnedHelper(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("COSLASH_HOME", home)
+	remote, current, content := lifecycleFixture(t)
+	cache := NewCache(filepath.Join(home, "remote-cache"))
+	options := Options{
+		Cache: cache, Now: time.Now,
+		ReleaseProvider:             fixedHelperRelease{document: remote.document, content: content},
+		LifecycleFactory:            func(string) (Lifecycle, error) { return lifecycleFor(remote), nil },
+		HelperInstallationAvailable: true,
+		HelperRefresh: func(context.Context, string, int64, time.Time, CachedSnapshotV2, helperTarget) (refreshOutcome, error) {
+			return refreshOutcome{Snapshot: CachedSnapshotV2{Version: cacheV2Version}}, nil
+		},
+	}
+	config := &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}
+	first := NewManager(options)
+	if err := first.ApplySettings(config); err != nil {
+		t.Fatal(err)
+	}
+	if health := first.SetupHelper(context.Background(), Consent{Install: true}); health.Helper == nil || !health.Helper.Compatible {
+		t.Fatalf("initial setup health = %#v", health)
+	}
+
+	previous := current
+	previous.Current = false
+	updated := current
+	updated.Version = "v2"
+	remote.document = signDocument(t, ReleaseMetadata{
+		Sequence: 2, ExpiresAtUnix: time.Now().Add(time.Hour).Unix(), Artifacts: []Artifact{updated, previous},
+	})
+	options.ReleaseProvider = fixedHelperRelease{document: remote.document, content: content}
+	restarted := NewManager(options)
+	if err := restarted.ApplySettings(config); err != nil {
+		t.Fatal(err)
+	}
+	restarted.ListView(time.Now().Add(-time.Hour).UnixMilli())
+	waitUntil(t, func() bool {
+		restarted.mu.Lock()
+		defer restarted.mu.Unlock()
+		return restarted.helperProbe == helperProbeReady && !restarted.helperSetup
+	})
+	if remote.installs != 2 || remote.removed != "~/.coslash/helpers/v1/coslash-helper" {
+		t.Fatalf("installs=%d removed=%q", remote.installs, remote.removed)
+	}
+	if health := restarted.DiagnosticsHealth(); health.Helper == nil || !health.Helper.Compatible || health.Helper.Version != "v2" {
+		t.Fatalf("updated health = %#v", health)
+	}
+	ownership, owned, err := cache.LoadHelperOwnership(config.ID)
+	if err != nil || !owned || ownership.Version != "v2" {
+		t.Fatalf("ownership = %#v, owned=%v, err=%v", ownership, owned, err)
+	}
+}
+
+func TestAutomaticUpdateRetriesWhenTheRemoteReturns(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("COSLASH_HOME", home)
+	now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+	remote, current, content := lifecycleFixture(t)
+	cache := NewCache(filepath.Join(home, "remote-cache"))
+	options := Options{
+		Cache: cache, Now: func() time.Time { return now },
+		ReleaseProvider:             fixedHelperRelease{document: remote.document, content: content},
+		LifecycleFactory:            func(string) (Lifecycle, error) { return lifecycleFor(remote), nil },
+		HelperInstallationAvailable: true,
+		Refresh: func(context.Context, string, int64, time.Time, CachedSnapshotV2) (refreshOutcome, error) {
+			return refreshOutcome{}, context.DeadlineExceeded
+		},
+	}
+	config := &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}
+	first := NewManager(options)
+	if err := first.ApplySettings(config); err != nil {
+		t.Fatal(err)
+	}
+	if health := first.SetupHelper(context.Background(), Consent{Install: true}); health.Helper == nil || !health.Helper.Compatible {
+		t.Fatalf("initial setup health = %#v", health)
+	}
+
+	previous := current
+	previous.Current = false
+	updated := current
+	updated.Version = "v2"
+	remote.document = signDocument(t, ReleaseMetadata{
+		Sequence: 2, ExpiresAtUnix: time.Now().Add(time.Hour).Unix(), Artifacts: []Artifact{updated, previous},
+	})
+	remote.probeErr = context.DeadlineExceeded
+	options.ReleaseProvider = fixedHelperRelease{document: remote.document, content: content}
+	restarted := NewManager(options)
+	if err := restarted.ApplySettings(config); err != nil {
+		t.Fatal(err)
+	}
+	restarted.ListView(0)
+	waitUntil(t, func() bool {
+		restarted.mu.Lock()
+		defer restarted.mu.Unlock()
+		return restarted.helperProbe == helperProbeFallback && !restarted.refreshing
+	})
+	if remote.installs != 1 {
+		t.Fatalf("offline update installs = %d", remote.installs)
+	}
+
+	now = now.Add(RemoteRetryInterval)
+	remote.probeErr = nil
+	restarted.ListView(0)
+	waitUntil(t, func() bool {
+		restarted.mu.Lock()
+		defer restarted.mu.Unlock()
+		return restarted.helperProbe == helperProbeReady && !restarted.helperSetup
+	})
+	if remote.installs != 2 {
+		t.Fatalf("returned remote installs = %d", remote.installs)
+	}
+}
+
 func TestHelperTestAcceptsEmptySuccessfulCollectionWithoutRewritingBoardState(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("COSLASH_HOME", home)

--- a/collector/internal/remote/manager_test.go
+++ b/collector/internal/remote/manager_test.go
@@ -495,6 +495,38 @@ func TestRestartAutomaticallyUpdatesAnOwnedHelper(t *testing.T) {
 	}
 }
 
+func TestLaunchSessionRequiresCurrentHealthyRemote(t *testing.T) {
+	manager := NewManager(Options{})
+	config := &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}
+	if err := manager.ApplySettings(config); err != nil {
+		t.Fatal(err)
+	}
+	manager.mu.Lock()
+	manager.state = StateOK
+	manager.complete = true
+	manager.sessions = []*session.Session{{Agent: vendors.AgentCodex, ID: "session", WorkingDirectory: "/workspace"}}
+	manager.mu.Unlock()
+	found, alias, ok := manager.LaunchSession(config.ID, vendors.AgentCodex, "session")
+	if !ok || alias != config.SSHAlias || found == nil || found.WorkingDirectory != "/workspace" {
+		t.Fatalf("launch session = %#v, %q, %v", found, alias, ok)
+	}
+	if _, _, ok := manager.LaunchSession(config.ID, vendors.AgentCodex, "missing"); ok {
+		t.Fatal("missing session was launchable")
+	}
+	manager.mu.Lock()
+	manager.state = StateLimited
+	manager.mu.Unlock()
+	if _, _, ok := manager.LaunchSession(config.ID, vendors.AgentCodex, "session"); !ok {
+		t.Fatal("connected limited remote was not launchable")
+	}
+	manager.mu.Lock()
+	manager.state = StateStale
+	manager.mu.Unlock()
+	if _, _, ok := manager.LaunchSession(config.ID, vendors.AgentCodex, "session"); ok {
+		t.Fatal("stale remote was launchable")
+	}
+}
+
 func TestAutomaticUpdateRetriesWhenTheRemoteReturns(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("COSLASH_HOME", home)
@@ -569,6 +601,7 @@ func TestHelperTestAcceptsEmptySuccessfulCollectionWithoutRewritingBoardState(t 
 			return refreshOutcome{Snapshot: CachedSnapshotV2{}}, nil
 		},
 	})
+	t.Cleanup(manager.Shutdown)
 	config := &settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}
 	if err := manager.ApplySettings(config); err != nil {
 		t.Fatal(err)

--- a/collector/internal/remote/manager_test.go
+++ b/collector/internal/remote/manager_test.go
@@ -506,24 +506,32 @@ func TestLaunchSessionRequiresCurrentHealthyRemote(t *testing.T) {
 	manager.complete = true
 	manager.sessions = []*session.Session{{Agent: vendors.AgentCodex, ID: "session", WorkingDirectory: "/workspace"}}
 	manager.mu.Unlock()
-	found, alias, ok := manager.LaunchSession(config.ID, vendors.AgentCodex, "session")
-	if !ok || alias != config.SSHAlias || found == nil || found.WorkingDirectory != "/workspace" {
-		t.Fatalf("launch session = %#v, %q, %v", found, alias, ok)
+	found, alias, err := manager.LaunchSession(config.ID, vendors.AgentCodex, "session")
+	if err != nil || alias != config.SSHAlias || found == nil || found.WorkingDirectory != "/workspace" {
+		t.Fatalf("launch session = %#v, %q, %v", found, alias, err)
 	}
-	if _, _, ok := manager.LaunchSession(config.ID, vendors.AgentCodex, "missing"); ok {
+	if found, _, err := manager.LaunchSession(config.ID, vendors.AgentCodex, "missing"); found != nil || err != nil {
 		t.Fatal("missing session was launchable")
 	}
 	manager.mu.Lock()
 	manager.state = StateLimited
 	manager.mu.Unlock()
-	if _, _, ok := manager.LaunchSession(config.ID, vendors.AgentCodex, "session"); !ok {
+	if found, _, err := manager.LaunchSession(config.ID, vendors.AgentCodex, "session"); found == nil || err != nil {
 		t.Fatal("connected limited remote was not launchable")
 	}
 	manager.mu.Lock()
 	manager.state = StateStale
 	manager.mu.Unlock()
-	if _, _, ok := manager.LaunchSession(config.ID, vendors.AgentCodex, "session"); ok {
+	if found, _, err := manager.LaunchSession(config.ID, vendors.AgentCodex, "session"); found != nil || err != nil {
 		t.Fatal("stale remote was launchable")
+	}
+	busy := "busy"
+	manager.mu.Lock()
+	manager.state = StateOK
+	manager.sessions[0].Status = &busy
+	manager.mu.Unlock()
+	if _, _, err := manager.LaunchSession(config.ID, vendors.AgentCodex, "session"); !errors.Is(err, ErrRemoteSessionActive) {
+		t.Fatalf("active session error = %v", err)
 	}
 }
 

--- a/docs/data-and-privacy.md
+++ b/docs/data-and-privacy.md
@@ -25,17 +25,16 @@ coSlash creates the storage directory with mode `0700` and persistent files with
 
 ## Optional SSH/SFTP access and helper installation
 
-When one remote machine is enabled, the Mac's system `ssh` client uses the saved
-OpenSSH alias and requests SFTP. SFTP collection runs no coSlash code on Linux.
-After a connection test, the user may explicitly consent to install the optional
-collector helper. Preview releases authenticate the embedded helper through the
-containing coSlash archive checksum, then verify its exact digest and platform
-before uploading a versioned executable to
+When a remote machine is added, the Mac's system `ssh` client uses the saved
+OpenSSH alias and requests SFTP. The setup action explicitly authorizes the
+first optional collector-helper installation. coSlash verifies the embedded
+helper's digest and platform before uploading a versioned executable to
 `~/.coslash/helpers/<version>/coslash-helper`, owned by the SSH user with mode
-`0700`. The helper has no root access or network access, reads only the same
-fixed allowlist below, and streams bounded normalized facts back to the Mac.
-No path, command, prompt, transcript row, cache, or handoff supplied by the Mac
-can choose files the helper opens.
+`0700`. Later coSlash releases may automatically replace only that previously
+verified helper. The helper has no root or network access, reads only the fixed
+allowlist below, and streams bounded normalized facts back to the Mac. No path,
+command, prompt, transcript row, cache, or handoff supplied by the Mac can
+choose files the helper opens.
 
 Builds without authenticated embedded helper assets disable the install action
 explicitly. They continue using SFTP and never upload an unverified helper.
@@ -110,11 +109,8 @@ Synthesis is off until you enable and save it in Settings. Disable it there to s
 
 Disabling a remote machine stops refreshes and hides its cards but retains its
 normalized last-good cache and any optional helper; it does not change Linux.
-**Remove host only** deletes the source's `~/.coslash/remotes/<source-id>`
-directory and deliberately leaves a previously installed helper in place.
-**Uninstall helper and remove** first removes only the exact verified helper
-version, then deletes local host settings and cache. If the remote uninstall
-fails, coSlash keeps the local host configuration so you can retry or explicitly
-choose remove-only; it never silently forgets helper ownership.
+**Remove** deletes the local host configuration and cache even if the host is
+offline. It deliberately leaves any previously installed helper in place on the
+remote machine.
 
 To remove all coSlash data, quit coSlash and delete `~/.coslash` (or your `COSLASH_HOME`). `coslash doctor --json` and **Copy diagnostics** exclude transcript contents, prompts, and session names.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -6,25 +6,20 @@ Start with `coslash doctor`. It checks session sources, agent CLIs, and storage.
 
 Create at least one local Claude Code or Codex session, then reload. Run `coslash doctor` for unreadable or missing sources. In the UI, select **All** vendors and time windows and clear search.
 
-For a remote machine, use **Settings → Machines → Test connection**. coSlash
+For a remote machine, choose **Settings → Machines → Add remote host**. coSlash
 uses the Mac's existing OpenSSH configuration, so first run `ssh <alias>` in
 Terminal if the host key or authentication still needs confirmation. The Linux
-SSH server must enable an SFTP subsystem and the SSH user must be able to read
-the Claude/Codex paths listed in [Data and privacy](data-and-privacy.md). No
-coSlash installation or agent CLI is required on Linux for SFTP collection. The
-test verifies that SSH authentication and the SFTP subsystem can open and close
-successfully. Readability of the allowed Claude/Codex roots is checked during
-the subsequent collection refresh.
+SSH server must enable SFTP and the SSH user must be able to read the
+Claude/Codex paths listed in [Data and privacy](data-and-privacy.md). Setup
+checks the connection, installs the digest-verified helper, and verifies it.
 
-The optional **Install helper** action needs explicit consent and installs the
-digest-verified collector embedded in the coSlash release, owned by the SSH
-user under `~/.coslash/helpers`. If it is unavailable, blocked
-by a `noexec` mount, unsupported, incompatible, revoked, or fails verification,
-coSlash does not execute it and continues with visibly labeled SFTP collection.
-Use **Upgrade helper** or **Install helper** only after reviewing the consent
-copy. Never paste remote stderr into a bug report; **Copy diagnostics** includes
-only bounded structured transport, version, timing, byte-count, and coverage
-facts.
+If setup fails, **Retry setup** tries again. A host that does not answer SSH is
+shown offline after a short check and retried in the background. coSlash uses
+SFTP when the helper is unavailable, blocked by a `noexec` mount, unsupported,
+or fails verification. Future coSlash releases automatically update only helpers
+that coSlash previously installed and verified. Never paste remote stderr into a
+bug report; **Copy diagnostics** contains bounded structured transport, version,
+timing, byte-count, and coverage facts.
 
 `SFTP subsystem unavailable` means ordinary SSH may work while SFTP is disabled
 by `sshd_config` or account policy. `Agent data is not readable` means the SSH
@@ -32,10 +27,8 @@ account connected but lacks file permissions. `No Claude or Codex data found`
 means the allowed roots are absent or empty. A stale banner keeps the last-good
 cards visible; **Retry** starts an immediate bounded refresh.
 
-To remove a remote host, choose **Remove host only** to leave the optional
-helper installed, or **Uninstall helper and remove**. The latter completes its
-exact remote uninstall before coSlash removes local settings. If it fails, use
-Retry or choose remove-only explicitly.
+To remove a remote host, choose **Remove**. It stops local monitoring even if
+the host is offline and leaves its optional helper installed on the host.
 
 ## coSlash will not start
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -56,8 +56,9 @@ Launching requires macOS, a recorded working directory, the agent CLI, and the t
 
 A fresh agent waiting silently is expected: handoff context is marked as background, and the agent waits for your next message.
 
-Remote sessions are monitoring-only, so Resume and Start Fresh are intentionally
-hidden. Use **Copy handoff** and continue manually where appropriate.
+Remote Resume and Start fresh require a live SSH connection and a recorded
+working directory. They are disabled while the host is offline; wait for it to
+reconnect, then try again.
 
 ## Report a bug
 


### PR DESCRIPTION
## Context

Remote “Start fresh with handoff” could fail to load its handoff because the generated shell command quoted the temporary file path literally. The remote Codex process therefore received an empty developer-instructions override.

## Changes

- Correct the remote shell expansion so Codex reads the decoded temporary handoff file.
- Add regression coverage for the generated Codex handoff command.

## Test

- `go test ./...` — passed
- `go vet ./...` — passed
- `gofmt -l ./cmd ./internal` — passed
- Manual: verified the remote command can decode a temporary handoff and invoke Codex successfully.