### PR TITLE
Align remote terminal action gating

### DIFF
--- a/collector/cmd/coslash/api.go
+++ b/collector/cmd/coslash/api.go
@@ -266,8 +266,12 @@ func handleLaunch(w http.ResponseWriter, r *http.Request, settingsStore *setting
 			http.Error(w, "remote session is already active", http.StatusConflict)
 			return
 		}
+		if errors.Is(err, remote.ErrRemoteSessionOversized) {
+			http.Error(w, "remote session details exceed the collection size limit", http.StatusConflict)
+			return
+		}
 		if errors.Is(err, remote.ErrRemoteSessionUnavailable) {
-			http.Error(w, "remote session details are too large to launch", http.StatusConflict)
+			http.Error(w, "remote session is missing its working directory", http.StatusConflict)
 			return
 		}
 	}

--- a/collector/cmd/coslash/api_source.go
+++ b/collector/cmd/coslash/api_source.go
@@ -31,12 +31,13 @@ type sessionsResponse struct {
 }
 
 type boardSession struct {
-	SourceID              string  `json:"sourceId"`
-	SourceLabel           string  `json:"sourceLabel"`
-	EligibleForAggregates bool    `json:"eligibleForAggregates"`
-	DisplayStale          bool    `json:"displayStale"`
-	LastSeenStatus        *string `json:"lastSeenStatus,omitempty"`
-	Launchable            bool    `json:"launchable"`
+	SourceID              string                   `json:"sourceId"`
+	SourceLabel           string                   `json:"sourceLabel"`
+	EligibleForAggregates bool                     `json:"eligibleForAggregates"`
+	DisplayStale          bool                     `json:"displayStale"`
+	LastSeenStatus        *string                  `json:"lastSeenStatus,omitempty"`
+	Launchable            bool                     `json:"launchable"`
+	LaunchBlockReason     remote.LaunchBlockReason `json:"launchBlockReason,omitempty"`
 	session.Session
 }
 
@@ -95,8 +96,8 @@ func boardRemoteSession(value remote.IndexedSession) boardSession {
 		SourceID: value.Key.SourceID, SourceLabel: value.SourceLabel,
 		EligibleForAggregates: value.EligibleForAggregates,
 		DisplayStale:          value.DisplayStale, LastSeenStatus: value.LastSeenStatus,
-		Launchable: value.Launchable,
-		Session:    sessionWithJSONCollections(*value.Session),
+		Launchable: value.Launchable, LaunchBlockReason: value.LaunchBlockReason,
+		Session: sessionWithJSONCollections(*value.Session),
 	}
 }
 

--- a/collector/internal/remote/manager.go
+++ b/collector/internal/remote/manager.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/centauri-ai/coslash/collector/internal/launch"
+	"github.com/centauri-ai/coslash/collector/internal/remotefacts"
 	"github.com/centauri-ai/coslash/collector/internal/session"
 	"github.com/centauri-ai/coslash/collector/internal/settings"
 	"github.com/centauri-ai/coslash/collector/internal/vendors"
