### PR TITLE
Normalize remote family facts across transports

### DIFF
--- a/collector/internal/remotefacts/facts.go
+++ b/collector/internal/remotefacts/facts.go
@@ -378,9 +378,24 @@ func validateOptionalCount(value *int) error {
 // FromParsed creates a deterministic family replacement for remote display.
 func FromParsed(vendor, familyID, parserVersion, state, staleReason string, parsed []*vendors.ParsedSession, metadata *vendors.SessionMetadata, fingerprints []vendors.FileFingerprint, headerMappings ...[]HeaderMapping) (Family, error) {
 	f := Family{SchemaVersion: SchemaVersion, ParserVersion: parserVersion, Vendor: vendor, FamilyID: familyID, State: state, StaleReason: truncate(staleReason, MaxDisplayBytes)}
+	present := make(map[string]bool, len(parsed))
+	for _, p := range parsed {
+		present[p.Session.ID] = true
+	}
 	for _, p := range parsed {
 		s := p.Session
-		fact := Session{ID: s.ID, ParentID: p.ParentID, SpawnKey: p.SpawnKey, Name: truncate(p.Name, MaxDisplayBytes), Branch: optional(s.Branch, MaxDisplayBytes), Entrypoint: optional(s.Entrypoint, MaxDisplayBytes), StartedAtMs: s.StartedAt, LastActivityAtMs: s.LastActivityTime, DurationMs: cloneInt(s.DurationMs), Stopped: p.Stopped, InTurn: p.InTurn, Model: optional(s.Model, MaxModelBytes), ContextTokens: cloneInt(s.ContextTokens), ContextWindow: cloneInt(s.ContextWindow), Counts: Counts{EditedFiles: s.EditedFileCount, Turns: s.Turns, ToolUses: s.ToolUses, Errors: s.Errors, Compactions: s.Compactions, PullRequests: s.PullRequests}, Display: *s}
+		display, err := cloneDisplay(*s)
+		if err != nil {
+			return Family{}, err
+		}
+		parentID, spawnKey := p.ParentID, p.SpawnKey
+		if s.ID == familyID {
+			parentID, spawnKey = "", ""
+		} else if parentID == "" || !present[parentID] {
+			parentID = familyID
+			f.State = StatePartial
+		}
+		fact := Session{ID: s.ID, ParentID: parentID, SpawnKey: spawnKey, Name: truncate(p.Name, MaxDisplayBytes), Branch: optional(s.Branch, MaxDisplayBytes), Entrypoint: optional(s.Entrypoint, MaxDisplayBytes), StartedAtMs: s.StartedAt, LastActivityAtMs: s.LastActivityTime, DurationMs: cloneInt(s.DurationMs), Stopped: p.Stopped, InTurn: p.InTurn, Model: optional(s.Model, MaxModelBytes), ContextTokens: cloneInt(s.ContextTokens), ContextWindow: cloneInt(s.ContextWindow), Counts: Counts{EditedFiles: s.EditedFileCount, Turns: s.Turns, ToolUses: s.ToolUses, Errors: s.Errors, Compactions: s.Compactions, PullRequests: s.PullRequests}, Display: *display}
 		if p.StatusHint != nil {
 			fact.StatusHint = truncate(*p.StatusHint, MaxDisplayBytes)
 		}

--- a/collector/internal/remotehelper/collect.go
+++ b/collector/internal/remotehelper/collect.go
@@ -360,19 +360,6 @@ func familyFacts(
 	if len(sessions) < len(item.sessionIDs) {
 		state = remotefacts.StatePartial
 	}
-	for _, parsed := range sessions {
-		if parsed.Session.ID == item.id {
-			// Within its family the root has no parent, whatever a header claimed.
-			parsed.ParentID, parsed.SpawnKey = "", ""
-			continue
-		}
-		if parsed.ParentID == "" || !present[parsed.ParentID] {
-			// The linking transcript is missing this generation; keep the session
-			// on its own card rather than dropping collected facts.
-			parsed.ParentID = item.id
-			state = remotefacts.StatePartial
-		}
-	}
 	return remotefacts.FromParsed(
 		scanned.vendor, item.id, vendors.ParserVersion, state, "",
 		sessions, scanned.metadata, item.fingerprints, item.headerMappings,


### PR DESCRIPTION
## Context

Helper-backed and SFTP remote collection could produce different normalized session facts from the same source data. This made transport changes affect otherwise identical cached families.

## Changes

- Canonicalize family relationships at the shared normalized-fact boundary.
- Strip non-transported display fields consistently and mark missing-parent families partial.
- Remove helper-specific relationship normalization.

## Test

- `cd collector && go test ./... -count=1` — passed
- Manual: helper-backed and SFTP collection produced identical normalized facts on an authorized Linux host; warm helper refresh remained incremental.