### PR TITLE
Show OpenCode session client in badges

### DIFF
--- a/collector/cmd/coslash/main.go
+++ b/collector/cmd/coslash/main.go
@@ -82,8 +82,8 @@ func main() {
 	}
 
 	settingsStore := settings.Open()
-	if err := opencode.EnsureWaitingPlugin(); err != nil {
-		log.Printf("install OpenCode status plugin: %v", err)
+	if err := opencode.EnsurePlugin(); err != nil {
+		log.Printf("install OpenCode coSlash plugin: %v", err)
 	}
 	settingsState := settingsStore.State()
 	var runner synthesis.Runner

--- a/collector/internal/diagnostics/checks.go
+++ b/collector/internal/diagnostics/checks.go
@@ -86,15 +86,15 @@ func derive(snapshot *Snapshot) []Check {
 func openCodePluginCheck(snapshot *Snapshot) Check {
 	plugin := snapshot.openCodePlugin
 	check := Check{
-		ID:     "opencode.waiting-plugin",
-		Title:  "OpenCode Waiting plugin",
+		ID:     "opencode.plugin",
+		Title:  "OpenCode coSlash plugin",
 		Status: StatusOK,
 		Detail: "Installed at " + plugin.Path + ".",
 	}
 	switch {
 	case plugin.Err != nil:
 		check.Status = StatusWarn
-		check.Detail = "coSlash could not inspect the OpenCode Waiting plugin: " + snapshot.openCodePluginError
+		check.Detail = "coSlash could not inspect the OpenCode plugin: " + snapshot.openCodePluginError
 		if plugin.Path == "" {
 			check.Fix = "Check that the current user has a valid home directory, then restart coSlash."
 		} else {
@@ -102,7 +102,7 @@ func openCodePluginCheck(snapshot *Snapshot) Check {
 		}
 	case !plugin.Installed:
 		check.Status = StatusWarn
-		check.Detail = "The OpenCode Waiting plugin is not installed. Pending approvals can appear Active."
+		check.Detail = "The OpenCode coSlash plugin is not installed. Waiting status and client labels may be unavailable."
 		check.Fix = "Restart coSlash to install the plugin, then restart OpenCode."
 	case plugin.RestartRequired:
 		check.Status = StatusWarn

--- a/collector/internal/diagnostics/snapshot.go
+++ b/collector/internal/diagnostics/snapshot.go
@@ -41,7 +41,7 @@ type Snapshot struct {
 	Sources             []Source  `json:"sources"`
 	Remote              *Remote   `json:"remote,omitempty"`
 	Checks              []Check   `json:"checks"`
-	openCodePlugin      opencode.WaitingPluginHealth
+	openCodePlugin      opencode.PluginHealth
 	openCodePluginError string
 	homeError           string
 }
@@ -189,7 +189,7 @@ func collectLocal(ctx context.Context, version string, includeVersions bool) *Sn
 	if userHomeErr != nil {
 		snapshot.homeError = userHomeErr.Error()
 	}
-	snapshot.openCodePlugin = opencode.WaitingPluginDiagnostics()
+	snapshot.openCodePlugin = opencode.PluginDiagnostics()
 	snapshot.openCodePlugin.Path = displayPath(userHome, snapshot.openCodePlugin.Path)
 	if snapshot.openCodePlugin.Err != nil {
 		snapshot.openCodePluginError = displayError(userHome, snapshot.openCodePlugin.Err.Error())

--- a/collector/internal/vendors/opencode/coslash-plugin.js
+++ b/collector/internal/vendors/opencode/coslash-plugin.js
@@ -58,7 +58,7 @@ async function clearSession(properties) {
   )
 }
 
-export const CoslashWaitingPlugin = async () => ({
+export const CoslashPlugin = async () => ({
   event: ({ event }) => {
     lifecycle = lifecycle.then(async () => {
       if (["session.created", "session.updated", "message.updated"].includes(event?.type)) {

--- a/collector/internal/vendors/opencode/coslash-waiting.js
+++ b/collector/internal/vendors/opencode/coslash-waiting.js
@@ -4,8 +4,25 @@ import os from "node:os"
 import path from "node:path"
 
 const directory = path.join(os.homedir(), ".coslash", "opencode-permissions")
+const clientDirectory = path.join(os.homedir(), ".coslash", "opencode-clients")
 const requestsBySession = new Map()
 let lifecycle = Promise.resolve()
+
+async function recordClient(properties) {
+  if (typeof properties.sessionID !== "string") return
+  const client = process.env.OPENCODE_CLIENT === "desktop" ? "desktop" : "cli"
+  await mkdir(clientDirectory, { recursive: true, mode: 0o700 })
+  await chmod(clientDirectory, 0o700)
+  const target = path.join(clientDirectory, `${properties.sessionID}.json`)
+  const temporary = `${target}.${process.pid}.tmp`
+  await writeFile(temporary, JSON.stringify({ sessionID: properties.sessionID, client }), { mode: 0o600 })
+  await rename(temporary, target)
+}
+
+async function clearClient(properties) {
+  if (typeof properties.sessionID !== "string") return
+  await unlink(path.join(clientDirectory, `${properties.sessionID}.json`)).catch(() => {})
+}
 
 async function record(properties) {
   if (typeof properties.id !== "string" || typeof properties.sessionID !== "string") return
@@ -44,6 +61,10 @@ async function clearSession(properties) {
 export const CoslashWaitingPlugin = async () => ({
   event: ({ event }) => {
     lifecycle = lifecycle.then(async () => {
+      if (["session.created", "session.updated", "message.updated"].includes(event?.type)) {
+        await recordClient(event.properties ?? {})
+      }
+      if (event?.type === "session.deleted") await clearClient(event.properties ?? {})
       if (event?.type === "permission.asked") await record(event.properties ?? {})
       if (event?.type === "permission.replied") await clear(event.properties ?? {})
       if (event?.type === "session.idle") await clearSession(event.properties ?? {})

--- a/collector/internal/vendors/opencode/metadata.go
+++ b/collector/internal/vendors/opencode/metadata.go
@@ -89,12 +89,42 @@ type pendingPermission struct {
 	PID       int    `json:"pid"`
 }
 
+type sessionClientRecord struct {
+	SessionID string `json:"sessionID"`
+	Client    string `json:"client"`
+}
+
 func permissionStateDir() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return ""
 	}
 	return filepath.Join(home, ".coslash", "opencode-permissions")
+}
+
+func clientStateDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".coslash", "opencode-clients")
+}
+
+func sessionEntrypoint(id, directory string) *string {
+	if !sessionIDPattern.MatchString(id) || directory == "" {
+		return nil
+	}
+	data, err := os.ReadFile(filepath.Join(directory, id+".json"))
+	if err != nil {
+		return nil
+	}
+	var record sessionClientRecord
+	if json.Unmarshal(data, &record) != nil || record.SessionID != id ||
+		(record.Client != "desktop" && record.Client != "cli") {
+		return nil
+	}
+	value := "opencode-" + record.Client
+	return &value
 }
 
 func markPendingPermissions(db *sql.DB, metadata *vendors.SessionMetadata, directory string) {

--- a/collector/internal/vendors/opencode/parse.go
+++ b/collector/internal/vendors/opencode/parse.go
@@ -289,6 +289,7 @@ func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 		Tokens:           tokens,
 		Subagents:        []session.Subagent{},
 		SessionDetails:   details,
+		Entrypoint:       sessionEntrypoint(row.id, clientStateDir()),
 	}
 	if activeDuration > 0 {
 		value := int(activeDuration)
@@ -301,10 +302,6 @@ func parse(tx *sql.Tx, row storedSession) (parsedSession, error) {
 	if summary != "" {
 		value := session.Truncate(summary, session.TruncateTextLimit)
 		result.Summary = &value
-	}
-	if row.agent.Valid && strings.TrimSpace(row.agent.String) != "" {
-		value := strings.TrimSpace(row.agent.String)
-		result.Entrypoint = &value
 	}
 	parsed := &vendors.ParsedSession{
 		Session:      result,

--- a/collector/internal/vendors/opencode/plugin.go
+++ b/collector/internal/vendors/opencode/plugin.go
@@ -11,32 +11,35 @@ import (
 	"strings"
 )
 
-const pluginName = "coslash-waiting.js"
+const (
+	pluginName       = "coslash-plugin.js"
+	legacyPluginName = "coslash-waiting.js"
+)
 
-//go:embed coslash-waiting.js
-var waitingPlugin []byte
+//go:embed coslash-plugin.js
+var pluginSource []byte
 
-func EnsureWaitingPlugin() error {
-	path, err := waitingPluginPath()
+func EnsurePlugin() error {
+	path, err := pluginPath()
 	if err != nil {
 		return err
 	}
-	return installWaitingPlugin(filepath.Dir(path))
+	return installPlugin(filepath.Dir(path))
 }
 
-type WaitingPluginHealth struct {
+type PluginHealth struct {
 	Path            string
 	Installed       bool
 	RestartRequired bool
 	Err             error
 }
 
-func WaitingPluginDiagnostics() WaitingPluginHealth {
-	path, err := waitingPluginPath()
+func PluginDiagnostics() PluginHealth {
+	path, err := pluginPath()
 	if err != nil {
-		return WaitingPluginHealth{Err: err}
+		return PluginHealth{Err: err}
 	}
-	health := WaitingPluginHealth{Path: path}
+	health := PluginHealth{Path: path}
 	current, err := os.ReadFile(path)
 	if errors.Is(err, os.ErrNotExist) {
 		return health
@@ -45,7 +48,7 @@ func WaitingPluginDiagnostics() WaitingPluginHealth {
 		health.Err = err
 		return health
 	}
-	if !bytes.Equal(current, waitingPlugin) {
+	if !bytes.Equal(current, pluginSource) {
 		health.Err = errors.New("installed plugin differs from the coSlash plugin")
 		return health
 	}
@@ -69,7 +72,7 @@ func WaitingPluginDiagnostics() WaitingPluginHealth {
 	return health
 }
 
-func waitingPluginPath() (string, error) {
+func pluginPath() (string, error) {
 	root := os.Getenv("XDG_CONFIG_HOME")
 	if root == "" {
 		home, err := os.UserHomeDir()
@@ -81,7 +84,7 @@ func waitingPluginPath() (string, error) {
 	return filepath.Join(root, "opencode", "plugins", pluginName), nil
 }
 
-func installWaitingPlugin(directory string) error {
+func installPlugin(directory string) error {
 	if err := os.MkdirAll(directory, 0o700); err != nil {
 		return err
 	}
@@ -90,13 +93,13 @@ func installWaitingPlugin(directory string) error {
 	if err == nil && !strings.HasPrefix(string(current), "// managed by coSlash;") {
 		return fmt.Errorf("refusing to overwrite unmanaged OpenCode plugin %s", path)
 	}
-	if err == nil && string(current) == string(waitingPlugin) {
-		return nil
+	if err == nil && string(current) == string(pluginSource) {
+		return removeManagedLegacyPlugin(directory)
 	}
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
-	temporary, err := os.CreateTemp(directory, ".coslash-waiting-*")
+	temporary, err := os.CreateTemp(directory, ".coslash-plugin-*")
 	if err != nil {
 		return err
 	}
@@ -106,12 +109,30 @@ func installWaitingPlugin(directory string) error {
 		temporary.Close()
 		return err
 	}
-	if _, err := temporary.Write(waitingPlugin); err != nil {
+	if _, err := temporary.Write(pluginSource); err != nil {
 		temporary.Close()
 		return err
 	}
 	if err := temporary.Close(); err != nil {
 		return err
 	}
-	return os.Rename(temporaryPath, path)
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return err
+	}
+	return removeManagedLegacyPlugin(directory)
+}
+
+func removeManagedLegacyPlugin(directory string) error {
+	path := filepath.Join(directory, legacyPluginName)
+	current, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !strings.HasPrefix(string(current), "// managed by coSlash;") {
+		return nil
+	}
+	return os.Remove(path)
 }

--- a/frontend/src/pages/coslash/lib/session.test.ts
+++ b/frontend/src/pages/coslash/lib/session.test.ts
@@ -3,6 +3,7 @@ import { decodeMachineFact } from '@/pages/coslash/lib/machines';
 import {
   boardStatusKey,
   environmentFact,
+  getModality,
   getSessionVendors,
   LOCAL_SOURCE_ID,
   sessionKey,
@@ -10,6 +11,14 @@ import {
   withLocalSourceDefaults,
   type Session,
 } from '@/pages/coslash/lib/session';
+
+describe('getModality', () => {
+  it('labels OpenCode client entrypoints without changing the shared CLI modality', () => {
+    expect(getModality('opencode-desktop')).toBe('Desktop');
+    expect(getModality('opencode-cli')).toBe('CLI');
+    expect(getModality('cli')).toBe('Interactive');
+  });
+});
 
 describe('getSessionVendors', () => {
   it('returns only vendors represented by loaded sessions in display order', () => {

--- a/frontend/src/pages/coslash/lib/session.ts
+++ b/frontend/src/pages/coslash/lib/session.ts
@@ -261,6 +261,8 @@ export const SUBAGENT_STATUSES = {
 const MODALITIES: Record<string, string> = {
   'cli': 'Interactive',
   'codex-tui': 'Interactive',
+  'opencode-cli': 'CLI',
+  'opencode-desktop': 'Desktop',
   'sdk-cli': 'Autonomous',
   'sdk-ts': 'Autonomous',
   'sdk-py': 'Autonomous',


### PR DESCRIPTION
## Context

OpenCode session badges previously showed the selected agent role, which does not identify the surface used to run a session. Surface labels now distinguish Desktop and CLI while preserving the existing modality labels for other agents.

## Changes

- Record the OpenCode client surface for session activity and display `Desktop` or `CLI` in session badges.
- Omit the OpenCode modality when no client record exists, rather than showing the misleading Build/Plan role.
- Remove client markers when an OpenCode session is deleted.

Note: old inactive opencode sessions created before this change will show no modality badge until that session is reopened. retroactively iterating through all old sessions and updating the entrypoint will add significant complexity.

## Test

- `GOCACHE=/private/tmp/coslash-go-cache go test ./...` — passed
- `GOCACHE=/private/tmp/coslash-go-cache go build ./...` — passed
- `npm test` — passed
- `npm run lint` — passed with existing warnings
- `npm run build` — passed

### Screenshots

- [x] Before — OpenCode only distinguishes between Build/Plan mode.
<img width="2321" height="789" alt="Screenshot 2026-09-03 at 11 30 49" src="https://github.com/user-attachments/assets/ff98608c-fb0a-49a9-a96d-c249f1b889c0" />


- [x] After — OpenCode can distinguish between sessions created in either CLI or Desktop app.
<img width="2323" height="418" alt="Screenshot 2026-09-03 at 11 18 20" src="https://github.com/user-attachments/assets/e7daa1c1-bfa1-4804-957b-73a87c65d58f" />
<img width="2313" height="305" alt="Screenshot 2026-09-03 at 11 16 53" src="https://github.com/user-attachments/assets/3319618b-79bc-45a3-bf6a-8cd22c3ded04" />