@@ -22,6 +23,14 @@ var (
 	ErrHelperSetupInProgress    = errors.New("helper setup is running for the configured SSH alias")
 	ErrRemoteSessionActive      = errors.New("remote session already has an active writer")
 	ErrRemoteSessionUnavailable = errors.New("remote session details are unavailable")
+	ErrRemoteSessionOversized   = errors.New("remote session details exceed the collection size limit")
+)
+
+type LaunchBlockReason string
+
+const (
+	LaunchBlockMissingDetails LaunchBlockReason = "missing_details"
+	LaunchBlockOversized      LaunchBlockReason = "oversized"
 )
 
 type SessionKey struct {
@@ -38,6 +47,7 @@ type IndexedSession struct {
 	DisplayStale          bool
 	LastSeenStatus        *string
 	Launchable            bool
+	LaunchBlockReason     LaunchBlockReason
 }
 
 type remoteSessionKey struct{ Agent, ID string }
@@ -452,10 +462,13 @@ func (manager *Manager) LaunchSession(sourceID, agent, sessionID, mode string) (
 	}
 	for _, item := range manager.sessions {
 		if item.Agent == agent && item.ID == sessionID {
-			if item.WorkingDirectory == "" {
+			switch launchBlockReason(manager.snapshot, item) {
+			case LaunchBlockOversized:
+				return nil, "", ErrRemoteSessionOversized
+			case LaunchBlockMissingDetails:
 				return nil, "", ErrRemoteSessionUnavailable
 			}
-			if mode == launch.ResumeSession && item.Status != nil && *item.Status == "busy" {
+			if mode == launch.ResumeSession && item.Status != nil && (*item.Status == "busy" || *item.Status == "idle") {
 				return nil, "", ErrRemoteSessionActive
 			}
 			copy := *item
@@ -742,12 +755,14 @@ func (manager *Manager) sessionsLocked(remoteSinceMs int64) []IndexedSession {
 		if remoteSinceMs > 0 && item.Status == nil && item.LastActivityTime < remoteSinceMs {
 			continue
 		}
+		blockReason := launchBlockReason(manager.snapshot, item)
 		indexed := IndexedSession{
 			Key:         SessionKey{SourceID: manager.cfg.ID, Agent: item.Agent, SourceSessionID: item.ID},
 			SourceLabel: manager.cfg.SSHAlias, Session: item,
 			EligibleForAggregates: eligible,
 			DisplayStale:          globalStale || manager.familyStale[remoteSessionKey{Agent: item.Agent, ID: item.ID}],
-			Launchable:            item.WorkingDirectory != "",
+			Launchable:            blockReason == "",
+			LaunchBlockReason:     blockReason,
 		}
 		if indexed.DisplayStale {
 			indexed.LastSeenStatus = item.Status
@@ -755,6 +770,25 @@ func (manager *Manager) sessionsLocked(remoteSinceMs int64) []IndexedSession {
 		result = append(result, indexed)
 	}
 	return result
+}
+
+func launchBlockReason(snapshot *CachedSnapshotV2, item *session.Session) LaunchBlockReason {
+	if snapshot != nil {
+		for _, family := range snapshot.Families {
+			if family.Vendor != item.Agent || family.StaleReason != remotefacts.StaleReasonOversizedFile {
+				continue
+			}
+			for _, fact := range family.Facts.Sessions {
+				if fact.ID == item.ID {
+					return LaunchBlockOversized
+				}
+			}
+		}
+	}
+	if item.WorkingDirectory != "" {
+		return ""
+	}
+	return LaunchBlockMissingDetails
 }
 
 func (manager *Manager) healthLocked(remoteSinceMs int64) Health {

--- a/collector/internal/remotehelper/vendorscan.go
+++ b/collector/internal/remotehelper/vendorscan.go
@@ -104,7 +104,20 @@ func scanClaude(
 func scanCodex(source *Source, home string, request remoteprotocol.Request) *vendorScan {
 	metadata := vendors.BestEffortMetadata(
 		vendors.AgentCodex,
-		codex.LoadMetadata,
+		func() (*vendors.SessionMetadata, error) {
+			metadata, err := codex.LoadRemoteMetadata(source, home)
+			if err != nil {
+				return nil, err
+			}
+			live, err := codex.LoadLiveSessions()
+			if err != nil {
+				return nil, err
+			}
+			for id := range live {
+				metadata.Live[id] = "interactive"
+			}
+			return metadata, nil
+		},
 	)
 	result := &vendorScan{
 		vendor:    vendors.AgentCodex,

--- a/collector/internal/remotehelper/vendorscan.go
+++ b/collector/internal/remotehelper/vendorscan.go
@@ -104,7 +104,7 @@ func scanClaude(
 func scanCodex(source *Source, home string, request remoteprotocol.Request) *vendorScan {
 	metadata := vendors.BestEffortMetadata(
 		vendors.AgentCodex,
-		func() (*vendors.SessionMetadata, error) { return codex.LoadRemoteMetadata(source, home) },
+		codex.LoadMetadata,
 	)
 	result := &vendorScan{
 		vendor:    vendors.AgentCodex,

--- a/collector/internal/vendors/codex/metadata.go
+++ b/collector/internal/vendors/codex/metadata.go
@@ -19,7 +19,7 @@ import (
 // get the "interactive" convention so resolveStatus applies the busy/idle
 // refinement.
 func LoadMetadata() (*vendors.SessionMetadata, error) {
-	live, err := liveSessions()
+	live, err := LoadLiveSessions()
 	if err != nil {
 		return nil, err
 	}
@@ -35,7 +35,8 @@ func LoadMetadata() (*vendors.SessionMetadata, error) {
 	return metadata, nil
 }
 
-func liveSessions() (map[string]struct{}, error) {
+// LoadLiveSessions returns the Codex session IDs that lsof reports as open.
+func LoadLiveSessions() (map[string]struct{}, error) {
 	openCodexSessions, err := exec.Command("lsof", "-a", "-c", "codex", "-Fn").Output()
 	if err != nil {
 		var exitErr *exec.ExitError

--- a/frontend/src/pages/coslash/components/SessionInspector.tsx
+++ b/frontend/src/pages/coslash/components/SessionInspector.tsx
@@ -62,6 +62,7 @@ import {
   getVendor,
   goalSourceLabel,
   isLocalSession,
+  remoteLaunchDisabledHint,
   resolveGoal,
   resumeDisabled,
   resumeDisabledHint,
@@ -1105,6 +1106,7 @@ export function SessionInspector({
     detail != null &&
     !isLocalSession(detail) &&
     detail.cwd.trim() !== '' &&
+    detail.launchable !== false &&
     machines.some(
       (machine) =>
         machine.sourceId === detail.sourceId && (machine.state === 'ok' || machine.state === 'limited'),
@@ -1114,11 +1116,7 @@ export function SessionInspector({
   const remoteLaunchHint =
     detail == null || isLocalSession(detail) || remoteLaunchable
       ? undefined
-      : remoteMachine?.state === 'connecting' || remoteMachine == null
-        ? 'Checking SSH liveness…'
-        : remoteMachine.state === 'ok' || remoteMachine.state === 'limited'
-          ? 'Waiting for remote session details'
-          : 'Remote is offline';
+      : remoteLaunchDisabledHint(remoteMachine?.state, detail.launchBlockReason);
   const remoteResumeHint =
     detail == null ? undefined : resumeDisabledHint(detail, remoteLaunchable, remoteLaunchHint);
 

--- a/frontend/src/pages/coslash/lib/session.ts
+++ b/frontend/src/pages/coslash/lib/session.ts
@@ -40,6 +40,7 @@ export type Session = {
   eligibleForAggregates: boolean;
   displayStale: boolean;
   launchable?: boolean;
+  launchBlockReason?: 'missing_details' | 'oversized';
   lastSeenStatus?: string;
   agent: string;
   id: string;
@@ -309,7 +310,8 @@ export function resumeDisabledHint(
   remoteLaunchHint?: string,
 ): string | undefined {
   if (
-    boardStatusKey(session) === 'busy' &&
+    (boardStatusKey(session) === 'busy' ||
+      (!isLocalSession(session) && boardStatusKey(session) === 'idle')) &&
     (isLocalSession(session) ? session.agent === 'codex' : remoteLaunchable)
   ) {
     return 'This session is already active';
@@ -318,12 +320,26 @@ export function resumeDisabledHint(
 }
 
 export function resumeDisabled(
-  session: Pick<Session, 'sourceId' | 'displayStale' | 'launchable'>,
+  session: Pick<Session, 'sourceId' | 'displayStale' | 'launchable'> & Partial<Pick<Session, 'status'>>,
   disabledHint?: string,
 ): boolean {
   return isLocalSession(session)
     ? disabledHint != null
-    : session.displayStale || session.launchable === false;
+    : session.status === 'busy' ||
+        session.status === 'idle' ||
+        session.displayStale ||
+        session.launchable === false;
+}
+
+export function remoteLaunchDisabledHint(
+  machineState: string | undefined,
+  blockReason?: Session['launchBlockReason'],
+): string {
+  if (machineState == null || machineState === 'connecting') return 'Checking SSH liveness…';
+  if (machineState !== 'ok' && machineState !== 'limited') return 'Remote is offline';
+  if (blockReason === 'oversized') return 'Remote session details exceed the collection size limit';
+  if (blockReason === 'missing_details') return 'Remote session is missing its working directory';
+  return 'Waiting for remote session details';
 }
 
 /** Badge label: live status, or "Last seen …" when the remote snapshot is stale/incomplete. */


### PR DESCRIPTION
## Context

Remote terminal controls could disagree with backend launch eligibility. Active sessions appeared resumable, while incomplete and oversized sessions received ambiguous guidance.

## Changes

- Block Resume for active remote sessions while keeping Start fresh available.
- Show distinct guidance for missing working-directory details and oversized session data.
- Preserve existing offline, stale, and Copy handoff behavior.

## Test

- `go test ./internal/remote -run '^(TestRemoteLaunchGatingDistinguishesSessionStates|TestLaunchSessionRequiresCurrentHealthyRemote)$' -count=1` — passed
- `go test ./cmd/coslash -count=1` — passed
- `npm test` — passed, 85 tests
- `npm run build` — passed

### Screenshots

- [x] Remote session inspector — can't resume active session
<img width="845" height="881" alt="Screenshot 2026-09-08 at 14 58 25" src="https://github.com/user-attachments/assets/9b1787f9-697f-419f-825a-09268b099656" />

- [x] Remote session inspector — session with missing working directory
<img width="755" height="884" alt="Screenshot 2026-09-08 at 14 37 47" src="https://github.com/user-attachments/assets/d0f43e53-dc04-42ce-8991-88e551433fbf" />
