### PR TITLE
Fix Claude session card facts

### DIFF
--- a/collector/internal/vendors/claude/parse.go
+++ b/collector/internal/vendors/claude/parse.go
@@ -41,7 +41,6 @@ type claudeSessionAnalysis struct {
 	toolUseCount             int
 	errors                   int
 	spawns                   map[string]vendors.SpawnState
-	editedFiles              map[string]struct{}
 	commands                 session.CommandLog
 	commitLog                []session.CommitObservation
 	dedupedMessageTokenUsage map[string]messageUsage
@@ -198,7 +197,6 @@ func analyzeClaudeSessionSource(
 		dedupedMessageTokenUsage: map[string]messageUsage{},
 		pullRequests:             map[string]struct{}{},
 		spawns:                   map[string]vendors.SpawnState{},
-		editedFiles:              map[string]struct{}{},
 		tokens:                   map[string]session.ModelTokens{},
 		tasks:                    map[string]*taskEntry{},
 		fileEdits:                session.NewFileEditSet(),
@@ -238,7 +236,7 @@ func analyzeClaudeSessionSource(
 		if row.WorkingDirectory != "" {
 			analysis.workingDirectory = row.WorkingDirectory
 		}
-		if row.Branch != nil && *row.Branch != "" {
+		if row.Branch != nil && *row.Branch != "" && *row.Branch != "HEAD" {
 			analysis.branch = row.Branch
 		}
 		if row.Entrypoint != nil && *row.Entrypoint != "" {
@@ -370,9 +368,6 @@ func analyzeClaudeSessionSource(
 						rowTimestamp,
 					)
 					pendingAssistantText = ""
-				}
-				if block.Name == "Edit" || block.Name == "Write" {
-					analysis.editedFiles[block.Input.FilePath] = struct{}{}
 				}
 				if block.Name == "TaskUpdate" {
 					if task, ok := analysis.tasks[block.Input.TaskID]; ok {
@@ -541,7 +536,7 @@ func (analysis *claudeSessionAnalysis) unifiedSession(filePath string) *session.
 		SessionDetails:   unifiedSessionDetails,
 		StartedAt:        analysis.timestamps.Earliest,
 		LastActivityTime: analysis.timestamps.Latest,
-		EditedFileCount:  len(analysis.editedFiles),
+		EditedFileCount:  len(analysis.fileEdits.Edits),
 		Tokens:           analysis.tokens,
 		Subagents:        []session.Subagent{},
 	}


### PR DESCRIPTION
## Context

Claude session cards could display `HEAD` as a branch when no repository branch was available. They could also count attempted or failed writes as edited files, disagreeing with the session inspector.

## Changes

- Treat Claude’s `HEAD` branch sentinel as an unknown branch.
- Derive edited-file counts from successfully parsed file edits.

## Test

- `go test -count=1 ./internal/vendors/claude ./internal/remotefacts ./internal/collector` — passed

### Screenshots

- [x] Remote Claude card — before
<img width="908" height="886" alt="Screenshot 2026-09-08 at 12 14 19" src="https://github.com/user-attachments/assets/d375d151-81fb-4a1a-818b-a1df137390c1" />

- [x] Remote Claude card — after
<img width="907" height="887" alt="Screenshot 2026-09-08 at 12 14 26" src="https://github.com/user-attachments/assets/43f22686-b2ba-41c0-913d-d2c8989e1c96" />
