### PR TITLE
Show working directory when remote repository is unavailable

### DIFF
--- a/frontend/src/pages/coslash/components/SessionCard.tsx
+++ b/frontend/src/pages/coslash/components/SessionCard.tsx
@@ -23,6 +23,7 @@ import {
   getSessionCardSummary,
   getTotalTokens,
   getVendor,
+  sessionLocationFact,
   STATUSES,
   SUBAGENT_STATUSES,
   sumTokens,
@@ -118,7 +119,7 @@ function Modality({ session }: { session: Session }) {
 function Metadata({ session }: { session: Session }) {
   return (
     <div className="text-muted-foreground pt-2 font-mono text-xs" title={environmentFact(session.cwd)}>
-      {environmentFact(session.repo)} · {environmentFact(session.branch)} · {formatTimeAgo(session.mtime)} ·{' '}
+      {sessionLocationFact(session)} · {environmentFact(session.branch)} · {formatTimeAgo(session.mtime)} ·{' '}
       {formatDuration(session.durationMs)} · {session.files} files
     </div>
   );

--- a/frontend/src/pages/coslash/lib/session.test.ts
+++ b/frontend/src/pages/coslash/lib/session.test.ts
@@ -71,6 +71,8 @@ describe('environmentFact', () => {
 describe('sessionLocationFact', () => {
   it('falls back to the working directory when repository metadata is unavailable', () => {
     expect(sessionLocationFact({ repo: null, cwd: '/tmp' })).toBe('/tmp');
+    expect(sessionLocationFact({ repo: '', cwd: '/tmp' })).toBe('/tmp');
+    expect(sessionLocationFact({ repo: '  ', cwd: '/tmp' })).toBe('/tmp');
   });
 });
 

--- a/frontend/src/pages/coslash/lib/session.test.ts
+++ b/frontend/src/pages/coslash/lib/session.test.ts
@@ -9,6 +9,7 @@ import {
   resumeDisabled,
   resumeDisabledHint,
   sessionKey,
+  sessionLocationFact,
   sessionsForAggregates,
   withLocalSourceDefaults,
   type Session,
@@ -64,6 +65,12 @@ describe('environmentFact', () => {
     expect(environmentFact('')).toBe('—');
     expect(environmentFact('  ')).toBe('—');
     expect(environmentFact('/home/user/proj')).toBe('/home/user/proj');
+  });
+});
+
+describe('sessionLocationFact', () => {
+  it('falls back to the working directory when repository metadata is unavailable', () => {
+    expect(sessionLocationFact({ repo: null, cwd: '/tmp' })).toBe('/tmp');
   });
 });
 

--- a/frontend/src/pages/coslash/lib/session.ts
+++ b/frontend/src/pages/coslash/lib/session.ts
@@ -110,6 +110,10 @@ export function environmentFact(value: string | null | undefined): string {
   return trimmed ? trimmed : '—';
 }
 
+export function sessionLocationFact(session: Pick<Session, 'repo' | 'cwd'>): string {
+  return environmentFact(session.repo ?? session.cwd);
+}
+
 export function withLocalSourceDefaults<T extends { agent: string; id: string }>(
   session: T,
 ): T & Pick<Session, 'sourceId' | 'sourceLabel' | 'eligibleForAggregates' | 'displayStale'> {

--- a/frontend/src/pages/coslash/lib/session.ts
+++ b/frontend/src/pages/coslash/lib/session.ts
@@ -111,7 +111,7 @@ export function environmentFact(value: string | null | undefined): string {
 }
 
 export function sessionLocationFact(session: Pick<Session, 'repo' | 'cwd'>): string {
-  return environmentFact(session.repo ?? session.cwd);
+  return environmentFact(session.repo?.trim() || session.cwd);
 }
 
 export function withLocalSourceDefaults<T extends { agent: string; id: string }>(


### PR DESCRIPTION
## Context

Remote session cards can lack repository metadata even when their working directory is known. This leaves the card’s location field blank despite having a useful folder to display.

## Changes

- Fall back to the session working directory when repository metadata is unavailable.
- Continue showing an em dash when neither value exists.

## Test

- `npm test -- --run src/pages/coslash/lib/session.test.ts` — passed
- `npx prettier --check src/pages/coslash/components/SessionCard.tsx src/pages/coslash/lib/session.ts src/pages/coslash/lib/session.test.ts` — passed
- `npm run lint -- src/pages/coslash/components/SessionCard.tsx src/pages/coslash/lib/session.ts src/pages/coslash/lib/session.test.ts` — passed
- Manual: verified a remote card without repository metadata displays `/tmp`.

### Screenshots

- [x] Remote session card — missing folder structure and no repo
<img width="757" height="622" alt="Screenshot 2026-09-08 at 18 01 04" src="https://github.com/user-attachments/assets/39c4d184-1c7e-47e1-936b-d66bb8a9a573" />

- [x] Remote session card — working-directory fallback displayed
<img width="758" height="612" alt="Screenshot 2026-09-08 at 18 08 33" src="https://github.com/user-attachments/assets/38b7cb6a-8c8c-44ae-beaa-35b66ec6b8fd" />