### PR TITLE
Keep command-heavy remote sessions instead of dropping them

### DIFF
--- a/collector/internal/remotefacts/facts.go
+++ b/collector/internal/remotefacts/facts.go
@@ -425,6 +425,20 @@ func FromParsed(vendor, familyID, parserVersion, state, staleReason string, pars
 			fact.CommandLabels = append(fact.CommandLabels, truncate(command.Label, MaxDisplayBytes))
 		}
 		fact.Commands = append([]session.SubagentCommand(nil), p.Commands...)
+		// Validate rejects over-limit lists. Keep transcript order and drop the tail
+		// so a command-heavy session still publishes instead of vanishing.
+		if len(fact.Usage) > MaxModelsPerSession {
+			fact.Usage = fact.Usage[:MaxModelsPerSession]
+		}
+		if len(fact.Spawns) > MaxSpawnsPerSession {
+			fact.Spawns = fact.Spawns[:MaxSpawnsPerSession]
+		}
+		if len(fact.CommandLabels) > MaxCommands {
+			fact.CommandLabels = fact.CommandLabels[:MaxCommands]
+		}
+		if len(fact.Commands) > MaxCommands {
+			fact.Commands = fact.Commands[:MaxCommands]
+		}
 		f.Sessions = append(f.Sessions, fact)
 	}
 	sort.Slice(f.Sessions, func(i, j int) bool { return f.Sessions[i].ID < f.Sessions[j].ID })

--- a/collector/internal/remotefacts/facts.go
+++ b/collector/internal/remotefacts/facts.go
@@ -421,24 +421,24 @@ func FromParsed(vendor, familyID, parserVersion, state, staleReason string, pars
 			spawn := p.Spawns[key]
 			fact.Spawns = append(fact.Spawns, Spawn{Key: key, Turn: cloneInt(spawn.Turn), Completed: spawn.Completed})
 		}
-		for _, command := range p.Commands {
+		n := min(len(p.Commands), MaxCommands)
+		for _, command := range p.Commands[:n] {
 			fact.CommandLabels = append(fact.CommandLabels, truncate(command.Label, MaxDisplayBytes))
 		}
-		fact.Commands = append([]session.SubagentCommand(nil), p.Commands...)
-		// Validate rejects over-limit lists. Keep transcript order and drop the tail
-		// so a command-heavy session still publishes instead of vanishing.
+		fact.Commands = append([]session.SubagentCommand(nil), p.Commands[:n]...)
+		fact.Display.Commands = fact.Display.Commands[:min(len(fact.Display.Commands), MaxCommands)]
 		if len(fact.Usage) > MaxModelsPerSession {
+			if fact.RecordedCostMicros == nil {
+				var total int64
+				for _, usage := range fact.Usage {
+					total += usage.CostMicroUSD
+				}
+				total = min(total, MaxCostMicroUSD)
+				fact.RecordedCostMicros = &total
+			}
 			fact.Usage = fact.Usage[:MaxModelsPerSession]
 		}
-		if len(fact.Spawns) > MaxSpawnsPerSession {
-			fact.Spawns = fact.Spawns[:MaxSpawnsPerSession]
-		}
-		if len(fact.CommandLabels) > MaxCommands {
-			fact.CommandLabels = fact.CommandLabels[:MaxCommands]
-		}
-		if len(fact.Commands) > MaxCommands {
-			fact.Commands = fact.Commands[:MaxCommands]
-		}
+		fact.Spawns = capSpawns(fact.Spawns, parsed, s.ID)
 		f.Sessions = append(f.Sessions, fact)
 	}
 	sort.Slice(f.Sessions, func(i, j int) bool { return f.Sessions[i].ID < f.Sessions[j].ID })
@@ -472,6 +472,33 @@ func FromParsed(vendor, familyID, parserVersion, state, staleReason string, pars
 	}
 	compact(&f)
 	return f, Validate(f)
