### PR TITLE
Keep synthesis disabled for new profiles

### DIFF
--- a/frontend/src/pages/coslash/lib/settings.test.ts
+++ b/frontend/src/pages/coslash/lib/settings.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
   availableSynthesisBackends,
+  initialSettingsDraft,
   settingsForSave,
   type BackendOption,
   type CoslashSettings,
+  type SettingsResponse,
 } from '@/pages/coslash/lib/settings';
 
 function backend(id: string, available: boolean): BackendOption {
@@ -15,6 +17,42 @@ describe('availableSynthesisBackends', () => {
     const options = [backend('claude-cli', true), backend('codex_exec', false)];
 
     expect(availableSynthesisBackends(options).map(({ id }) => id)).toEqual(['claude-cli']);
+  });
+});
+
+describe('initialSettingsDraft', () => {
+  it('keeps synthesis disabled for unpersisted settings with an available backend', () => {
+    const response: SettingsResponse = {
+      settings: {
+        $schema: 'x',
+        version: 1,
+        synthesis: { enabled: false, backend: '', model: '' },
+        appearance: { theme: 'light' },
+        launch: { terminal: 'Terminal' },
+      },
+      persisted: false,
+      valid: true,
+      options: {
+        synthesisBackends: [
+          {
+            id: 'claude-cli',
+            label: 'Claude CLI',
+            available: true,
+            models: [
+              { id: 'claude-sonnet', label: 'Claude Sonnet', default: false },
+              { id: 'claude-opus', label: 'Claude Opus', default: true },
+            ],
+          },
+        ],
+        terminals: [],
+      },
+    };
+
+    expect(initialSettingsDraft(response).synthesis).toEqual({
+      enabled: false,
+      backend: 'claude-cli',
+      model: 'claude-opus',
+    });
   });
 });
 

--- a/frontend/src/pages/coslash/lib/settings.ts
+++ b/frontend/src/pages/coslash/lib/settings.ts
@@ -119,7 +119,7 @@ export function initialSettingsDraft(response: SettingsResponse): CoslashSetting
 
   if (!response.persisted) {
     const availableBackend = availableSynthesisBackends(response.options.synthesisBackends)[0];
-    synthesis.enabled = availableBackend != null;
+    synthesis.enabled = false;
     if (availableBackend) {
       synthesis.backend = availableBackend.id;
       synthesis.model = modelForBackend(response, availableBackend.id);


### PR DESCRIPTION
## Context

New profiles should not automatically enable synthesis merely because a supported backend is detected. Keep the available backend and model preselected so users can opt in without extra setup.

## Changes

- Leave synthesis disabled when initializing unpersisted settings.
- Preserve automatic selection of an available backend and its default model.
- Add regression coverage for new-profile initialization.

## Test

- `npm test` — passed, 80 tests
- `npm run build` — passed
- `npm run lint` — passed with existing warnings
- `npm run format:check` — passed
- `git diff --check` — passed

### Screenshots

- [x] Fresh profile settings — AI synthesis is disabled while a backend and model remain preselected
<img width="590" height="698" alt="Screenshot 2026-09-04 at 11 03 41" src="https://github.com/user-attachments/assets/7c711bfa-634a-49fb-8b62-557d57cea194" />
