### PR TITLE
Preserve SFTP handshake failure classification

### DIFF
--- a/collector/internal/remote/manager.go
+++ b/collector/internal/remote/manager.go
@@ -898,12 +898,12 @@ func classifyError(err error) Reason {
 	if strings.Contains(message, "i/o timeout") || strings.Contains(message, "deadline exceeded") {
 		return ReasonRefreshTimeout
 	}
+	if strings.Contains(message, "subsystem") || strings.Contains(message, "sftp") {
+		return ReasonSFTPUnavailable
+	}
 	if strings.Contains(message, "broken pipe") || strings.Contains(message, "connection reset") ||
 		strings.Contains(message, "connection refused") || strings.Contains(message, "unexpected eof") {
 		return ReasonConnectionFailed
-	}
-	if strings.Contains(message, "subsystem") || strings.Contains(message, "sftp") {
-		return ReasonSFTPUnavailable
 	}
 	if strings.Contains(message, "json") ||
 		strings.Contains(message, "unmarshal") ||

--- a/collector/internal/remote/sftp.go
+++ b/collector/internal/remote/sftp.go
@@ -314,13 +314,14 @@ func OpenSession(ctx context.Context, alias string, options OpenOptions) (*Sessi
 	}
 	if err != nil {
 		_ = stdin.Close()
+		sessionErr := sessionCtx.Err()
 		cancel()
 		_ = cmd.Wait()
 		if stderr.overflow {
 			return nil, ErrStderrLimit
 		}
-		if sessionCtx.Err() != nil {
-			return nil, sessionCtx.Err()
+		if sessionErr != nil {
+			return nil, sessionErr
 		}
 		return nil, wrapSSHError(fmt.Errorf("open SFTP subsystem: %w", err), stderr.String())
 	}


### PR DESCRIPTION
## Context

SFTP handshake failures could be masked by internal cleanup cancellation and reported as timeouts or generic connection failures. Preserve the original failure so users receive accurate SFTP-specific recovery guidance.

## Changes

- Preserve SFTP handshake errors across session cleanup.
- Prioritize SFTP subsystem classification over generic unexpected-EOF handling.

## Test

- `GOCACHE=/private/tmp/coslash-go-cache go test ./internal/remote -run '^TestOpenSessionPreservesSFTPHandshakeFailure$' -count=1` — passed
- `GOCACHE=/private/tmp/coslash-go-cache go test ./internal/remote -run 'Test(OpenSessionPreservesSFTPHandshakeFailure|ClassifyLifecycleError|SSHLifecycleRemote|LifecycleSFTP|RunSSHCommand|HelperCollect)' -count=1` — passed
- `GOCACHE=/private/tmp/coslash-go-cache go test ./cmd/coslash -count=1` — passed