+}
+
+func capSpawns(spawns []Spawn, parsed []*vendors.ParsedSession, parentID string) []Spawn {
+	if len(spawns) <= MaxSpawnsPerSession {
+		return spawns
+	}
+	need := map[string]bool{}
+	for _, p := range parsed {
+		if p != nil && p.ParentID == parentID && p.SpawnKey != "" {
+			need[p.SpawnKey] = true
+		}
+	}
+	var kept, extra []Spawn
+	for _, spawn := range spawns {
+		if need[spawn.Key] {
+			kept = append(kept, spawn)
+		} else {
+			extra = append(extra, spawn)
+		}
+	}
+	if len(kept) > MaxSpawnsPerSession {
+		kept = kept[:MaxSpawnsPerSession]
+	} else {
+		kept = append(kept, extra[:min(len(extra), MaxSpawnsPerSession-len(kept))]...)
+	}
+	sort.Slice(kept, func(i, j int) bool { return kept[i].Key < kept[j].Key })
+	return kept
 }
 
 func compact(f *Family) {

--- a/collector/internal/remotefacts/facts_test.go
+++ b/collector/internal/remotefacts/facts_test.go
@@ -20,6 +20,31 @@ func validFamily() Family {
 	}
 }
 
+func TestFromParsedCapsCommandLabels(t *testing.T) {
+	commands := make([]session.SubagentCommand, MaxCommands+8)
+	for i := range commands {
+		commands[i] = session.SubagentCommand{Label: "cmd", Command: "true"}
+	}
+	parsed := []*vendors.ParsedSession{{
+		Session:  &session.Session{ID: "root", StartedAt: 1, LastActivityTime: 2},
+		Commands: commands,
+	}}
+	f, err := FromParsed(
+		"codex", "root", "parser-v1", StateComplete, "", parsed,
+		vendors.EmptySessionMetadata(),
+		[]vendors.FileFingerprint{{Key: "opaque", Size: 1, ModifiedAtMs: 2}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(f.Sessions[0].CommandLabels); got != MaxCommands {
+		t.Fatalf("command labels = %d, want %d", got, MaxCommands)
+	}
+	if got := len(f.Sessions[0].Commands); got != MaxCommands {
+		t.Fatalf("commands = %d, want %d", got, MaxCommands)
+	}
+}
+
 func TestFromParsedCompactsOversizedFamily(t *testing.T) {
 	large := strings.Repeat("x", 600<<10)
 	parsed := []*vendors.ParsedSession{

--- a/collector/internal/remotefacts/facts_test.go
+++ b/collector/internal/remotefacts/facts_test.go
@@ -2,6 +2,7 @@ package remotefacts
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -20,28 +21,47 @@ func validFamily() Family {
 	}
 }
 
-func TestFromParsedCapsCommandLabels(t *testing.T) {
-	commands := make([]session.SubagentCommand, MaxCommands+8)
-	for i := range commands {
-		commands[i] = session.SubagentCommand{Label: "cmd", Command: "true"}
+func TestFromParsedCapsOverLimitLists(t *testing.T) {
+	nCmd, nSpawn, nModel := MaxCommands+1, MaxSpawnsPerSession+1, MaxModelsPerSession+1
+	cmds := make([]session.SubagentCommand, nCmd)
+	raw := make([]string, nCmd)
+	spawns := map[string]vendors.SpawnState{}
+	tokens := map[string]session.ModelTokens{}
+	for i := 0; i < nSpawn; i++ {
+		key := fmt.Sprintf("s%03d", i)
+		spawns[key] = vendors.SpawnState{}
+		if i < nCmd {
+			cmds[i] = session.SubagentCommand{Label: "cmd"}
+			raw[i] = "x"
+		}
+		if i < nModel {
+			tokens[key] = session.ModelTokens{Cost: 1}
+		}
 	}
-	parsed := []*vendors.ParsedSession{{
-		Session:  &session.Session{ID: "root", StartedAt: 1, LastActivityTime: 2},
-		Commands: commands,
-	}}
-	f, err := FromParsed(
-		"codex", "root", "parser-v1", StateComplete, "", parsed,
-		vendors.EmptySessionMetadata(),
-		[]vendors.FileFingerprint{{Key: "opaque", Size: 1, ModifiedAtMs: 2}},
-	)
+	last := fmt.Sprintf("s%03d", MaxSpawnsPerSession)
+	f, err := FromParsed("claude", "root", "parser-v1", StateComplete, "", []*vendors.ParsedSession{
+		{Session: &session.Session{ID: "root", StartedAt: 1, LastActivityTime: 2, Tokens: tokens, SessionDetails: session.SessionDetails{Commands: raw}}, Commands: cmds, Spawns: spawns},
+		{Session: &session.Session{ID: "child", StartedAt: 1, LastActivityTime: 2}, ParentID: "root", SpawnKey: last},
+	}, vendors.EmptySessionMetadata(), []vendors.FileFingerprint{{Key: "opaque", Size: 1, ModifiedAtMs: 2}})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := len(f.Sessions[0].CommandLabels); got != MaxCommands {
-		t.Fatalf("command labels = %d, want %d", got, MaxCommands)
+	s := f.Sessions[0]
+	if s.ID != "root" {
+		s = f.Sessions[1]
 	}
-	if got := len(f.Sessions[0].Commands); got != MaxCommands {
-		t.Fatalf("commands = %d, want %d", got, MaxCommands)
+	if len(s.CommandLabels) != MaxCommands || len(s.Commands) != MaxCommands || len(s.Display.Commands) != MaxCommands {
+		t.Fatalf("commands %d %d %d", len(s.CommandLabels), len(s.Commands), len(s.Display.Commands))
+	}
+	if len(s.Usage) != MaxModelsPerSession || s.RecordedCostMicros == nil || *s.RecordedCostMicros != int64(nModel)*1_000_000 {
+		t.Fatalf("usage %d cost %v", len(s.Usage), s.RecordedCostMicros)
+	}
+	kept := false
+	for _, spawn := range s.Spawns {
+		kept = kept || spawn.Key == last
+	}
+	if len(s.Spawns) != MaxSpawnsPerSession || !kept {
+		t.Fatalf("spawns %d kept %v", len(s.Spawns), kept)
 	}
 }
 

--- a/collector/internal/remotehelper/collect.go
+++ b/collector/internal/remotehelper/collect.go
@@ -354,16 +354,20 @@ func familyFacts(
 		present[parsed.Session.ID] = true
 	}
 	if !present[item.id] {
-		return remotefacts.Family{}, errors.New("family root transcript is unavailable")
+		return remotefacts.Family{}, fmt.Errorf("%w: family root transcript is unavailable", vendors.ErrInvalidData)
 	}
 	state := remotefacts.StateComplete
 	if len(sessions) < len(item.sessionIDs) {
 		state = remotefacts.StatePartial
 	}
-	return remotefacts.FromParsed(
+	family, err := remotefacts.FromParsed(
 		scanned.vendor, item.id, vendors.ParserVersion, state, "",
 		sessions, scanned.metadata, item.fingerprints, item.headerMappings,
 	)
+	if err != nil {
+		return remotefacts.Family{}, fmt.Errorf("%w: %v", vendors.ErrInvalidData, err)
+	}
+	return family, nil
 }
 
 // restabilize re-stats a family's files after the parse. Fingerprint equality is

--- a/collector/internal/remotehelper/remotehelper_test.go
+++ b/collector/internal/remotehelper/remotehelper_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/centauri-ai/coslash/collector/internal/remotefacts"
 	"github.com/centauri-ai/coslash/collector/internal/remoteprotocol"
+	"github.com/centauri-ai/coslash/collector/internal/session"
 	"github.com/centauri-ai/coslash/collector/internal/vendors"
 )
 
@@ -124,6 +125,26 @@ func TestEmitterReportsNegotiatedOutputLimit(t *testing.T) {
 	_, err := Collect(context.Background(), request, Options{Home: t.TempDir()}, &output)
 	if !errors.Is(err, ErrRecordLimit) {
 		t.Fatalf("Collect error = %v, want ErrRecordLimit", err)
+	}
+}
+
+func TestFamilyFactsFailureIsInvalidData(t *testing.T) {
+	item := &family{
+		id: "root", sessionIDs: []string{"root"},
+		fingerprints: []vendors.FileFingerprint{{Key: "opaque", Size: 1, ModifiedAtMs: 2}},
+	}
+	scanned := &vendorScan{vendor: "codex", metadata: vendors.EmptySessionMetadata()}
+	_, err := familyFacts(scanned, item, []*vendors.ParsedSession{{
+		Session: &session.Session{ID: "root", StartedAt: 0, LastActivityTime: 2},
+	}})
+	if err == nil {
+		t.Fatal("expected family facts to fail")
+	}
+	if !errors.Is(err, vendors.ErrInvalidData) {
+		t.Fatalf("error = %v, want ErrInvalidData", err)
+	}
+	if got := boundedReason(err); got != remotefacts.StaleReasonInvalidData {
+		t.Fatalf("skip reason = %q, want %q", got, remotefacts.StaleReasonInvalidData)
 	}
 }
 

--- a/collector/internal/remotehelper/remotehelper_test.go
+++ b/collector/internal/remotehelper/remotehelper_test.go
@@ -129,22 +129,12 @@ func TestEmitterReportsNegotiatedOutputLimit(t *testing.T) {
 }
 
 func TestFamilyFactsFailureIsInvalidData(t *testing.T) {
-	item := &family{
+	_, err := familyFacts(&vendorScan{vendor: "codex", metadata: vendors.EmptySessionMetadata()}, &family{
 		id: "root", sessionIDs: []string{"root"},
 		fingerprints: []vendors.FileFingerprint{{Key: "opaque", Size: 1, ModifiedAtMs: 2}},
-	}
-	scanned := &vendorScan{vendor: "codex", metadata: vendors.EmptySessionMetadata()}
-	_, err := familyFacts(scanned, item, []*vendors.ParsedSession{{
-		Session: &session.Session{ID: "root", StartedAt: 0, LastActivityTime: 2},
-	}})
-	if err == nil {
-		t.Fatal("expected family facts to fail")
-	}
-	if !errors.Is(err, vendors.ErrInvalidData) {
-		t.Fatalf("error = %v, want ErrInvalidData", err)
-	}
-	if got := boundedReason(err); got != remotefacts.StaleReasonInvalidData {
-		t.Fatalf("skip reason = %q, want %q", got, remotefacts.StaleReasonInvalidData)
+	}, []*vendors.ParsedSession{{Session: &session.Session{ID: "root"}}})
+	if !errors.Is(err, vendors.ErrInvalidData) || boundedReason(err) != remotefacts.StaleReasonInvalidData {
+		t.Fatalf("error = %v", err)
 	}
 }
 


### PR DESCRIPTION
## Context

Remote collection could skip a valid session when its normalized facts had more command labels than the protocol allows. The helper treated that validation failure as a read error, so the session disappeared from the board with no last-good card.

## Changes

- Truncate over-limit per-session model, spawn, and command lists in transcript order when building remote facts, so the family still publishes.
- Leave Validate as a reject-not-repair gate for helper and cache input.
- Report fact-assembly failures as `invalid_data` instead of `read_failed`.

## Test

- `go test ./internal/remotefacts/` — passed
- `go test ./internal/remotehelper/` — passed
- Manual: rebuilt and upgraded the Linux helper; helper collection published a previously missing command-heavy Codex session.


Made with [Cursor](https://cursor.com)