### PR TITLE
Disable Resume for active local Codex sessions

### DIFF
--- a/frontend/src/pages/coslash/components/SessionInspector.tsx
+++ b/frontend/src/pages/coslash/components/SessionInspector.tsx
@@ -63,6 +63,8 @@ import {
   goalSourceLabel,
   isLocalSession,
   resolveGoal,
+  resumeDisabled,
+  resumeDisabledHint,
   sessionKey,
   STATUSES,
   SUBAGENT_STATUSES,
@@ -370,7 +372,7 @@ function DisabledLaunchTooltip({ hint, children }: { hint?: string; children: Re
 
 function ResumeSessionButton({ detail, disabledHint }: { detail: SessionDetail; disabledHint?: string }) {
   const { launch, launchError } = useLaunchTerminal(detail);
-  const disabled = !isLocalSession(detail) && (detail.displayStale || detail.launchable === false);
+  const disabled = resumeDisabled(detail, disabledHint);
 
   return (
     <div className="flex flex-col gap-1">
@@ -1118,11 +1120,7 @@ export function SessionInspector({
           ? 'Waiting for remote session details'
           : 'Remote is offline';
   const remoteResumeHint =
-    detail != null && !isLocalSession(detail) && remoteLaunchable && boardStatusKey(detail) === 'busy'
-      ? 'This session is already active'
-      : detail != null && !isLocalSession(detail) && !remoteLaunchable
-        ? remoteLaunchHint
-        : undefined;
+    detail == null ? undefined : resumeDisabledHint(detail, remoteLaunchable, remoteLaunchHint);
 
   useEffect(() => {
     setSelectedDiff(null);

--- a/frontend/src/pages/coslash/lib/session.test.ts
+++ b/frontend/src/pages/coslash/lib/session.test.ts
@@ -6,6 +6,8 @@ import {
   getModality,
   getSessionVendors,
   LOCAL_SOURCE_ID,
+  resumeDisabled,
+  resumeDisabledHint,
   sessionKey,
   sessionsForAggregates,
   withLocalSourceDefaults,
@@ -87,6 +89,71 @@ describe('boardStatusKey', () => {
 
   it('uses Inactive only for local sessions with no status', () => {
     expect(boardStatusKey({ sourceId: 'local', status: null, displayStale: false })).toBe('inactive');
+  });
+});
+
+describe('resumeDisabledHint', () => {
+  it('disables Resume for an active local Codex session', () => {
+    expect(
+      resumeDisabledHint({ sourceId: LOCAL_SOURCE_ID, agent: 'codex', status: 'busy', displayStale: false }),
+    ).toBe('This session is already active');
+  });
+
+  it('leaves inactive local and non-Codex sessions resumable', () => {
+    expect(
+      resumeDisabledHint({ sourceId: LOCAL_SOURCE_ID, agent: 'codex', status: 'idle', displayStale: false }),
+    ).toBeUndefined();
+    expect(
+      resumeDisabledHint({ sourceId: LOCAL_SOURCE_ID, agent: 'claude', status: 'busy', displayStale: false }),
+    ).toBeUndefined();
+  });
+
+  it('preserves remote active and unavailable hints', () => {
+    expect(
+      resumeDisabledHint(
+        { sourceId: 'r_0123456789abcdef', agent: 'codex', status: 'busy', displayStale: false },
+        true,
+        'remote hint',
+      ),
+    ).toBe('This session is already active');
+    expect(
+      resumeDisabledHint(
+        { sourceId: 'r_0123456789abcdef', agent: 'codex', status: 'idle', displayStale: false },
+        false,
+        'Remote is offline',
+      ),
+    ).toBe('Remote is offline');
+  });
+});
+
+describe('resumeDisabled', () => {
+  it('disables an active local Codex session but preserves remote launch behavior', () => {
+    expect(
+      resumeDisabled(
+        { sourceId: LOCAL_SOURCE_ID, displayStale: false, launchable: true },
+        'This session is already active',
+      ),
+    ).toBe(true);
+    expect(
+      resumeDisabled(
+        {
+          sourceId: 'r_0123456789abcdef',
+          displayStale: false,
+          launchable: true,
+        },
+        'This session is already active',
+      ),
+    ).toBe(false);
+    expect(
+      resumeDisabled(
+        {
+          sourceId: 'r_0123456789abcdef',
+          displayStale: false,
+          launchable: false,
+        },
+        'Remote is offline',
+      ),
+    ).toBe(true);
   });
 });
 

--- a/frontend/src/pages/coslash/lib/session.ts
+++ b/frontend/src/pages/coslash/lib/session.ts
@@ -303,6 +303,29 @@ export function boardStatusKey(session: Pick<Session, 'sourceId' | 'status' | 'd
   return getStatus(session.status);
 }
 
+export function resumeDisabledHint(
+  session: Pick<Session, 'sourceId' | 'agent' | 'status' | 'displayStale'>,
+  remoteLaunchable = false,
+  remoteLaunchHint?: string,
+): string | undefined {
+  if (
+    boardStatusKey(session) === 'busy' &&
+    (isLocalSession(session) ? session.agent === 'codex' : remoteLaunchable)
+  ) {
+    return 'This session is already active';
+  }
+  return !isLocalSession(session) && !remoteLaunchable ? remoteLaunchHint : undefined;
+}
+
+export function resumeDisabled(
+  session: Pick<Session, 'sourceId' | 'displayStale' | 'launchable'>,
+  disabledHint?: string,
+): boolean {
+  return isLocalSession(session)
+    ? disabledHint != null
+    : session.displayStale || session.launchable === false;
+}
+
 /** Badge label: live status, or "Last seen …" when the remote snapshot is stale/incomplete. */
 export function displayStatusLabel(
   session: Pick<Session, 'status' | 'displayStale' | 'lastSeenStatus'> & { sourceId?: string },


### PR DESCRIPTION
## Context

The session inspector could offer Resume for a local Codex session that already had an active writer, resulting in a terminal error. The action should be unavailable while that session is active.

## Changes

- Disable Resume for active local Codex sessions and show an active-session hint.
- Preserve Resume behavior for inactive local sessions, other local agents, and existing remote states.
- Add focused regression coverage.

## Test

- `npm test` — passed, 83 tests
- `npm run build` — passed
- `npm run lint` — passed with existing warnings
- `npm run format:check` — passed
- `git diff --check` — passed

### Screenshots

- [x] Active local Codex session — Resume button is disabled
<img width="729" height="906" alt="Screenshot 2026-09-04 at 11 10 18" src="https://github.com/user-attachments/assets/abeac061-ed37-4547-ba93-957fdead8ac4" />
