### PR TITLE
feat(remote): add guided SSH authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ It is **off until you explicitly enable and save it**.
 
 ## Settings and data
 
-Settings live behind the top-right button and are stored machine-wide in `~/.coslash/settings.json` — synthesis backend and model, light or dark theme, the terminal used for local launches (Apple Terminal or iTerm2), and one optional SSH alias. See [`settings.schema.json`](settings.schema.json) for the file format.
+Settings live behind the top-right button and are stored machine-wide in `~/.coslash/settings.json` — synthesis backend and model, light or dark theme, the terminal used for local launches (Apple Terminal or iTerm2), and one optional SSH alias or simple `user@host` destination. See [`settings.schema.json`](settings.schema.json) for the file format.
 
 The dialog offers a short model list per backend, but the model is not restricted to it. Editing `settings.json` directly accepts any model the selected CLI can actually reach — including one served through an API proxy such as `ANTHROPIC_BASE_URL`, or a third-party provider — so long as that CLI is set up to resolve it.
 

--- a/collector/cmd/coslash/api_remote.go
+++ b/collector/cmd/coslash/api_remote.go
@@ -6,8 +6,10 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"os"
 	"time"
 
+	"github.com/centauri-ai/coslash/collector/internal/launch"
 	"github.com/centauri-ai/coslash/collector/internal/remote"
 	"github.com/centauri-ai/coslash/collector/internal/settings"
 )
@@ -20,6 +22,15 @@ type remoteHelperSetupRequest struct {
 	SSHAlias string `json:"sshAlias"`
 	Install  bool   `json:"install"`
 	Upgrade  bool   `json:"upgrade"`
+}
+
+type remoteAuthResponse struct {
+	ID    string           `json:"id"`
+	State remote.AuthState `json:"state"`
+}
+
+func terminalAuthenticationPermitted(health remote.Health) bool {
+	return health.Reason != nil && (*health.Reason == remote.ReasonAuthentication || *health.Reason == remote.ReasonHostKeyConfirmation)
 }
 
 type helperSetupResponse struct {
@@ -76,18 +87,81 @@ func handleRemoteTest(w http.ResponseWriter, request *http.Request, manager *rem
 	var body remoteTestRequest
 	decoder := json.NewDecoder(io.LimitReader(request.Body, 4<<10))
 	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&body); err != nil || !settings.ValidSSHAlias(body.SSHAlias) {
-		http.Error(w, "invalid remote test request", http.StatusBadRequest)
+	if err := decoder.Decode(&body); err != nil || decoder.Decode(&struct{}{}) != io.EOF || !settings.ValidSSHAlias(body.SSHAlias) {
+		writeAPIError(w, http.StatusBadRequest, "invalid_destination", "Enter an SSH alias or user@host.")
 		return
 	}
 	ctx, cancel := context.WithTimeout(request.Context(), remote.DefaultConnectTimeout+5*time.Second)
 	defer cancel()
 	health, err := manager.TestAlias(ctx, body.SSHAlias)
 	if err != nil {
-		http.Error(w, "invalid sshAlias", http.StatusBadRequest)
+		writeAPIError(w, http.StatusBadRequest, "invalid_destination", "Enter an SSH alias or user@host.")
 		return
 	}
 	writeJSON(w, machineFromHealth(health))
+}
+
+func handleRemoteAuthStart(w http.ResponseWriter, request *http.Request, manager *remote.Manager, store *settings.Store) {
+	var body remoteTestRequest
+	decoder := json.NewDecoder(io.LimitReader(request.Body, 4<<10))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&body); err != nil || decoder.Decode(&struct{}{}) != io.EOF || !settings.ValidSSHAlias(body.SSHAlias) {
+		writeAPIError(w, http.StatusBadRequest, "invalid_destination", "Enter an SSH alias or user@host.")
+		return
+	}
+	if remote.AuthAttemptActive(body.SSHAlias) {
+		writeAPIError(w, http.StatusConflict, "authentication_in_progress", "Authentication is already waiting in Terminal.")
+		return
+	}
+	ctx, cancel := context.WithTimeout(request.Context(), remote.DefaultConnectTimeout+5*time.Second)
+	defer cancel()
+	health, err := manager.TestAlias(ctx, body.SSHAlias)
+	if err != nil || !terminalAuthenticationPermitted(health) {
+		writeAPIError(w, http.StatusConflict, "authentication_not_required", "Terminal authentication is not required for this host.")
+		return
+	}
+	id, err := remote.CreateAuthAttempt(body.SSHAlias)
+	if errors.Is(err, remote.ErrAuthAttemptActive) {
+		writeAPIError(w, http.StatusConflict, "authentication_in_progress", "Authentication is already waiting in Terminal.")
+		return
+	}
+	if err != nil {
+		writeAPIError(w, http.StatusInternalServerError, "authentication_unavailable", "Could not prepare terminal authentication.")
+		return
+	}
+	executable, err := os.Executable()
+	if err == nil {
+		err = launch.SSHAuthentication(store.State().Config.Launch.Terminal, executable, id)
+	}
+	if err != nil {
+		_ = remote.CancelAuthAttempt(id)
+		writeAPIError(w, http.StatusConflict, "terminal_unavailable", "Could not open the selected terminal for SSH authentication.")
+		return
+	}
+	writeJSON(w, remoteAuthResponse{ID: id, State: remote.AuthWaiting})
+}
+
+func handleRemoteAuthStatus(w http.ResponseWriter, request *http.Request) {
+	id := request.URL.Query().Get("id")
+	state, err := remote.AuthAttemptState(request.Context(), id)
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, "invalid_authentication_attempt", "Authentication attempt is unavailable.")
+		return
+	}
+	writeJSON(w, remoteAuthResponse{ID: id, State: state})
+}
+
+func handleRemoteAuthCancel(w http.ResponseWriter, request *http.Request) {
+	var body struct {
+		ID string `json:"id"`
+	}
+	decoder := json.NewDecoder(io.LimitReader(request.Body, 4<<10))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&body); err != nil || decoder.Decode(&struct{}{}) != io.EOF || remote.CancelAuthAttempt(body.ID) != nil {
+		writeAPIError(w, http.StatusBadRequest, "invalid_authentication_attempt", "Authentication attempt is unavailable.")
+		return
+	}
+	writeJSON(w, remoteAuthResponse{ID: body.ID, State: remote.AuthCancelled})
 }
 
 func handleRemoteRetry(w http.ResponseWriter, _ *http.Request, manager *remote.Manager) {

--- a/collector/cmd/coslash/api_remote_test.go
+++ b/collector/cmd/coslash/api_remote_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/centauri-ai/coslash/collector/internal/remote"
+)
+
+func TestTerminalAuthenticationPermittedRejectsChangedHostKey(t *testing.T) {
+	changed := remote.ReasonHostKeyChanged
+	if terminalAuthenticationPermitted(remote.Health{Reason: &changed}) {
+		t.Fatal("changed host key was accepted for terminal authentication")
+	}
+	confirmation := remote.ReasonHostKeyConfirmation
+	if !terminalAuthenticationPermitted(remote.Health{Reason: &confirmation}) {
+		t.Fatal("unknown host key was rejected for terminal confirmation")
+	}
+	authentication := remote.ReasonAuthentication
+	if !terminalAuthenticationPermitted(remote.Health{Reason: &authentication}) {
+		t.Fatal("authentication failure was rejected")
+	}
+}
+
+func TestMachineAuthenticationContract(t *testing.T) {
+	reason := remote.ReasonAuthentication
+	machine := machineFromHealth(remote.Health{Label: "agent-box", State: remote.StateStale, Reason: &reason})
+	if machine.ActionRequired != remote.ActionAuthenticate || machine.AuthState != remote.AuthRequired {
+		t.Fatalf("authentication contract = %q/%q", machine.ActionRequired, machine.AuthState)
+	}
+	changed := remote.ReasonHostKeyChanged
+	machine = machineFromHealth(remote.Health{Label: "agent-box", State: remote.StateError, Reason: &changed})
+	if machine.ActionRequired != remote.ActionVerifyHostKey || machine.AuthState != remote.AuthNotRequired {
+		t.Fatalf("changed-key contract = %q/%q", machine.ActionRequired, machine.AuthState)
+	}
+}

--- a/collector/cmd/coslash/api_source.go
+++ b/collector/cmd/coslash/api_source.go
@@ -60,6 +60,8 @@ type machineFact struct {
 	State                       remote.State             `json:"state"`
 	Complete                    bool                     `json:"complete"`
 	Reason                      *remote.Reason           `json:"reason,omitempty"`
+	ActionRequired              remote.ActionRequired    `json:"actionRequired,omitempty"`
+	AuthState                   remote.AuthState         `json:"authState"`
 	LastSuccessAtMs             *int64                   `json:"lastSuccessAtMs,omitempty"`
 	LastCheckedAtMs             *int64                   `json:"lastCheckedAtMs,omitempty"`
 	SessionCount                int                      `json:"sessionCount"`
@@ -78,13 +80,15 @@ type machineFact struct {
 }
 
 func localMachineFact() machineFact {
-	return machineFact{SourceID: localSourceID, Label: localSourceLabel, State: remote.StateOK, Complete: true}
+	return machineFact{SourceID: localSourceID, Label: localSourceLabel, State: remote.StateOK, Complete: true, AuthState: remote.AuthNotRequired}
 }
 
 func machineFromHealth(health remote.Health) machineFact {
+	health = remote.WithAuthenticationStatus(health)
 	return machineFact{
 		SourceID: health.SourceID, Label: safeSourceLabel(health.SourceID), State: health.State,
 		Complete: health.Complete, Reason: health.Reason,
+		ActionRequired: health.ActionRequired, AuthState: health.AuthState,
 		LastSuccessAtMs: health.LastSuccessAtMs, LastCheckedAtMs: health.LastCheckedAtMs,
 		SessionCount: health.SessionCount, CoverageSinceMs: health.CoverageSinceMs,
 		RoundTripMs: health.RoundTripMs, Coverage: health.Coverage, Error: health.Error,

--- a/collector/cmd/coslash/main.go
+++ b/collector/cmd/coslash/main.go
@@ -65,6 +65,23 @@ func parseOptions(arguments []string) (options, error) {
 }
 
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "ssh-auth" {
+		if len(os.Args) != 3 {
+			log.Fatal("coslash ssh-auth requires one attempt ID")
+		}
+		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
+		defer stop()
+		if err := remote.RunAuthAttempt(ctx, os.Args[2]); err != nil {
+			if errors.Is(ctx.Err(), context.Canceled) {
+				fmt.Fprintln(os.Stderr, "SSH authentication cancelled; return to coSlash.")
+			} else {
+				fmt.Fprintln(os.Stderr, "SSH authentication did not complete; return to coSlash and try again.")
+			}
+			return
+		}
+		fmt.Println("SSH authentication ready; return to coSlash.")
+		return
+	}
 	if len(os.Args) > 1 && os.Args[1] == "doctor" {
 		os.Exit(runDoctor(os.Stdout, os.Stderr, os.Args[2:]))
 	}
@@ -218,6 +235,11 @@ func routes(
 	api.HandleFunc("POST /api/remote/test", func(w http.ResponseWriter, r *http.Request) {
 		handleRemoteTest(w, r, remoteManager)
 	})
+	api.HandleFunc("POST /api/remote/auth/start", func(w http.ResponseWriter, r *http.Request) {
+		handleRemoteAuthStart(w, r, remoteManager, settingsStore)
+	})
+	api.HandleFunc("GET /api/remote/auth/status", handleRemoteAuthStatus)
+	api.HandleFunc("POST /api/remote/auth/cancel", handleRemoteAuthCancel)
 	api.HandleFunc("POST /api/remote/retry", func(w http.ResponseWriter, r *http.Request) {
 		handleRemoteRetry(w, r, remoteManager)
 	})

--- a/collector/internal/launch/launch.go
+++ b/collector/internal/launch/launch.go
@@ -69,7 +69,8 @@ func Terminal(terminal, agent, workingDirectory, sessionID, mode, handoff string
 // RemoteTerminal opens the selected local terminal and runs an agent CLI on a
 // configured SSH host.
 func RemoteTerminal(terminal, alias, agent, workingDirectory, sessionID, mode, handoff string) error {
-	if alias == "" {
+	destination, err := settings.ParseSSHDestination(alias)
+	if err != nil {
 		return errors.New("launch: SSH alias is required")
 	}
 	if workingDirectory == "" {
@@ -80,7 +81,19 @@ func RemoteTerminal(terminal, alias, agent, workingDirectory, sessionID, mode, h
 		return err
 	}
 	remoteCommand := "cd " + shellQuote(workingDirectory) + " && " + command
-	return openTerminal(terminal, ".", shellJoin("ssh", "-tt", alias, remoteCommand))
+	args := append([]string{"ssh", "-tt"}, destination.Args()...)
+	args = append(args, remoteCommand)
+	return openTerminal(terminal, ".", shellJoin(args...))
+}
+
+// SSHAuthentication opens the selected terminal with a fixed coSlash command.
+// The opaque attempt ID resolves to locally stored, validated argv in the
+// ssh-auth subcommand; destination text is never interpolated into this shell.
+func SSHAuthentication(terminal, executable, attemptID string) error {
+	if executable == "" || attemptID == "" {
+		return errors.New("launch: authentication command is required")
+	}
+	return openTerminal(terminal, ".", shellJoin("env", "COSLASH_HOME="+settings.Home(), executable, "ssh-auth", attemptID))
 }
 
 func openTerminal(terminal, workingDirectory, command string) error {

--- a/collector/internal/remote/auth.go
+++ b/collector/internal/remote/auth.go
@@ -178,20 +178,9 @@ func CancelAuthAttempt(id string) error {
 	}
 	_, err = updateAuthAttemptIfWaiting(id, AuthCancelled)
 	if err == nil {
-		removeAuthAttempt(id)
 		exitAuthControlMaster(attempt.Destination)
 	}
 	return err
-}
-
-// removeAuthAttempt removes only the validated record path. The single
-// coordinator lock is retained because unlinking a live advisory lock could
-// let another process create a different inode and bypass synchronization.
-func removeAuthAttempt(id string) {
-	path, err := authAttemptPath(id)
-	if err == nil {
-		_ = os.Remove(path)
-	}
 }
 
 // CancelAuthAttemptsForDestination prevents a removed host from gaining a
@@ -216,7 +205,10 @@ func CancelAuthAttemptsForDestination(destination string) {
 			if _, err := authAttemptPath(attempt.ID); err != nil {
 				continue
 			}
-			removeAuthAttempt(attempt.ID)
+			attempt.State = AuthCancelled
+			if err := writeAuthAttempt(attempt); err != nil {
+				return err
+			}
 			removed = true
 		}
 		return nil
@@ -334,6 +326,12 @@ func RunAuthAttempt(ctx context.Context, id string) error {
 		if err != nil {
 			return err
 		}
+		if latest.State == AuthReady {
+			// A status poll may see the new socket before this terminal process
+			// reacquires the coordinator. That is a successful attempt, not a
+			// cancellation, so the shared master must remain available.
+			return nil
+		}
 		if latest.State != AuthWaiting {
 			closeMaster = true
 			return nil
@@ -360,7 +358,6 @@ func AuthAttemptState(ctx context.Context, id string) (AuthState, error) {
 		return "", err
 	}
 	if attempt.State != AuthWaiting {
-		removeAuthAttempt(id)
 		return attempt.State, nil
 	}
 	if time.Since(attempt.CreatedAt) > AuthAttemptTTL {
@@ -368,7 +365,6 @@ func AuthAttemptState(ctx context.Context, id string) (AuthState, error) {
 		if updateErr != nil {
 			return "", updateErr
 		}
-		removeAuthAttempt(id)
 		return state, nil
 	}
 	args, err := controlCheckArgs(attempt.Destination)
@@ -382,7 +378,6 @@ func AuthAttemptState(ctx context.Context, id string) (AuthState, error) {
 		if updateErr != nil {
 			return "", updateErr
 		}
-		removeAuthAttempt(id)
 		return state, nil
 	}
 	return AuthWaiting, nil

--- a/collector/internal/remote/auth.go
+++ b/collector/internal/remote/auth.go
@@ -1,0 +1,389 @@
+package remote
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"syscall"
+	"time"
+
+	"github.com/centauri-ai/coslash/collector/internal/settings"
+)
+
+const AuthAttemptTTL = 5 * time.Minute
+
+var authAttemptIDPattern = regexp.MustCompile(`^[0-9a-f]{32}$`)
+
+var ErrAuthAttemptActive = errors.New("authentication attempt already active")
+
+type AuthState string
+
+const (
+	AuthNotRequired AuthState = "not_required"
+	AuthRequired    AuthState = "required"
+	AuthLaunching   AuthState = "launching"
+	AuthWaiting     AuthState = "waiting"
+	AuthReady       AuthState = "ready"
+	AuthTimedOut    AuthState = "timed_out"
+	AuthCancelled   AuthState = "cancelled"
+	AuthFailed      AuthState = "failed"
+)
+
+type authAttempt struct {
+	ID          string    `json:"id"`
+	Destination string    `json:"destination"`
+	CreatedAt   time.Time `json:"createdAt"`
+	State       AuthState `json:"state"`
+}
+
+func authAttemptPath(id string) (string, error) {
+	if !authAttemptIDPattern.MatchString(id) {
+		return "", errors.New("invalid authentication attempt")
+	}
+	return filepath.Join(settings.Home(), "ssh", "auth-"+id+".json"), nil
+}
+
+func createAuthAttempt(destination string) (string, error) {
+	if _, err := parseDestination(destination); err != nil {
+		return "", err
+	}
+	var id string
+	err := withDestinationCoordinator(destination, func() error {
+		entries, err := filepath.Glob(filepath.Join(settings.Home(), "ssh", "auth-*.json"))
+		if err != nil {
+			return err
+		}
+		for _, path := range entries {
+			data, readErr := os.ReadFile(path)
+			var existing authAttempt
+			if readErr != nil || json.Unmarshal(data, &existing) != nil || time.Since(existing.CreatedAt) > AuthAttemptTTL {
+				_ = os.Remove(path)
+				continue
+			}
+			if existing.Destination == destination && existing.State == AuthWaiting {
+				return ErrAuthAttemptActive
+			}
+		}
+		raw := make([]byte, 16)
+		if _, err := rand.Read(raw); err != nil {
+			return fmt.Errorf("generate authentication attempt: %w", err)
+		}
+		id = hex.EncodeToString(raw)
+		path, err := authAttemptPath(id)
+		if err != nil {
+			return err
+		}
+		data, err := json.Marshal(authAttempt{ID: id, Destination: destination, CreatedAt: time.Now().UTC(), State: AuthWaiting})
+		if err != nil {
+			return err
+		}
+		file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+		if err != nil {
+			return fmt.Errorf("create authentication attempt: %w", err)
+		}
+		if _, err := file.Write(data); err != nil {
+			_ = file.Close()
+			_ = os.Remove(path)
+			return fmt.Errorf("write authentication attempt: %w", err)
+		}
+		if err := file.Close(); err != nil {
+			_ = os.Remove(path)
+			return fmt.Errorf("close authentication attempt: %w", err)
+		}
+		return nil
+	})
+	return id, err
+}
+
+// withDestinationCoordinator serializes an interactive attempt with every
+// control-master check/start. The single lock is stronger than a per-
+// destination lock, and avoids leaving a new lock file for every attempted
+// destination. flock is released by the kernel if a process exits.
+func withDestinationCoordinator(_ string, callback func() error) error {
+	if err := ensureSSHControlDir(); err != nil {
+		return err
+	}
+	lockPath := filepath.Join(settings.Home(), "ssh", ".auth-coordinator.lock")
+	lock, err := os.OpenFile(lockPath, os.O_WRONLY|os.O_CREATE, 0o600)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = lock.Close() }()
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
+		return fmt.Errorf("lock SSH destination: %w", err)
+	}
+	defer func() { _ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN) }()
+	return callback()
+}
+
+var runInteractiveSSH = func(ctx context.Context, args []string) error {
+	cmd := exec.CommandContext(ctx, "ssh", args...)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	return cmd.Run()
+}
+
+var exitAuthControlMaster = exitControlMasterBestEffort
+
+func loadAuthAttempt(id string) (authAttempt, error) {
+	path, err := authAttemptPath(id)
+	if err != nil {
+		return authAttempt{}, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return authAttempt{}, err
+	}
+	var attempt authAttempt
+	if err := json.Unmarshal(data, &attempt); err != nil || attempt.ID != id {
+		return authAttempt{}, errors.New("invalid authentication attempt")
+	}
+	if _, err := parseDestination(attempt.Destination); err != nil {
+		return authAttempt{}, errors.New("invalid authentication destination")
+	}
+	return attempt, nil
+}
+
+// CreateAuthAttempt records only the already-validated destination in a
+// mode-0600, short-lived local file. The terminal receives only its opaque ID.
+func CreateAuthAttempt(destination string) (string, error) { return createAuthAttempt(destination) }
+
+// AuthAttemptActive is used by background work to avoid racing an explicit
+// terminal prompt. Corrupt and expired records are not considered active.
+func AuthAttemptActive(destination string) bool {
+	entries, err := filepath.Glob(filepath.Join(settings.Home(), "ssh", "auth-*.json"))
+	if err != nil {
+		return false
+	}
+	for _, path := range entries {
+		data, err := os.ReadFile(path)
+		var attempt authAttempt
+		if err == nil && json.Unmarshal(data, &attempt) == nil && attempt.Destination == destination && attempt.State == AuthWaiting && time.Since(attempt.CreatedAt) <= AuthAttemptTTL {
+			return true
+		}
+	}
+	return false
+}
+
+func CancelAuthAttempt(id string) error {
+	attempt, err := loadAuthAttempt(id)
+	if err != nil {
+		return err
+	}
+	_, err = updateAuthAttemptIfWaiting(id, AuthCancelled)
+	if err == nil {
+		removeAuthAttempt(id)
+		exitAuthControlMaster(attempt.Destination)
+	}
+	return err
+}
+
+// removeAuthAttempt removes only the validated record path. The single
+// coordinator lock is retained because unlinking a live advisory lock could
+// let another process create a different inode and bypass synchronization.
+func removeAuthAttempt(id string) {
+	path, err := authAttemptPath(id)
+	if err == nil {
+		_ = os.Remove(path)
+	}
+}
+
+// CancelAuthAttemptsForDestination prevents a removed host from gaining a
+// late interactive master. The terminal command re-checks its record under
+// this same destination coordinator before treating SSH success as ready.
+func CancelAuthAttemptsForDestination(destination string) {
+	if destination == "" {
+		return
+	}
+	removed := false
+	_ = withDestinationCoordinator(destination, func() error {
+		entries, err := filepath.Glob(filepath.Join(settings.Home(), "ssh", "auth-*.json"))
+		if err != nil {
+			return err
+		}
+		for _, path := range entries {
+			data, err := os.ReadFile(path)
+			var attempt authAttempt
+			if err != nil || json.Unmarshal(data, &attempt) != nil || attempt.Destination != destination {
+				continue
+			}
+			if _, err := authAttemptPath(attempt.ID); err != nil {
+				continue
+			}
+			removeAuthAttempt(attempt.ID)
+			removed = true
+		}
+		return nil
+	})
+	if removed {
+		exitAuthControlMaster(destination)
+	}
+}
+
+// updateAuthAttemptIfWaiting preserves a terminal result chosen by another
+// process (for example, Cancel in the app racing a terminal SSH failure).
+func updateAuthAttemptIfWaiting(id string, state AuthState) (AuthState, error) {
+	initial, err := loadAuthAttempt(id)
+	if err != nil {
+		return "", err
+	}
+	var result AuthState
+	err = withDestinationCoordinator(initial.Destination, func() error {
+		attempt, err := loadAuthAttempt(id)
+		if err != nil {
+			return err
+		}
+		if attempt.State != AuthWaiting {
+			result = attempt.State
+			return nil
+		}
+		attempt.State = state
+		if err := writeAuthAttempt(attempt); err != nil {
+			return err
+		}
+		result = state
+		return nil
+	})
+	return result, err
+}
+
+func writeAuthAttempt(attempt authAttempt) error {
+	path, err := authAttemptPath(attempt.ID)
+	if err != nil {
+		return err
+	}
+	data, err := json.Marshal(attempt)
+	if err != nil {
+		return err
+	}
+	temporary, err := os.CreateTemp(filepath.Dir(path), ".auth-*")
+	if err != nil {
+		return err
+	}
+	if err := temporary.Chmod(0o600); err == nil {
+		_, err = temporary.Write(data)
+	}
+	if closeErr := temporary.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		_ = os.Remove(temporary.Name())
+		return err
+	}
+	return os.Rename(temporary.Name(), path)
+}
+
+func interactiveMasterArgs(destination string) ([]string, error) {
+	parsed, err := parseDestination(destination)
+	if err != nil {
+		return nil, err
+	}
+	args := []string{
+		"-f", "-N",
+		"-o", "BatchMode=no",
+		"-o", "ConnectTimeout=" + fmt.Sprint(int(DefaultConnectTimeout.Seconds())),
+		"-o", "ControlMaster=yes",
+		"-o", "ControlPath=" + controlSocketPath(),
+		"-o", "ControlPersist=" + defaultControlPersist,
+	}
+	return append(args, parsed.Args()...), nil
+}
+
+// RunAuthAttempt is the ssh-auth subcommand entry point. Its stdin and output
+// belong to the terminal, never to the collector HTTP process.
+func RunAuthAttempt(ctx context.Context, id string) error {
+	attempt, err := loadAuthAttempt(id)
+	if err != nil {
+		return err
+	}
+	if time.Since(attempt.CreatedAt) > AuthAttemptTTL {
+		_, _ = updateAuthAttemptIfWaiting(id, AuthTimedOut)
+		return errors.New("authentication attempt expired")
+	}
+	deadline := attempt.CreatedAt.Add(AuthAttemptTTL)
+	ctx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+	args, err := interactiveMasterArgs(attempt.Destination)
+	if err != nil {
+		return err
+	}
+	if err := runInteractiveSSH(ctx, args); err != nil {
+		state := AuthFailed
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			state = AuthTimedOut
+		}
+		if errors.Is(ctx.Err(), context.Canceled) {
+			state = AuthCancelled
+		}
+		_, _ = updateAuthAttemptIfWaiting(id, state)
+		return fmt.Errorf("authenticate SSH: %w", err)
+	}
+	closeMaster := false
+	err = withDestinationCoordinator(attempt.Destination, func() error {
+		latest, err := loadAuthAttempt(id)
+		if errors.Is(err, os.ErrNotExist) {
+			closeMaster = true
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if latest.State != AuthWaiting {
+			closeMaster = true
+			return nil
+		}
+		latest.State = AuthReady
+		return writeAuthAttempt(latest)
+	})
+	if err != nil {
+		return fmt.Errorf("record SSH authentication: %w", err)
+	}
+	if closeMaster {
+		exitAuthControlMaster(attempt.Destination)
+		return errors.New("authentication attempt was cancelled")
+	}
+	return nil
+}
+
+func AuthAttemptState(ctx context.Context, id string) (AuthState, error) {
+	attempt, err := loadAuthAttempt(id)
+	if errors.Is(err, os.ErrNotExist) {
+		return AuthCancelled, nil
+	}
+	if err != nil {
+		return "", err
+	}
+	if attempt.State != AuthWaiting {
+		removeAuthAttempt(id)
+		return attempt.State, nil
+	}
+	if time.Since(attempt.CreatedAt) > AuthAttemptTTL {
+		state, updateErr := updateAuthAttemptIfWaiting(id, AuthTimedOut)
+		if updateErr != nil {
+			return "", updateErr
+		}
+		removeAuthAttempt(id)
+		return state, nil
+	}
+	args, err := controlCheckArgs(attempt.Destination)
+	if err != nil {
+		return "", err
+	}
+	checkCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	if err := runSSHCommand(checkCtx, OpenOptions{}, args); err == nil {
+		state, updateErr := updateAuthAttemptIfWaiting(id, AuthReady)
+		if updateErr != nil {
+			return "", updateErr
+		}
+		removeAuthAttempt(id)
+		return state, nil
+	}
+	return AuthWaiting, nil
+}

--- a/collector/internal/remote/auth_test.go
+++ b/collector/internal/remote/auth_test.go
@@ -162,6 +162,32 @@ func TestRunAuthAttemptClosesMasterAfterCancellation(t *testing.T) {
 	}
 }
 
+func TestRunAuthAttemptKeepsMasterWhenStatusAlreadyMarkedReady(t *testing.T) {
+	t.Setenv("COSLASH_HOME", t.TempDir())
+	originalRun := runInteractiveSSH
+	originalExit := exitAuthControlMaster
+	t.Cleanup(func() {
+		runInteractiveSSH = originalRun
+		exitAuthControlMaster = originalExit
+	})
+	id, err := CreateAuthAttempt("agent-box")
+	if err != nil {
+		t.Fatal(err)
+	}
+	exited := false
+	exitAuthControlMaster = func(string) { exited = true }
+	runInteractiveSSH = func(context.Context, []string) error {
+		_, err := updateAuthAttemptIfWaiting(id, AuthReady)
+		return err
+	}
+	if err := RunAuthAttempt(context.Background(), id); err != nil {
+		t.Fatalf("RunAuthAttempt: %v", err)
+	}
+	if exited {
+		t.Fatal("successful master was closed after status marked the attempt ready")
+	}
+}
+
 func TestDestinationCoordinatorCoversControlMasterStart(t *testing.T) {
 	t.Setenv("COSLASH_HOME", t.TempDir())
 	startedMaster := make(chan struct{})

--- a/collector/internal/remote/auth_test.go
+++ b/collector/internal/remote/auth_test.go
@@ -1,0 +1,250 @@
+package remote
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/centauri-ai/coslash/collector/internal/settings"
+)
+
+func TestInteractiveMasterArgsUseStructuredDestination(t *testing.T) {
+	args, err := interactiveMasterArgs("jane@devvm1872.cln0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index := range args {
+		if args[index] == "BatchMode=yes" {
+			t.Fatal("interactive authentication must not set BatchMode")
+		}
+	}
+	foundBatchModeOverride := false
+	for index := 0; index+1 < len(args); index++ {
+		if args[index] == "-o" && args[index+1] == "BatchMode=no" {
+			foundBatchModeOverride = true
+		}
+	}
+	if !foundBatchModeOverride {
+		t.Fatal("interactive authentication must override a BatchMode=yes SSH config")
+	}
+	found := false
+	for index := 0; index+2 < len(args); index++ {
+		if args[index] == "-l" && args[index+1] == "jane" && args[index+2] == "devvm1872.cln0" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("args = %#v, want structured -l user host", args)
+	}
+}
+
+func TestAuthAttemptCancelAndInvalidID(t *testing.T) {
+	t.Setenv("COSLASH_HOME", t.TempDir())
+	id, err := CreateAuthAttempt("agent-box")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := CancelAuthAttempt(id); err != nil {
+		t.Fatal(err)
+	}
+	if state, err := AuthAttemptState(context.Background(), id); err != nil || state != AuthCancelled {
+		t.Fatalf("cancelled state = %q, %v", state, err)
+	}
+	if err := CancelAuthAttempt("not-an-id"); err == nil {
+		t.Fatal("invalid ID accepted")
+	}
+}
+
+func TestCreateAuthAttemptAllowsOnlyOneWaitingAttempt(t *testing.T) {
+	t.Setenv("COSLASH_HOME", t.TempDir())
+	const requests = 12
+	var group sync.WaitGroup
+	results := make(chan error, requests)
+	for range requests {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			_, err := CreateAuthAttempt("agent-box")
+			results <- err
+		}()
+	}
+	group.Wait()
+	close(results)
+	winners := 0
+	for err := range results {
+		if err == nil {
+			winners++
+			continue
+		}
+		if !errors.Is(err, ErrAuthAttemptActive) {
+			t.Fatalf("CreateAuthAttempt error = %v, want ErrAuthAttemptActive", err)
+		}
+	}
+	if winners != 1 {
+		t.Fatalf("successful attempts = %d, want 1", winners)
+	}
+	if !AuthAttemptActive("agent-box") {
+		t.Fatal("waiting attempt was not reported active")
+	}
+}
+
+func TestRunAuthAttemptRecordsTerminalOutcomes(t *testing.T) {
+	t.Setenv("COSLASH_HOME", t.TempDir())
+	original := runInteractiveSSH
+	t.Cleanup(func() { runInteractiveSSH = original })
+
+	runInteractiveSSH = func(context.Context, []string) error { return errors.New("bad password") }
+	id, err := CreateAuthAttempt("agent-box")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := RunAuthAttempt(context.Background(), id); err == nil {
+		t.Fatal("RunAuthAttempt succeeded")
+	}
+	if state, err := AuthAttemptState(context.Background(), id); err != nil || state != AuthFailed {
+		t.Fatalf("failure state = %q, %v", state, err)
+	}
+
+	runInteractiveSSH = func(ctx context.Context, _ []string) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	id, err = CreateAuthAttempt("agent-box")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := RunAuthAttempt(ctx, id); err == nil {
+		t.Fatal("cancelled RunAuthAttempt succeeded")
+	}
+	if state, err := AuthAttemptState(context.Background(), id); err != nil || state != AuthCancelled {
+		t.Fatalf("cancelled state = %q, %v", state, err)
+	}
+}
+
+func TestRunAuthAttemptClosesMasterAfterCancellation(t *testing.T) {
+	t.Setenv("COSLASH_HOME", t.TempDir())
+	originalRun := runInteractiveSSH
+	originalExit := exitAuthControlMaster
+	t.Cleanup(func() {
+		runInteractiveSSH = originalRun
+		exitAuthControlMaster = originalExit
+	})
+	id, err := CreateAuthAttempt("agent-box")
+	if err != nil {
+		t.Fatal(err)
+	}
+	closed := make(chan string, 2)
+	exitAuthControlMaster = func(destination string) { closed <- destination }
+	runInteractiveSSH = func(context.Context, []string) error {
+		if err := CancelAuthAttempt(id); err != nil {
+			t.Errorf("CancelAuthAttempt: %v", err)
+		}
+		return nil
+	}
+	if err := RunAuthAttempt(context.Background(), id); err == nil {
+		t.Fatal("cancelled attempt was reported ready")
+	}
+	for range 2 {
+		select {
+		case destination := <-closed:
+			if destination != "agent-box" {
+				t.Fatalf("closed %q, want agent-box", destination)
+			}
+		default:
+			t.Fatal("late master was not closed")
+		}
+	}
+}
+
+func TestDestinationCoordinatorCoversControlMasterStart(t *testing.T) {
+	t.Setenv("COSLASH_HOME", t.TempDir())
+	startedMaster := make(chan struct{})
+	var once sync.Once
+	command := func(ctx context.Context, _ string, args ...string) *exec.Cmd {
+		for _, arg := range args {
+			if arg == "ControlMaster=yes" {
+				once.Do(func() { close(startedMaster) })
+				return exec.CommandContext(ctx, "sleep", "0.12")
+			}
+		}
+		return exec.CommandContext(ctx, "false")
+	}
+	ensureDone := make(chan error, 1)
+	go func() {
+		ensureDone <- ensureControlMaster(context.Background(), "agent-box", OpenOptions{command: command})
+	}()
+	select {
+	case <-startedMaster:
+	case <-time.After(time.Second):
+		t.Fatal("control master did not start")
+	}
+	created := make(chan error, 1)
+	go func() {
+		_, err := CreateAuthAttempt("agent-box")
+		created <- err
+	}()
+	select {
+	case err := <-created:
+		t.Fatalf("attempt creation raced control-master startup: %v", err)
+	case <-time.After(30 * time.Millisecond):
+	}
+	if err := <-ensureDone; err != nil {
+		t.Fatalf("ensureControlMaster: %v", err)
+	}
+	if err := <-created; err != nil {
+		t.Fatalf("CreateAuthAttempt: %v", err)
+	}
+	locks, err := filepath.Glob(filepath.Join(settings.Home(), "ssh", "auth-*.json.lock"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(locks) != 0 {
+		t.Fatalf("per-attempt lock files remain: %v", locks)
+	}
+}
+
+func TestAuthenticationStatusKeepsChangedHostKeyOutOfTerminalFlow(t *testing.T) {
+	changed := WithAuthenticationStatus(Health{Label: "agent-box", Reason: reasonPtr(ReasonHostKeyChanged)})
+	if changed.ActionRequired != ActionVerifyHostKey || changed.AuthState != AuthNotRequired {
+		t.Fatalf("changed key action/state = %q/%q", changed.ActionRequired, changed.AuthState)
+	}
+	required := WithAuthenticationStatus(Health{Label: "agent-box", Reason: reasonPtr(ReasonHostKeyConfirmation)})
+	if required.ActionRequired != ActionAuthenticate || required.AuthState != AuthRequired {
+		t.Fatalf("confirmation action/state = %q/%q", required.ActionRequired, required.AuthState)
+	}
+}
+
+func TestWaitingAuthenticationSuppressesRefreshAndControlMaster(t *testing.T) {
+	t.Setenv("COSLASH_HOME", t.TempDir())
+	if _, err := CreateAuthAttempt("agent-box"); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureControlMaster(context.Background(), "agent-box", OpenOptions{}); !errors.Is(err, ErrAuthAttemptActive) {
+		t.Fatalf("ensureControlMaster error = %v, want ErrAuthAttemptActive", err)
+	}
+	var started int
+	manager := NewManager(Options{
+		Cache: NewCache(t.TempDir()),
+		Refresh: func(context.Context, string, int64, time.Time, CachedSnapshotV2) (refreshOutcome, error) {
+			started++
+			return refreshOutcome{}, nil
+		},
+	})
+	if err := manager.ApplySettings(&settings.RemoteSettings{ID: "r_0123456789abcdef", SSHAlias: "agent-box", Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	manager.ListView(0)
+	time.Sleep(30 * time.Millisecond)
+	if started != 0 {
+		t.Fatalf("background refreshes = %d, want 0 while authentication waits", started)
+	}
+	if _, started := manager.Retry(); started {
+		t.Fatal("manual retry reported a refresh while authentication waits")
+	}
+}

--- a/collector/internal/remote/health.go
+++ b/collector/internal/remote/health.go
@@ -18,21 +18,29 @@ const (
 
 type Reason string
 
+type ActionRequired string
+
 const (
-	ReasonInitialRefresh   Reason = "initial_refresh"
-	ReasonBroaderHistory   Reason = "broader_history"
-	ReasonHistoryTruncated Reason = "history_truncated"
-	ReasonRefreshTimeout   Reason = "refresh_timeout"
-	ReasonAuthentication   Reason = "authentication_failed"
-	ReasonHostKey          Reason = "host_key_failed"
-	ReasonConnectionFailed Reason = "connection_failed"
-	ReasonSFTPUnavailable  Reason = "sftp_unavailable"
-	ReasonPermissionDenied Reason = "permission_denied"
-	ReasonNoSupportedData  Reason = "no_supported_data"
-	ReasonPartialAgentData Reason = "partial_agent_data"
-	ReasonInvalidData      Reason = "invalid_remote_data"
-	ReasonLocalCacheFailed Reason = "local_cache_failed"
-	ReasonDisabled         Reason = "disabled"
+	ActionAuthenticate  ActionRequired = "authenticate"
+	ActionVerifyHostKey ActionRequired = "verify_host_key"
+)
+
+const (
+	ReasonInitialRefresh      Reason = "initial_refresh"
+	ReasonBroaderHistory      Reason = "broader_history"
+	ReasonHistoryTruncated    Reason = "history_truncated"
+	ReasonRefreshTimeout      Reason = "refresh_timeout"
+	ReasonAuthentication      Reason = "authentication_failed"
+	ReasonHostKeyConfirmation Reason = "host_key_confirmation_required"
+	ReasonHostKeyChanged      Reason = "host_key_changed"
+	ReasonConnectionFailed    Reason = "connection_failed"
+	ReasonSFTPUnavailable     Reason = "sftp_unavailable"
+	ReasonPermissionDenied    Reason = "permission_denied"
+	ReasonNoSupportedData     Reason = "no_supported_data"
+	ReasonPartialAgentData    Reason = "partial_agent_data"
+	ReasonInvalidData         Reason = "invalid_remote_data"
+	ReasonLocalCacheFailed    Reason = "local_cache_failed"
+	ReasonDisabled            Reason = "disabled"
 )
 
 type Health struct {
@@ -41,6 +49,8 @@ type Health struct {
 	State                       State             `json:"state"`
 	Complete                    bool              `json:"complete"`
 	Reason                      *Reason           `json:"reason,omitempty"`
+	ActionRequired              ActionRequired    `json:"actionRequired,omitempty"`
+	AuthState                   AuthState         `json:"authState"`
 	LastSuccessAtMs             *int64            `json:"lastSuccessAtMs,omitempty"`
 	LastCheckedAtMs             *int64            `json:"lastCheckedAtMs,omitempty"`
 	SessionCount                int               `json:"sessionCount"`
@@ -59,6 +69,27 @@ type Health struct {
 	// must still prevent a silent alias replacement.
 	HelperOwnershipRecorded bool `json:"helperOwnershipRecorded"`
 	HelperOwnershipCorrupt  bool `json:"helperOwnershipCorrupt"`
+}
+
+// WithAuthenticationStatus keeps connection remediation distinct from whether
+// cached machine data is fresh. It is deliberately safe to call for every
+// response, including an unconfigured machine.
+func WithAuthenticationStatus(health Health) Health {
+	health.AuthState = AuthNotRequired
+	if health.Reason != nil {
+		switch *health.Reason {
+		case ReasonAuthentication, ReasonHostKeyConfirmation:
+			health.ActionRequired = ActionAuthenticate
+			health.AuthState = AuthRequired
+		case ReasonHostKeyChanged:
+			health.ActionRequired = ActionVerifyHostKey
+		}
+	}
+	if health.ActionRequired != ActionVerifyHostKey && health.Label != "" && AuthAttemptActive(health.Label) {
+		health.ActionRequired = ActionAuthenticate
+		health.AuthState = AuthWaiting
+	}
+	return health
 }
 
 func reasonPtr(reason Reason) *Reason { return &reason }
@@ -94,9 +125,11 @@ func redactDiagnostic(text string) string {
 func genericErrorCopy(reason Reason) string {
 	switch reason {
 	case ReasonAuthentication:
-		return "SSH authentication failed — run ssh once in Terminal, then Retry"
-	case ReasonHostKey:
-		return "SSH host key needs confirmation — run ssh once in Terminal, then Retry"
+		return "SSH authentication required"
+	case ReasonHostKeyConfirmation:
+		return "SSH host key confirmation required"
+	case ReasonHostKeyChanged:
+		return "SSH host key changed — verify the host identity before reconnecting"
 	case ReasonConnectionFailed:
 		return "SSH is not reachable yet — check the alias, then Retry"
 	case ReasonSFTPUnavailable:

--- a/collector/internal/remote/helperexec.go
+++ b/collector/internal/remote/helperexec.go
@@ -54,8 +54,9 @@ var (
 // never appears here: the request travels on stdin, so the remote command line
 // is a validated path plus one word from a closed set.
 func HelperArgs(alias, helperPath, subcommand string, connectTimeoutSeconds int) ([]string, error) {
-	if !aliasPattern.MatchString(alias) {
-		return nil, ErrInvalidAlias
+	destination, err := parseDestination(alias)
+	if err != nil {
+		return nil, err
 	}
 	if subcommand != HelperCommandCapabilities && subcommand != HelperCommandCollect {
 		return nil, fmt.Errorf("%w: %q", ErrInvalidHelperArgs, subcommand)
@@ -67,16 +68,16 @@ func HelperArgs(alias, helperPath, subcommand string, connectTimeoutSeconds int)
 	if connectTimeoutSeconds <= 0 {
 		connectTimeoutSeconds = int(DefaultConnectTimeout.Seconds())
 	}
-	return []string{
+	args := []string{
 		"-T",
 		"-o", "BatchMode=yes",
 		"-o", "ConnectTimeout=" + strconv.Itoa(connectTimeoutSeconds),
 		"-o", "ControlMaster=auto",
 		"-o", "ControlPath=" + controlSocketPath(),
 		"-o", "ControlPersist=" + defaultControlPersist,
-		alias,
-		command,
-	}, nil
+	}
+	args = append(args, destination.Args()...)
+	return append(args, command), nil
 }
 
 // helperCommand renders the remote command. OpenSSH hands the command to the

--- a/collector/internal/remote/lifecycle.go
+++ b/collector/internal/remote/lifecycle.go
@@ -286,22 +286,23 @@ func (metadata ReleaseMetadata) Validate() error {
 // HelperPlatformArgs builds the fixed, bounded platform probe. Unlike helper
 // execution, it contains no remote path or caller-provided command text.
 func HelperPlatformArgs(alias string, connectTimeoutSeconds int) ([]string, error) {
-	if !aliasPattern.MatchString(alias) {
-		return nil, ErrInvalidAlias
+	destination, err := parseDestination(alias)
+	if err != nil {
+		return nil, err
 	}
 	if connectTimeoutSeconds <= 0 {
 		connectTimeoutSeconds = int(DefaultConnectTimeout.Seconds())
 	}
-	return []string{
+	args := []string{
 		"-T",
 		"-o", "BatchMode=yes",
 		"-o", "ConnectTimeout=" + strconv.Itoa(connectTimeoutSeconds),
 		"-o", "ControlMaster=auto",
 		"-o", "ControlPath=" + controlSocketPath(),
 		"-o", "ControlPersist=" + defaultControlPersist,
-		alias,
-		"uname -s; uname -m; id -u",
-	}, nil
+	}
+	args = append(args, destination.Args()...)
+	return append(args, "uname -s; uname -m; id -u"), nil
 }
 
 func (artifact Artifact) Validate() error {

--- a/collector/internal/remote/lifecycle_ssh.go
+++ b/collector/internal/remote/lifecycle_ssh.go
@@ -28,7 +28,7 @@ type SSHLifecycleRemote struct {
 }
 
 func NewSSHLifecycleRemote(alias string, options OpenOptions) (*SSHLifecycleRemote, error) {
-	if !aliasPattern.MatchString(alias) {
+	if _, err := parseDestination(alias); err != nil {
 		return nil, ErrInvalidAlias
 	}
 	return &SSHLifecycleRemote{Alias: alias, Options: options}, nil
@@ -183,11 +183,16 @@ func (remote *SSHLifecycleRemote) runStagedInstaller(ctx context.Context, stagin
 	}
 	runCtx, cancel := context.WithTimeout(ctx, min(limits.Deadline, DefaultHelperInstallTimeout))
 	defer cancel()
+	destination, err := parseDestination(remote.Alias)
+	if err != nil {
+		return err
+	}
 	args := []string{
 		"-T", "-o", "BatchMode=yes", "-o", "ConnectTimeout=" + strconv.Itoa(int(limits.ConnectTimeout.Seconds())),
 		"-o", "ControlMaster=auto", "-o", "ControlPath=" + controlSocketPath(), "-o", "ControlPersist=" + defaultControlPersist,
-		remote.Alias, shellQuote(staging) + " install " + shellQuote(home) + " " + shellQuote(version) + " " + shellQuote(sha256),
 	}
+	args = append(args, destination.Args()...)
+	args = append(args, shellQuote(staging)+" install "+shellQuote(home)+" "+shellQuote(version)+" "+shellQuote(sha256))
 	cmd := command(runCtx, bin, args...)
 	stdout := &boundedCommandOutput{limit: 128, cancel: cancel}
 	stderr := &boundedCommandOutput{limit: limits.MaxStderrBytes, cancel: cancel}

--- a/collector/internal/remote/manager.go
+++ b/collector/internal/remote/manager.go
@@ -260,6 +260,7 @@ func (manager *Manager) ApplySettings(remote *settings.RemoteSettings) error {
 	previous := manager.cfg
 	aliasChanged := previous != nil && previous.SSHAlias != remote.SSHAlias
 	if aliasChanged {
+		CancelAuthAttemptsForDestination(previous.SSHAlias)
 		exitControlMasterBestEffort(previous.SSHAlias)
 		if err := manager.cache.RemoveSource(remote.ID); err != nil {
 			return err
@@ -283,6 +284,7 @@ func (manager *Manager) ApplySettings(remote *settings.RemoteSettings) error {
 		manager.complete = true
 		manager.errorCopy = ""
 		manager.transport = TransportSFTP
+		CancelAuthAttemptsForDestination(remote.SSHAlias)
 		exitControlMasterBestEffort(remote.SSHAlias)
 		return nil
 	}
@@ -397,6 +399,9 @@ func (manager *Manager) Retry() (Health, bool) {
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
 	if manager.cfg == nil || !manager.cfg.Enabled {
+		return manager.healthLocked(manager.lastRequestedMs), false
+	}
+	if AuthAttemptActive(manager.cfg.SSHAlias) {
 		return manager.healthLocked(manager.lastRequestedMs), false
 	}
 	if manager.refreshing || (!manager.lastManualRetryAt.IsZero() &&
@@ -526,6 +531,7 @@ func (manager *Manager) Shutdown() {
 	manager.cancelLifeLocked()
 	manager.refreshing = false
 	manager.mu.Unlock()
+	CancelAuthAttemptsForDestination(alias)
 	exitControlMasterBestEffort(alias)
 }
 
@@ -562,6 +568,7 @@ func (manager *Manager) removeLocked() error {
 	manager.helperOwnershipCorrupt = false
 	manager.helperProbe = helperProbeFallback
 	manager.metrics = CollectionMetrics{}
+	CancelAuthAttemptsForDestination(alias)
 	exitControlMasterBestEffort(alias)
 	if sourceID != "" {
 		return manager.cache.RemoveSource(sourceID)
@@ -625,6 +632,9 @@ func (manager *Manager) cancelLifeLocked() {
 
 func (manager *Manager) maybeStartRefreshLocked(remoteSinceMs int64, manual bool) {
 	if manager.refreshing || manager.cfg == nil || !manager.cfg.Enabled || manager.lifeCtx == nil {
+		return
+	}
+	if AuthAttemptActive(manager.cfg.SSHAlias) {
 		return
 	}
 	if !manual && !manager.nextRetryAt.IsZero() && manager.now().Before(manager.nextRetryAt) {
@@ -946,12 +956,15 @@ func classifyError(err error) Reason {
 		return ReasonInvalidData
 	case errors.Is(err, vendors.ErrInvalidData):
 		return ReasonInvalidData
+	case errors.Is(err, ErrAuthAttemptActive):
+		return ReasonAuthentication
 	}
 	message := strings.ToLower(err.Error() + " " + sshErrorStderr(err))
-	if strings.Contains(message, "host key verification failed") ||
-		strings.Contains(message, "remote host identification has changed") ||
-		strings.Contains(message, "no host key is known") {
-		return ReasonHostKey
+	if strings.Contains(message, "remote host identification has changed") || strings.Contains(message, "offending") {
+		return ReasonHostKeyChanged
+	}
+	if strings.Contains(message, "host key verification failed") || strings.Contains(message, "no host key is known") {
+		return ReasonHostKeyConfirmation
 	}
 	if strings.Contains(message, "permission denied (publickey") ||
 		strings.Contains(message, "permission denied, please try again") ||

--- a/collector/internal/remote/sftp.go
+++ b/collector/internal/remote/sftp.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -20,9 +19,15 @@ import (
 	"github.com/pkg/sftp"
 )
 
-var aliasPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
-
 const defaultControlPersist = "10m"
+
+func parseDestination(value string) (settings.SSHDestination, error) {
+	destination, err := settings.ParseSSHDestination(value)
+	if err != nil {
+		return settings.SSHDestination{}, ErrInvalidAlias
+	}
+	return destination, nil
+}
 
 func controlSocketPath() string {
 	return filepath.Join(settings.Home(), "ssh", "cm-%C")
@@ -47,55 +52,59 @@ func ensureSSHControlDir() error {
 }
 
 func SSHArgs(alias string, connectTimeoutSeconds int) ([]string, error) {
-	if !aliasPattern.MatchString(alias) {
-		return nil, ErrInvalidAlias
+	destination, err := parseDestination(alias)
+	if err != nil {
+		return nil, err
 	}
 	if connectTimeoutSeconds <= 0 {
 		connectTimeoutSeconds = int(DefaultConnectTimeout.Seconds())
 	}
-	return []string{
+	args := []string{
 		"-T",
 		"-o", "BatchMode=yes",
 		"-o", "ConnectTimeout=" + strconv.Itoa(connectTimeoutSeconds),
 		"-o", "ControlMaster=auto",
 		"-o", "ControlPath=" + controlSocketPath(),
 		"-o", "ControlPersist=" + defaultControlPersist,
-		alias,
-		"-s", "sftp",
-	}, nil
+	}
+	args = append(args, destination.Args()...)
+	return append(args, "-s", "sftp"), nil
 }
 
 func ControlExitArgs(alias string) ([]string, error) {
-	if !aliasPattern.MatchString(alias) {
-		return nil, ErrInvalidAlias
+	destination, err := parseDestination(alias)
+	if err != nil {
+		return nil, err
 	}
-	return []string{
+	args := []string{
 		"-O", "exit",
 		"-o", "ControlPath=" + controlSocketPath(),
-		alias,
-	}, nil
+	}
+	return append(args, destination.Args()...), nil
 }
 
 func controlCheckArgs(alias string) ([]string, error) {
-	if !aliasPattern.MatchString(alias) {
-		return nil, ErrInvalidAlias
+	destination, err := parseDestination(alias)
+	if err != nil {
+		return nil, err
 	}
-	return []string{
+	args := []string{
 		"-O", "check",
 		"-o", "ControlPath=" + controlSocketPath(),
-		alias,
-	}, nil
+	}
+	return append(args, destination.Args()...), nil
 }
 
 func controlMasterStartArgs(alias string, connectTimeoutSeconds int) ([]string, error) {
-	if !aliasPattern.MatchString(alias) {
-		return nil, ErrInvalidAlias
+	destination, err := parseDestination(alias)
+	if err != nil {
+		return nil, err
 	}
 	if connectTimeoutSeconds <= 0 {
 		connectTimeoutSeconds = int(DefaultConnectTimeout.Seconds())
 	}
 	// -f -N leaves a background master so later SFTP clients can die without the tunnel.
-	return []string{
+	args := []string{
 		"-f",
 		"-N",
 		"-o", "BatchMode=yes",
@@ -103,8 +112,8 @@ func controlMasterStartArgs(alias string, connectTimeoutSeconds int) ([]string, 
 		"-o", "ControlMaster=yes",
 		"-o", "ControlPath=" + controlSocketPath(),
 		"-o", "ControlPersist=" + defaultControlPersist,
-		alias,
-	}, nil
+	}
+	return append(args, destination.Args()...), nil
 }
 
 func runSSHCommand(ctx context.Context, options OpenOptions, args []string) error {
@@ -148,32 +157,37 @@ func runSSHCommand(ctx context.Context, options OpenOptions, args []string) erro
 }
 
 func ensureControlMaster(ctx context.Context, alias string, options OpenOptions) error {
-	if err := ensureSSHControlDir(); err != nil {
+	if _, err := parseDestination(alias); err != nil {
 		return err
 	}
-	checkArgs, err := controlCheckArgs(alias)
-	if err != nil {
-		return err
-	}
-	limits := options.Limits.withDefaults()
-	checkCtx, cancelCheck := context.WithTimeout(ctx, limits.ConnectTimeout)
-	err = runSSHCommand(checkCtx, options, checkArgs)
-	cancelCheck()
-	if err == nil {
+	return withDestinationCoordinator(alias, func() error {
+		if AuthAttemptActive(alias) {
+			return ErrAuthAttemptActive
+		}
+		checkArgs, err := controlCheckArgs(alias)
+		if err != nil {
+			return err
+		}
+		limits := options.Limits.withDefaults()
+		checkCtx, cancelCheck := context.WithTimeout(ctx, limits.ConnectTimeout)
+		err = runSSHCommand(checkCtx, options, checkArgs)
+		cancelCheck()
+		if err == nil {
+			return nil
+		} else if errors.Is(err, ErrStderrLimit) || ctx.Err() != nil {
+			return err
+		}
+		startArgs, err := controlMasterStartArgs(alias, int(limits.ConnectTimeout.Seconds()))
+		if err != nil {
+			return err
+		}
+		startCtx, cancel := context.WithTimeout(ctx, limits.ConnectTimeout)
+		defer cancel()
+		if err := runSSHCommand(startCtx, options, startArgs); err != nil {
+			return fmt.Errorf("start SSH control master: %w", err)
+		}
 		return nil
-	} else if errors.Is(err, ErrStderrLimit) || ctx.Err() != nil {
-		return err
-	}
-	startArgs, err := controlMasterStartArgs(alias, int(limits.ConnectTimeout.Seconds()))
-	if err != nil {
-		return err
-	}
-	startCtx, cancel := context.WithTimeout(ctx, limits.ConnectTimeout)
-	defer cancel()
-	if err := runSSHCommand(startCtx, options, startArgs); err != nil {
-		return fmt.Errorf("start SSH control master: %w", err)
-	}
-	return nil
+	})
 }
 
 // ExitControlMaster asks OpenSSH to drop coSlash's multiplexed master for alias.

--- a/collector/internal/settings/destination_test.go
+++ b/collector/internal/settings/destination_test.go
@@ -1,0 +1,35 @@
+package settings
+
+import "testing"
+
+func TestParseSSHDestination(t *testing.T) {
+	for _, test := range []struct {
+		input string
+		want  []string
+	}{
+		{"agent-box", []string{"agent-box"}},
+		{"jane.doe@devvm1872.cln0", []string{"-l", "jane.doe", "devvm1872.cln0"}},
+	} {
+		destination, err := ParseSSHDestination(test.input)
+		if err != nil {
+			t.Fatalf("ParseSSHDestination(%q): %v", test.input, err)
+		}
+		if got := destination.Args(); len(got) != len(test.want) {
+			t.Fatalf("Args(%q) = %#v, want %#v", test.input, got, test.want)
+		} else {
+			for i := range got {
+				if got[i] != test.want[i] {
+					t.Fatalf("Args(%q) = %#v, want %#v", test.input, got, test.want)
+				}
+			}
+		}
+	}
+}
+
+func TestParseSSHDestinationRejectsUnsafeForms(t *testing.T) {
+	for _, input := range []string{"", "-oProxyCommand=x", "user@host@again", "user@host:22", "user@[::1]", "user @host", "user@host;id"} {
+		if _, err := ParseSSHDestination(input); err == nil {
+			t.Errorf("ParseSSHDestination(%q) succeeded", input)
+		}
+	}
+}

--- a/collector/internal/settings/settings.go
+++ b/collector/internal/settings/settings.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"sync"
 )
 
@@ -160,6 +161,8 @@ var modelPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:/-]*$`)
 
 var (
 	sshAliasPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+	sshUserPattern  = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+	sshHostPattern  = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9.-]*$`)
 	remoteIDPattern = regexp.MustCompile(`^r_[0-9a-f]{16}$`)
 )
 
@@ -169,9 +172,42 @@ func ValidSynthesisModel(model string) bool {
 	return len(model) <= 200 && modelPattern.MatchString(model)
 }
 
-// ValidSSHAlias reports whether alias is safe as a local ssh argv after `--`.
+// SSHDestination is the single parsed form used for every SSH invocation.
+// The initial public boundary intentionally supports an SSH-config alias or a
+// simple user@host destination. Ports, IPv6, and ProxyJump remain SSH-config
+// concerns so callers never need to interpret arbitrary ssh syntax.
+type SSHDestination struct {
+	Display string
+	User    string
+	Host    string
+}
+
+func (destination SSHDestination) Args() []string {
+	if destination.User == "" {
+		return []string{destination.Host}
+	}
+	return []string{"-l", destination.User, destination.Host}
+}
+
+func ParseSSHDestination(value string) (SSHDestination, error) {
+	if len(value) == 0 || len(value) > 255 {
+		return SSHDestination{}, errors.New("SSH destination must be 1 to 255 characters")
+	}
+	if sshAliasPattern.MatchString(value) {
+		return SSHDestination{Display: value, Host: value}, nil
+	}
+	user, host, found := strings.Cut(value, "@")
+	if !found || !sshUserPattern.MatchString(user) || !sshHostPattern.MatchString(host) {
+		return SSHDestination{}, errors.New("SSH destination must be an alias or user@host")
+	}
+	return SSHDestination{Display: value, User: user, Host: host}, nil
+}
+
+// ValidSSHAlias is retained for the persisted sshAlias field. Despite the
+// legacy name, it accepts every supported SSH destination.
 func ValidSSHAlias(alias string) bool {
-	return len(alias) > 0 && len(alias) <= 255 && sshAliasPattern.MatchString(alias)
+	_, err := ParseSSHDestination(alias)
+	return err == nil
 }
 
 // ValidRemoteID reports whether id is a Mac-generated path-safe source id.

--- a/docs/eng-1412-interactive-ssh-auth-analysis.md
+++ b/docs/eng-1412-interactive-ssh-auth-analysis.md
@@ -254,15 +254,16 @@ Only one authentication attempt should be active for a destination. While it is 
 - Allow repeated status checks without extending the attempt forever.
 - Let the user cancel waiting.
 - Treat closing the terminal before readiness as cancelled or failed once observable.
-- Remove short-lived attempt metadata after success, cancellation, or timeout.
+- Expire short-lived attempt metadata conservatively while retaining terminal
+  outcomes long enough to distinguish a ready master from a cancellation.
 - Close a healthy coSlash control master when a host is removed.
 - Clean up stale socket files conservatively; never delete an unverified arbitrary path.
 
 The first release uses a five-minute attempt timeout. Cancellation records a
-safe cancelled outcome, then removes the short-lived record; it does not
-terminate the user-owned terminal SSH process. Failed and timed-out terminal
-commands durably record their outcome until the next status response consumes
-it (or expiry cleanup), so the browser never mistakes them for a long wait.
+safe cancelled outcome and closes any coSlash control master, but does not
+terminate the user-owned terminal SSH process. Terminal outcomes remain until
+expiry cleanup so a status poll and the terminal process cannot mistake a
+ready master for a cancelled attempt.
 
 ### 7. Minimize diagnostics at the source
 

--- a/docs/eng-1412-interactive-ssh-auth-analysis.md
+++ b/docs/eng-1412-interactive-ssh-auth-analysis.md
@@ -1,0 +1,450 @@
+# ENG-1412: Interactive SSH authentication analysis
+
+Issue: [ENG-1412 — Support interactive SSH authentication during remote host setup](https://linear.app/centauri-ai/issue/ENG-1412/support-interactive-ssh-authentication-during-remote-host-setup)
+
+Status of this document: approved initial implementation direction. The first
+release covers aliases and bounded `user@host` destinations, macOS terminal
+authentication, five-minute attempts, and authentication as an action/reason
+that preserves the existing freshness state.
+
+## Summary
+
+ENG-1412 combines three related but independently useful changes:
+
+1. Accept a documented SSH config alias or a bounded `user@host` destination and report validation failures clearly.
+2. Let a user satisfy password, key-passphrase, host-key, or MFA prompts in their system terminal while coSlash continues to use non-interactive SSH internally.
+3. Represent expired authentication as an actionable condition and reconnect without removing the machine.
+
+The codebase already has most of the transport foundation. coSlash uses the system OpenSSH client, creates a private control-socket directory, starts a `%C`-keyed control master, reuses it for SFTP and helper operations, and can open Apple Terminal or iTerm2. The missing pieces are a shared destination model, an explicit interactive control-master bootstrap, a structured API/state contract, and coordination between authentication attempts and background refreshes.
+
+The recommended direction is to preserve the current non-interactive probe, offer a deliberate **Authenticate in Terminal** action only for actionable authentication conditions, and run a fixed coSlash-owned terminal command identified by an opaque attempt ID. OpenSSH should remain the only process that reads or renders credentials and MFA responses.
+
+## Current behavior
+
+### `user@host` fails before SSH starts
+
+The current destination is named `sshAlias` throughout settings, APIs, and the UI. Validation permits only `A-Z`, `a-z`, digits, `.`, `_`, and `-`. Consequently, `janedoe@devvm1872.cln0` is rejected before OpenSSH is invoked.
+
+The failure path is:
+
+```text
+user enters janedoe@devvm1872.cln0
+        |
+        v
+frontend sends { sshAlias: "janedoe@devvm1872.cln0" }
+        |
+        v
+backend alias validator rejects "@"
+        |
+        v
+backend returns a plain-text HTTP 400
+        |
+        v
+frontend cannot decode a structured API error
+        |
+        v
+Remote test failed (400)
+```
+
+Relevant implementation:
+
+- [`ValidSSHAlias`](../collector/internal/settings/settings.go) applies the alias-only regex.
+- [`handleRemoteTest`](../collector/cmd/coslash/api_remote.go) returns plain-text `400` responses for malformed or rejected input.
+- [`testRemoteAlias`](../frontend/src/pages/coslash/lib/remote-api.ts) falls back to `Remote test failed (<status>)` when no structured error is available.
+
+### Valid aliases cannot prompt interactively
+
+For a valid alias, remote setup opens SFTP through system OpenSSH. Before opening SFTP, coSlash checks for or starts its own control master under `~/.coslash/ssh`.
+
+Both the SFTP command and control-master startup force `BatchMode=yes`. This is correct for background work, but OpenSSH then disables password, passphrase, host-key confirmation, and keyboard-interactive prompts. The UI currently tells the user to run `ssh <alias>` manually and retry the flow.
+
+Relevant implementation:
+
+- [`SSHArgs`, `controlMasterStartArgs`, and `ensureControlMaster`](../collector/internal/remote/sftp.go) implement the existing non-interactive control-master path.
+- [`MachinesSettingsSection`](../frontend/src/pages/coslash/components/MachinesSettingsSection.tsx) displays the manual Terminal-and-retry guidance.
+- [`classifyError`](../collector/internal/remote/manager.go) maps SSH stderr to a small set of machine reasons using substring matching.
+
+### Existing capabilities we should reuse
+
+- System OpenSSH remains the SSH implementation.
+- `~/.coslash/ssh` is created with mode `0700` and rejected if it is a symlink.
+- `ControlPath=~/.coslash/ssh/cm-%C` separates sockets by effective host, port, and user.
+- `ControlPersist=10m` keeps an authenticated connection available for later SFTP/helper operations.
+- Apple Terminal and iTerm2 launch adapters already exist in [`internal/launch`](../collector/internal/launch/launch.go).
+- Machine health already distinguishes current, stale, and unavailable data, and preserves the last successful snapshot after connection failures.
+
+## Problem decomposition
+
+| Problem | User impact | Root cause | Desired result |
+| --- | --- | --- | --- |
+| Destination mismatch | Natural `user@host` input produces an opaque 400 | An alias-only regex is used as the destination model | Validate aliases and a deliberately bounded `user@host` form before SSH |
+| Unstructured errors | Users cannot tell invalid input, DNS failure, timeout, auth failure, and SFTP failure apart | Some API failures are plain text and SSH outcomes are broadly classified | Stable error/reason codes with specific, safe UI copy |
+| No interactive bootstrap | Password, passphrase, host-key, and MFA users cannot finish setup | All coSlash-owned SSH starts use `BatchMode=yes` | A deliberate terminal flow starts the shared authenticated master |
+| Setup restart | The user must leave coSlash, run SSH manually, then repeat setup | coSlash does not observe completion of the manual SSH step | Poll master readiness and continue the existing setup automatically |
+| Reauthentication looks offline | Expired credentials are indistinguishable from network failures | Authentication is represented only as a generic failed refresh | Show an Authentication required action while preserving stale data |
+| Retry races | Background collection may compete with terminal authentication | There is no authentication-attempt coordinator | Suppress or serialize automatic master creation during an interactive attempt |
+| Diagnostic leakage | SSH stderr can contain usernames, hosts, paths, banners, and prompt text | Classification and diagnostic persistence share the same raw input | Classify stderr in bounded memory, persist only safe enums and measurements |
+
+## Solution options
+
+### Option A: Improve validation and keep authentication manual
+
+Implement destination parsing, structured error responses, and better UI instructions, but continue asking the user to run SSH in Terminal themselves.
+
+Advantages:
+
+- Smallest and lowest-risk change.
+- Fixes the reported `user@host`/HTTP 400 failure immediately.
+- Does not introduce authentication-attempt lifecycle or terminal coordination.
+
+Limitations:
+
+- Users must still switch contexts and manually repeat setup.
+- coSlash cannot distinguish an abandoned prompt from a completed authentication.
+- Reauthentication remains awkward after a control master expires.
+
+Best use: an independently shippable first slice, not the complete ENG-1412 solution.
+
+### Option B: Launch a generated `ssh` command directly in Terminal
+
+After a non-interactive authentication failure, open the selected terminal with an `ssh -f -N` command configured to create the coSlash control master. Poll `ssh -O check` from the main process.
+
+Advantages:
+
+- Uses the existing terminal adapters and control-socket implementation.
+- Relatively little new backend machinery.
+- Credentials and prompts remain in OpenSSH and the terminal.
+
+Limitations:
+
+- The terminal adapters accept a command string, so destination data must be mechanically shell-quoted even if it was parsed safely.
+- Cancellation and terminal exit status are difficult to observe through the existing `osascript` launch boundary.
+- It is harder to associate a terminal window with a particular setup attempt or prevent stale attempts from completing a newer flow.
+
+Best use: a pragmatic implementation if the product accepts weaker attempt tracking and carefully tested shell quoting.
+
+### Option C: Launch a fixed coSlash authentication command
+
+Create an authentication attempt in the running collector, identified by a random opaque ID. Open Terminal with a fixed command such as:
+
+```text
+coslash ssh-auth <opaque-attempt-id>
+```
+
+The subcommand resolves server-owned, already-validated attempt data and invokes system OpenSSH with structured argv. The UI polls an authentication-status API, which checks the matching socket with `ssh -O check` and reports terminal, timeout, cancellation, or readiness states.
+
+Advantages:
+
+- User-provided destination text is not interpolated into a terminal shell command.
+- Authentication attempts have explicit identity, expiry, and cancellation semantics.
+- Terminal output can show a small coSlash-owned success/failure message without returning prompt text to the browser.
+- The approach extends naturally to reauthentication.
+
+Limitations:
+
+- Requires an attempt registry or tightly permissioned temporary attempt record.
+- The new subprocess must locate and safely communicate with the running collector or read a short-lived local record.
+- More lifecycle and integration-test work than Option B.
+
+Best use: the recommended complete solution because it creates the cleanest security and lifecycle boundary.
+
+### Option D: Render SSH prompts inside the web UI
+
+Run SSH behind a PTY and relay prompts and responses through the local API and browser.
+
+Advantages:
+
+- Keeps the user in one window.
+
+Limitations:
+
+- coSlash would receive credential and MFA responses.
+- Prompt detection is brittle across OpenSSH versions, locales, PAM configurations, and enterprise providers.
+- It materially expands secret handling, logging, memory, API, and browser security boundaries.
+- It contradicts ENG-1412's core privacy constraint.
+
+Best use: reject this option.
+
+## Recommended design
+
+### 1. Centralize destination parsing
+
+Replace scattered alias validation with a single immutable destination value. It should distinguish:
+
+- An SSH config alias, passed as the destination argument.
+- A supported `user@host` form, emitted as structured arguments such as `-l user host`.
+
+All SFTP, control-master, control-check, control-exit, helper, platform-probe, and remote-launch commands must use this parser and argument builder. Do not independently expand regexes in each caller.
+
+For backward compatibility, the persisted `sshAlias` field can initially retain its name and store the normalized display form. A later schema migration may rename it to `sshDestination`; renaming is not necessary to deliver the behavior.
+
+Recommended initial boundary: support existing aliases and `user@host`; require SSH config for ports, ProxyJump, identity selection, and other advanced configuration.
+
+### 2. Keep background SSH non-interactive
+
+Continue using `BatchMode=yes` for tests, collection, helper operations, and recovery attempts. A background refresh must never unexpectedly open a password or MFA prompt.
+
+The test should return a typed outcome rather than treating every operational SSH failure as an HTTP exception. Suggested reasons include:
+
+- `invalid_destination`
+- `dns_failed`
+- `connection_timeout`
+- `connection_failed`
+- `host_key_confirmation_required`
+- `host_key_changed`
+- `authentication_required`
+- `authentication_failed`
+- `sftp_unavailable`
+- `terminal_unavailable`
+- `authentication_cancelled`
+- `authentication_timeout`
+
+Malformed JSON and invalid destinations should use structured 4xx API errors. A well-formed connection test may return HTTP 200 with a typed unsuccessful test result, matching the current `MachineFact` pattern.
+
+### 3. Start an interactive master only after explicit user action
+
+When the batch probe returns an actionable authentication reason, present **Authenticate in Terminal**. The action should:
+
+1. Create a short-lived authentication attempt bound to the exact normalized destination.
+2. Suspend new automatic master-start attempts for that destination.
+3. Open the configured and available terminal with the fixed coSlash authentication command.
+4. Have that command invoke system OpenSSH with `ControlMaster=yes`, the coSlash `ControlPath`, the selected `ControlPersist`, and interactive prompting enabled.
+5. Never return stdin, prompt text, or raw stderr through the HTTP API.
+
+An unknown host key may use this flow because OpenSSH can display and record the user's confirmation. A changed host key should be a distinct security condition with explicit remediation; it should not be presented as an ordinary authentication prompt.
+
+### 4. Observe readiness and continue setup
+
+The main process should poll the expected master using `ssh -O check`. Once healthy:
+
+1. Mark the authentication attempt ready.
+2. Rerun the ordinary non-interactive SFTP test through the shared master.
+3. Save the host using the existing settings flow.
+4. Continue to connector consent/setup without requiring the user to restart.
+
+“Return to coSlash automatically” should mean that the existing web flow advances automatically. Automatically activating an arbitrary browser window should be treated as separate scope.
+
+### 5. Model authentication separately from data freshness
+
+The current top-level machine state describes data availability: `ok`, `limited`, `stale`, `error`, and so on. Authentication is an actionable connection condition, not a complete replacement for freshness. A machine can simultaneously have stale cached data and require authentication.
+
+Recommended representation:
+
+```json
+{
+  "state": "stale",
+  "reason": "authentication_required",
+  "actionRequired": "authenticate",
+  "authState": "required"
+}
+```
+
+Possible `authState` values are `not_required`, `required`, `launching`, `waiting`, and `ready`. This preserves stale/error semantics while allowing Settings and the machine indicator to show **Authentication required · Reconnect**.
+
+Alternative: add `needs_auth` as a top-level machine state. This is simpler to display but conflates connection remediation with whether a usable cached snapshot exists and requires updates to every machine-state consumer.
+
+The first release uses the orthogonal reason/action approach rather than a
+new top-level `needs_auth` state.
+
+### 6. Coordinate refresh, cancellation, and cleanup
+
+Only one authentication attempt should be active for a destination. While it is active:
+
+- Do not let periodic refreshes start a competing batch-mode control master.
+- Allow repeated status checks without extending the attempt forever.
+- Let the user cancel waiting.
+- Treat closing the terminal before readiness as cancelled or failed once observable.
+- Remove short-lived attempt metadata after success, cancellation, or timeout.
+- Close a healthy coSlash control master when a host is removed.
+- Clean up stale socket files conservatively; never delete an unverified arbitrary path.
+
+The first release uses a five-minute attempt timeout. Cancellation records a
+safe cancelled outcome, then removes the short-lived record; it does not
+terminate the user-owned terminal SSH process. Failed and timed-out terminal
+commands durably record their outcome until the next status response consumes
+it (or expiry cleanup), so the browser never mistakes them for a long wait.
+
+### 7. Minimize diagnostics at the source
+
+Raw SSH stderr should exist only in a bounded in-memory buffer long enough to classify the failure. Persist and expose only:
+
+- Stable reason code.
+- Attempt state.
+- Bounded timing information.
+- Exit category, if available.
+- Whether the control socket became healthy.
+
+Do not persist prompt text, usernames, hosts, paths, banners, or complete SSH stderr. Redaction should be defense in depth rather than the main privacy mechanism.
+
+## Intended user experience
+
+For the reported user, the completed recommended design changes the setup flow
+from an opaque validation failure into a guided, resumable SSH setup:
+
+1. The user enters a supported `user@host` destination, such as
+   `janedoe@devvm1872.cln0`. coSlash accepts it rather than rejecting `@`
+   before SSH begins.
+2. coSlash runs its ordinary non-interactive SSH/SFTP probe. A successful
+   probe proceeds directly to saving the host and the existing connector
+   install-or-skip choice.
+3. If the probe determines that a password, private-key passphrase,
+   keyboard-interactive/MFA response, or unknown-host-key confirmation is
+   required, coSlash shows a specific result and an **Authenticate in
+   Terminal** action. It does not show an opaque HTTP 400 or ask the user to
+   run a separate SSH command and restart setup.
+4. A Terminal or iTerm2 window opens only after the user explicitly chooses
+   that action. The user completes the native OpenSSH prompt in that terminal;
+   credentials, MFA responses, and prompt text never enter the browser or
+   coSlash diagnostics.
+5. coSlash observes the authenticated control master, reruns the normal
+   non-interactive SFTP test through it, saves the host, and advances the
+   existing setup UI to connector consent/setup automatically. The user does
+   not need to re-enter the destination or click **Add remote host** again.
+6. If authentication later expires, existing cached sessions remain visible
+   as stale. The machine presents **Authentication required · Reconnect**,
+   rather than appearing simply offline or requiring the user to remove and
+   add the host again.
+
+A terminal must never open from a background refresh. A changed host key is a
+separate security condition with explicit remediation, not an ordinary
+authentication prompt.
+
+## Reproducing the current failure and validating the replacement
+
+### Current failure
+
+The current `user@host` failure is deterministic and does not require a
+Linux machine, ARM hardware, DNS, or a reachable SSH service. In the current
+Settings → Machines flow, enter a value containing `@`, for example
+`testuser@agent-box-arm`, and choose **Add remote host**. The backend rejects
+the destination before invoking OpenSSH with a plain-text HTTP 400; the
+frontend then displays `Remote test failed (400)`.
+
+This should become a regression test at both API and UI levels. It directly
+exercises the current alias-only validation and generic client error fallback.
+
+### End-to-end environment
+
+`agent-box-arm` is suitable for validating an SSH-config alias, interactive
+control-master reuse, SFTP, and the automatic continuation of setup. It is
+not by itself a faithful raw-`user@host` test environment when its connection
+depends on SSH-config-only behavior such as `ProxyCommand`, `ProxyJump`,
+non-default ports, or identity selection. The initial destination boundary
+requires those advanced configurations to continue using an SSH alias.
+
+Use two isolated test paths:
+
+1. **Alias path:** configure a dedicated `coslash-e2e` SSH alias for
+   `agent-box-arm` and a disposable test account. Exercise the terminal
+   authentication flow, control-master readiness, SFTP reuse, and automatic
+   progression to connector consent without manual SSH or a retry.
+2. **Raw destination path:** provide a dedicated ARM Linux test account at a
+   directly reachable hostname for `user@host`. Do not depend on an SSH
+   config alias or an IAP/proxy tunnel. This is the environment that proves
+   parsing and structured argv construction for the newly supported syntax.
+
+Run the app with an isolated `COSLASH_HOME` so test settings and control
+sockets do not affect a developer's normal coSlash configuration. Configure
+the disposable account or test host to cover password authentication,
+encrypted-key passphrases, keyboard-interactive MFA, unknown host-key
+confirmation, changed host-key warnings, and SFTP-unavailable behavior. The
+key manual acceptance assertion is that a successful terminal authentication
+advances setup automatically, with no manual `ssh` command and no second
+**Add remote host** action.
+
+## Recommended delivery slices
+
+### Slice 1: Destination and error contract
+
+- Add the shared destination parser and argv builder.
+- Accept a bounded `user@host` form.
+- Keep existing aliases working without migration.
+- Return structured validation and connection-test outcomes.
+- Replace `Remote test failed (400)` with specific inline guidance.
+- Add unit tests for every accepted and rejected destination form and all command builders.
+
+This slice fixes the immediate bug and can ship independently.
+
+### Slice 2: Terminal-assisted initial setup
+
+- Add authentication-attempt creation and status APIs.
+- Add the fixed `coslash ssh-auth <attempt-id>` terminal command.
+- Add **Authenticate in Terminal** and authentication-progress UI.
+- Poll the control socket and continue SFTP test, save, and connector setup automatically.
+- Cover success, unavailable terminal, timeout, cancellation, failed auth, and SFTP-after-auth failure.
+
+### Slice 3: Reauthentication lifecycle
+
+- Expose authentication-required as an explicit action on a configured machine.
+- Preserve stale history while waiting for authentication.
+- Suppress futile background retries while user action is required.
+- Add Reconnect without remove/re-add.
+- Cover master loss, expiry, application restart, host removal, and cleanup.
+
+### Slice 4: Guidance and hardening
+
+- Document ssh-agent, macOS Keychain, SSH certificates, and supported enterprise/SSO agents.
+- Explain the limitations of servers that demand fresh MFA for every connection.
+- Add privacy regression tests proving that prompt and stderr content do not enter API responses, diagnostics, or durable state.
+- Add integration fixtures for keyboard-interactive auth and control-master reuse where practical.
+
+## Testing strategy
+
+### Unit tests
+
+- Destination parsing, normalization, maximum lengths, and rejected option-like inputs.
+- Argument construction for SFTP, master start/check/exit, helper operations, and remote launch.
+- Structured API errors for malformed JSON and invalid destinations.
+- Classification of DNS, timeout, unknown host key, changed host key, authentication, and SFTP failures.
+- State transitions and retry suppression during an active authentication attempt.
+- Bounded diagnostics and absence of raw SSH text in serialized state.
+
+### Integration tests
+
+- Existing non-interactive aliases remain unchanged.
+- `user@host` reaches OpenSSH as structured argv.
+- A keyboard-interactive fixture reaches terminal-assisted authentication.
+- A healthy master is detected and reused by SFTP and helper operations.
+- Setup resumes without a second Add action.
+- Master loss produces the authentication-required action when appropriate.
+- Cancellation, timeout, stale attempts, and concurrent refresh attempts are handled deterministically.
+- Host removal closes or releases coSlash-owned master state safely.
+
+### Manual acceptance
+
+- Password authentication.
+- Encrypted private-key passphrase.
+- Unknown host-key confirmation.
+- Changed host-key warning.
+- Keyboard-interactive MFA/passcode.
+- ssh-agent or Keychain success without terminal assistance.
+- ProxyJump or enterprise agent configured through an SSH alias.
+- Apple Terminal and iTerm2 availability and automation-permission failures.
+
+## Decisions needed before implementation
+
+1. Exact supported destination grammar, especially ports and IPv6.
+2. Whether terminal-assisted auth is explicitly macOS-only for this release.
+3. Whether authentication is a new machine state or an orthogonal reason/action substate.
+4. Interactive attempt timeout and cancellation semantics.
+5. Whether cancellation must terminate an in-progress terminal SSH process.
+6. Whether `ControlPersist=10m` remains the intended lifetime.
+7. Whether browser/window refocusing is out of scope.
+
+## Issue assessment
+
+ENG-1412 scores **4.2/5** and is ready for product and technical breakdown, but it is broader than a single bounded implementation task.
+
+| Element | Status | Score | Assessment |
+| --- | --- | ---: | --- |
+| Purpose | Present | 5 | The affected users, failure mode, and privacy motivation are explicit |
+| Required outcome | Unclear | 3 | Strong direction, but destination grammar, state semantics, and attempt lifecycle remain undecided |
+| Acceptance | Present | 4 | Broad and observable, though cancellation and interactive-failure behavior need exact definitions |
+| Constraints | Present | 5 | Credential ownership, argv safety, diagnostics, and non-interactive defaults are strong |
+| Context | Present | 4 | The reproduction and proposed architecture are useful; platform and current-system details should be made explicit |
+
+The most important issue refinements are:
+
+1. **Split** delivery into destination/errors, initial interactive setup, and reauthentication lifecycle.
+2. **Add** explicit decisions for destination grammar, state representation, timeout, and cancellation.
+3. **Replace** the general statement about returning to coSlash with the observable requirement that the existing web flow advances after the control socket becomes healthy.

--- a/frontend/src/pages/coslash/CoslashPage.tsx
+++ b/frontend/src/pages/coslash/CoslashPage.tsx
@@ -218,6 +218,7 @@ function SessionsStats({
   loadFailed,
   timeWindow,
   onRemoteRetry,
+  onRemoteAuthenticate,
   remoteRetryInFlight,
 }: {
   sessions: Session[];
@@ -226,6 +227,7 @@ function SessionsStats({
   loadFailed: boolean;
   timeWindow: TimeWindow;
   onRemoteRetry: () => void;
+  onRemoteAuthenticate: () => void;
   remoteRetryInFlight: boolean;
 }) {
   if (loadFailed) return null;
@@ -257,6 +259,7 @@ function SessionsStats({
         machines={machines}
         sessions={activitySessions}
         onRemoteRetry={onRemoteRetry}
+        onRemoteAuthenticate={onRemoteAuthenticate}
         remoteRetryInFlight={remoteRetryInFlight}
       />
     </div>
@@ -561,6 +564,7 @@ export function CoslashPage() {
                   loadFailed={loadError != null}
                   timeWindow={timeWindow}
                   onRemoteRetry={handleRemoteRetry}
+                  onRemoteAuthenticate={() => setSettingsDialogMode('full-settings')}
                   remoteRetryInFlight={remoteRetryInFlight}
                 />
               </LoadingSpinner>

--- a/frontend/src/pages/coslash/CoslashPage.tsx
+++ b/frontend/src/pages/coslash/CoslashPage.tsx
@@ -32,10 +32,7 @@ import {
   type ViewMode,
 } from '@/pages/coslash/CoslashTabMenus';
 import { loadHubDestination } from '@/pages/coslash/features/sharing/api';
-import {
-  HUB_SHARE_VERSION,
-  type DestinationResult,
-} from '@/pages/coslash/features/sharing/model';
+import { HUB_SHARE_VERSION, type DestinationResult } from '@/pages/coslash/features/sharing/model';
 import { ShareToHubDialog } from '@/pages/coslash/features/sharing/ShareToHubDialog';
 import { useDiagnostics } from '@/pages/coslash/hooks/use-diagnostics';
 import { useSessions } from '@/pages/coslash/hooks/use-sessions';

--- a/frontend/src/pages/coslash/components/MachineActivity.tsx
+++ b/frontend/src/pages/coslash/components/MachineActivity.tsx
@@ -26,6 +26,12 @@ function machineCopy(machine: MachineFact, checking: boolean) {
   }
   if (connectorFailed(machine))
     return `Setup failed: ${connectorFailureCopy(machine)}. Open Settings to retry.`;
+  if (machine.reason === 'authentication_failed') {
+    return `Authentication required. Saved history from ${savedHistory}. Open Settings to reconnect.`;
+  }
+  if (machine.reason === 'host_key_changed') {
+    return `SSH host key changed. Verify the host identity before reconnecting. Saved history from ${savedHistory}.`;
+  }
   if (machine.state === 'stale') {
     return `Offline. Last checked ${lastChecked}. Saved history from ${savedHistory}.`;
   }
@@ -38,7 +44,7 @@ function machineCopy(machine: MachineFact, checking: boolean) {
 }
 
 function needsAttention(machine: MachineFact) {
-  return machine.reason === 'authentication_failed' || machine.reason === 'host_key_failed';
+  return machine.reason === 'authentication_failed' || machine.reason === 'host_key_confirmation_required' || machine.reason === 'host_key_changed';
 }
 
 function connectorFailed(machine: MachineFact) {
@@ -67,11 +73,13 @@ export function MachineActivity({
   machines,
   sessions,
   onRemoteRetry,
+  onRemoteAuthenticate,
   remoteRetryInFlight,
 }: {
   machines: MachineFact[];
   sessions: Session[];
   onRemoteRetry: () => void;
+  onRemoteAuthenticate: () => void;
   remoteRetryInFlight: boolean;
 }) {
   return (
@@ -83,7 +91,9 @@ export function MachineActivity({
             isChecking(machine) || (machine.sourceId !== LOCAL_SOURCE_ID && remoteRetryInFlight);
           const retryable =
             machine.sourceId !== LOCAL_SOURCE_ID &&
+            machine.actionRequired == null &&
             (machine.state === 'stale' || machine.state === 'error' || connectorFailed(machine));
+          const authenticationRequired = machine.sourceId !== LOCAL_SOURCE_ID && machine.actionRequired === 'authenticate';
           const offline =
             machine.sourceId !== LOCAL_SOURCE_ID &&
             !refreshing &&
@@ -94,10 +104,10 @@ export function MachineActivity({
                 <span>
                   <button
                     type="button"
-                    onClick={retryable ? onRemoteRetry : undefined}
-                    disabled={!retryable || remoteRetryInFlight}
+                    onClick={authenticationRequired ? onRemoteAuthenticate : retryable ? onRemoteRetry : undefined}
+                    disabled={(!retryable && !authenticationRequired) || remoteRetryInFlight}
                     className="bg-muted/60 hover:bg-muted text-muted-foreground disabled:hover:bg-muted/60 inline-flex items-center gap-2 rounded-md px-2 py-1 text-left transition-colors disabled:cursor-help"
-                    aria-label={retryable ? `Retry ${machine.label}` : undefined}
+                    aria-label={authenticationRequired ? `Reconnect ${machine.label}` : retryable ? `Retry ${machine.label}` : undefined}
                   >
                     {refreshing ? (
                       <LoaderCircleIcon className="text-info size-3 animate-spin" aria-label="Refreshing" />
@@ -112,6 +122,10 @@ export function MachineActivity({
                       <span className="text-muted-foreground">Checking</span>
                     ) : connectorFailed(machine) ? (
                       <span className="text-destructive">Setup failed</span>
+                    ) : authenticationRequired ? (
+                      <span className="text-warning-fg">Authentication required · Reconnect</span>
+                    ) : machine.reason === 'host_key_changed' ? (
+                      <span className="text-destructive">Host key changed</span>
                     ) : offline ? (
                       <span className="text-muted-foreground">Offline</span>
                     ) : (

--- a/frontend/src/pages/coslash/components/MachineActivity.tsx
+++ b/frontend/src/pages/coslash/components/MachineActivity.tsx
@@ -44,7 +44,11 @@ function machineCopy(machine: MachineFact, checking: boolean) {
 }
 
 function needsAttention(machine: MachineFact) {
-  return machine.reason === 'authentication_failed' || machine.reason === 'host_key_confirmation_required' || machine.reason === 'host_key_changed';
+  return (
+    machine.reason === 'authentication_failed' ||
+    machine.reason === 'host_key_confirmation_required' ||
+    machine.reason === 'host_key_changed'
+  );
 }
 
 function connectorFailed(machine: MachineFact) {
@@ -93,7 +97,8 @@ export function MachineActivity({
             machine.sourceId !== LOCAL_SOURCE_ID &&
             machine.actionRequired == null &&
             (machine.state === 'stale' || machine.state === 'error' || connectorFailed(machine));
-          const authenticationRequired = machine.sourceId !== LOCAL_SOURCE_ID && machine.actionRequired === 'authenticate';
+          const authenticationRequired =
+            machine.sourceId !== LOCAL_SOURCE_ID && machine.actionRequired === 'authenticate';
           const offline =
             machine.sourceId !== LOCAL_SOURCE_ID &&
             !refreshing &&
@@ -104,10 +109,18 @@ export function MachineActivity({
                 <span>
                   <button
                     type="button"
-                    onClick={authenticationRequired ? onRemoteAuthenticate : retryable ? onRemoteRetry : undefined}
+                    onClick={
+                      authenticationRequired ? onRemoteAuthenticate : retryable ? onRemoteRetry : undefined
+                    }
                     disabled={(!retryable && !authenticationRequired) || remoteRetryInFlight}
                     className="bg-muted/60 hover:bg-muted text-muted-foreground disabled:hover:bg-muted/60 inline-flex items-center gap-2 rounded-md px-2 py-1 text-left transition-colors disabled:cursor-help"
-                    aria-label={authenticationRequired ? `Reconnect ${machine.label}` : retryable ? `Retry ${machine.label}` : undefined}
+                    aria-label={
+                      authenticationRequired
+                        ? `Reconnect ${machine.label}`
+                        : retryable
+                          ? `Retry ${machine.label}`
+                          : undefined
+                    }
                   >
                     {refreshing ? (
                       <LoaderCircleIcon className="text-info size-3 animate-spin" aria-label="Refreshing" />

--- a/frontend/src/pages/coslash/components/MachinesSettingsSection.tsx
+++ b/frontend/src/pages/coslash/components/MachinesSettingsSection.tsx
@@ -1,11 +1,50 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import type { MachineFact } from '@/pages/coslash/lib/machines';
-import { remoteStatus, setupRemoteHelper, testRemoteAlias } from '@/pages/coslash/lib/remote-api';
+import {
+  cancelRemoteAuthentication,
+  remoteAuthenticationStatus,
+  remoteStatus,
+  retryRemoteRefreshAndWait,
+  setupRemoteHelper,
+  startRemoteAuthentication,
+  testRemoteAlias,
+} from '@/pages/coslash/lib/remote-api';
 import type { RemoteHostSettings } from '@/pages/coslash/lib/settings';
 
-type SetupStage = 'idle' | 'testing' | 'saving' | 'consent' | 'installing' | 'ready' | 'error' | 'removing';
+type SetupStage =
+  | 'idle'
+  | 'testing'
+  | 'authentication_required'
+  | 'authenticating'
+  | 'saving'
+  | 'consent'
+  | 'installing'
+  | 'ready'
+  | 'error'
+  | 'removing';
+
+type AuthenticationRun = {
+  cancelled: boolean;
+  controller: AbortController;
+  attemptID: string | null;
+};
+
+function waitForAuthPoll(signal: AbortSignal) {
+  return new Promise<void>((resolve, reject) => {
+    if (signal.aborted) return reject(signal.reason);
+    const timer = window.setTimeout(() => {
+      signal.removeEventListener('abort', abort);
+      resolve();
+    }, 600);
+    const abort = () => {
+      window.clearTimeout(timer);
+      reject(signal.reason);
+    };
+    signal.addEventListener('abort', abort, { once: true });
+  });
+}
 
 function testResultCopy(machine: MachineFact) {
   return machine.state === 'ok'
@@ -34,13 +73,32 @@ export function MachinesSettingsSection({
   const [stage, setStage] = useState<SetupStage>('idle');
   const [message, setMessage] = useState<string | null>(null);
   const [machine, setMachine] = useState<MachineFact | null>(null);
-  const busy = stage === 'testing' || stage === 'saving' || stage === 'installing' || stage === 'removing';
+  const [authAlias, setAuthAlias] = useState<string | null>(null);
+  const [authAttemptID, setAuthAttemptID] = useState<string | null>(null);
+  const [authReconnect, setAuthReconnect] = useState(false);
+  const authenticationRun = useRef<AuthenticationRun | null>(null);
+  const busy =
+    stage === 'testing' ||
+    stage === 'authenticating' ||
+    stage === 'saving' ||
+    stage === 'installing' ||
+    stage === 'removing';
   const setupFailed =
     stage === 'error' ||
     (stage === 'idle' && machine?.helper?.compatible === false && machine.helper.reason != null);
 
   useEffect(() => onBusyChange(busy), [busy, onBusyChange]);
   useEffect(() => () => onBusyChange(false), [onBusyChange]);
+  useEffect(
+    () => () => {
+      const run = authenticationRun.current;
+      if (run == null) return;
+      run.cancelled = true;
+      run.controller.abort();
+      if (run.attemptID != null) void cancelRemoteAuthentication(run.attemptID).catch(() => undefined);
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!remote?.sshAlias) {
@@ -94,6 +152,120 @@ export function MachinesSettingsSection({
     }
   };
 
+  const saveVerifiedHost = async (sshAlias: string) => {
+    setStage('saving');
+    setMessage('Connection succeeded. Adding SSH monitoring…');
+    if (!(await onAddHost(sshAlias))) {
+      setStage('error');
+      setMessage('Could not add this SSH host.');
+      return;
+    }
+    setStage('consent');
+    setMessage('Install a private connector on this host, or skip installation.');
+  };
+
+  const waitForAuthentication = async (
+    sshAlias: string,
+    id: string,
+    reconnect: boolean,
+    run: AuthenticationRun,
+  ) => {
+    try {
+      for (;;) {
+        await waitForAuthPoll(run.controller.signal);
+        const attempt = await remoteAuthenticationStatus(id, run.controller.signal);
+        if (attempt.state === 'waiting') continue;
+        if (authenticationRun.current !== run || run.cancelled) return;
+        setAuthAttemptID(null);
+        if (attempt.state !== 'ready') {
+          setStage('error');
+          setMessage(
+            attempt.state === 'timed_out'
+              ? 'Authentication timed out. Try again.'
+              : attempt.state === 'failed'
+                ? 'Authentication did not complete. Check the Terminal prompt and try again.'
+                : 'Authentication was cancelled. Try again.',
+          );
+          return;
+        }
+        if (reconnect) {
+          const refreshed = await retryRemoteRefreshAndWait(run.controller.signal);
+          if (authenticationRun.current !== run || run.cancelled) return;
+          setMachine(refreshed);
+          setStage(refreshed.state === 'ok' ? 'ready' : 'error');
+          setMessage(refreshed.state === 'ok' ? 'SSH monitoring reconnected.' : `${testResultCopy(refreshed)}.`);
+          if (refreshed.state === 'ok') onConnectionVerified?.();
+          return;
+        }
+        const test = await testRemoteAlias(sshAlias);
+        if (authenticationRun.current !== run || run.cancelled) return;
+        if (test.state !== 'ok') {
+          setStage('error');
+          setMessage(`${testResultCopy(test)}.`);
+          return;
+        }
+        await saveVerifiedHost(sshAlias);
+        return;
+      }
+    } catch (error: unknown) {
+      if (run.cancelled || run.controller.signal.aborted || authenticationRun.current !== run) return;
+      // A failed status request must not leave an interactive server attempt
+      // consuming its full TTL with no client observing it.
+      await cancelRemoteAuthentication(id).catch(() => undefined);
+      if (authenticationRun.current !== run || run.cancelled) return;
+      setAuthAttemptID(null);
+      setStage('error');
+      setMessage(error instanceof Error ? error.message : 'Authentication status could not be checked. Try again.');
+    }
+  };
+
+  const authenticateInTerminal = async () => {
+    if (authAlias == null) return;
+    const run: AuthenticationRun = { cancelled: false, controller: new AbortController(), attemptID: null };
+    authenticationRun.current = run;
+    setStage('authenticating');
+    setMessage('Terminal opened. Complete the SSH prompt there; setup will continue automatically.');
+    try {
+      const attempt = await startRemoteAuthentication(authAlias);
+      run.attemptID = attempt.id;
+      if (run.cancelled || authenticationRun.current !== run) {
+        await cancelRemoteAuthentication(attempt.id).catch(() => undefined);
+        return;
+      }
+      setAuthAttemptID(attempt.id);
+      await waitForAuthentication(authAlias, attempt.id, authReconnect, run);
+    } catch (error: unknown) {
+      if (run.cancelled || authenticationRun.current !== run) return;
+      setAuthAttemptID(null);
+      setStage('error');
+      setMessage(error instanceof Error ? error.message : 'Could not start terminal authentication.');
+    } finally {
+      if (authenticationRun.current === run) authenticationRun.current = null;
+    }
+  };
+
+  const cancelAuthentication = async () => {
+    const run = authenticationRun.current;
+    if (run != null) {
+      run.cancelled = true;
+      run.controller.abort();
+      if (run.attemptID != null) await cancelRemoteAuthentication(run.attemptID).catch(() => undefined);
+    } else if (authAttemptID != null) {
+      await cancelRemoteAuthentication(authAttemptID).catch(() => undefined);
+    }
+    setAuthAttemptID(null);
+    setStage('error');
+    setMessage('Authentication was cancelled. Try again.');
+  };
+
+  const reconnect = () => {
+    if (remote == null) return;
+    setAuthAlias(remote.sshAlias);
+    setAuthReconnect(true);
+    setStage('authentication_required');
+    setMessage('Authentication required. Authenticate in Terminal to reconnect monitoring.');
+  };
+
   const addHost = async () => {
     const sshAlias = alias.trim();
     if (!sshAlias) {
@@ -106,25 +278,18 @@ export function MachinesSettingsSection({
     try {
       const test = await testRemoteAlias(sshAlias);
       if (test.state !== 'ok') {
-        setStage('error');
-        const hint =
-          test.reason === 'connection_failed' ||
-          test.reason === 'authentication_failed' ||
-          test.reason === 'host_key_failed'
-            ? ` Run ssh ${sshAlias} once in Terminal, complete any prompt, then try again.`
-            : '';
-        setMessage(`${testResultCopy(test)}.${hint}`);
+        if (test.actionRequired === 'authenticate') {
+          setAuthAlias(sshAlias);
+          setAuthReconnect(false);
+          setStage('authentication_required');
+          setMessage(`${testResultCopy(test)}. Authenticate in Terminal to continue.`);
+        } else {
+          setStage('error');
+          setMessage(`${testResultCopy(test)}.`);
+        }
         return;
       }
-      setStage('saving');
-      setMessage('Connection succeeded. Adding SSH monitoring…');
-      if (!(await onAddHost(sshAlias))) {
-        setStage('error');
-        setMessage('Could not add this SSH host.');
-        return;
-      }
-      setStage('consent');
-      setMessage('Install a private connector on this host, or skip installation.');
+      await saveVerifiedHost(sshAlias);
     } catch (error: unknown) {
       setStage('error');
       setMessage(error instanceof Error ? error.message : 'Could not add this SSH host.');
@@ -179,7 +344,11 @@ export function MachinesSettingsSection({
                   ? 'Setup failed'
                   : machine?.refreshing || machine?.state === 'connecting'
                     ? 'Checking'
-                    : machine?.state === 'stale' || machine?.state === 'error'
+                    : machine?.actionRequired === 'authenticate'
+                      ? 'Authentication required · Reconnect'
+                      : machine?.actionRequired === 'verify_host_key'
+                        ? 'Host key changed · Verify host identity'
+                        : machine?.state === 'stale' || machine?.state === 'error'
                       ? 'Offline'
                       : machine?.state === 'ok' && machine.sessionCount === 0
                         ? 'Connected · no recent agent sessions found'
@@ -201,6 +370,11 @@ export function MachinesSettingsSection({
                   Retry setup
                 </Button>
               ) : null}
+              {machine?.actionRequired === 'authenticate' && stage !== 'authenticating' ? (
+                <Button type="button" size="sm" disabled={busy} onClick={reconnect}>
+                  Authenticate in Terminal
+                </Button>
+              ) : null}
               <Button
                 type="button"
                 variant="outline"
@@ -217,7 +391,7 @@ export function MachinesSettingsSection({
             <div>
               <div className="text-sm font-semibold">Add remote host</div>
               <div className="text-muted-foreground mt-1 text-xs text-pretty">
-                Connect through an alias already configured in your SSH config.
+                Connect through an SSH alias or a simple user@host destination.
               </div>
             </div>
             <div className="flex flex-col gap-2 sm:flex-row">
@@ -250,7 +424,17 @@ export function MachinesSettingsSection({
               'bg-destructive/10 text-destructive': stage === 'error',
             })}
           >
-            <span className={cn({ 'animate-pulse': stage === 'installing' })}>{message}</span>
+            <span className={cn({ 'animate-pulse': stage === 'installing' || stage === 'authenticating' })}>{message}</span>
+            {stage === 'authentication_required' && (
+              <Button type="button" size="sm" className="ml-3" onClick={() => void authenticateInTerminal()}>
+                Authenticate in Terminal
+              </Button>
+            )}
+            {stage === 'authenticating' && (
+              <Button type="button" variant="outline" size="sm" className="ml-3" onClick={() => void cancelAuthentication()}>
+                Cancel
+              </Button>
+            )}
           </div>
         )}
         {message == null && setupFailed && (

--- a/frontend/src/pages/coslash/components/MachinesSettingsSection.tsx
+++ b/frontend/src/pages/coslash/components/MachinesSettingsSection.tsx
@@ -77,12 +77,8 @@ export function MachinesSettingsSection({
   const [authAttemptID, setAuthAttemptID] = useState<string | null>(null);
   const [authReconnect, setAuthReconnect] = useState(false);
   const authenticationRun = useRef<AuthenticationRun | null>(null);
-  const busy =
-    stage === 'testing' ||
-    stage === 'authenticating' ||
-    stage === 'saving' ||
-    stage === 'installing' ||
-    stage === 'removing';
+  const busy = stage === 'testing' || stage === 'saving' || stage === 'installing' || stage === 'removing';
+  const removeDisabled = busy || stage === 'authenticating';
   const setupFailed =
     stage === 'error' ||
     (stage === 'idle' && machine?.helper?.compatible === false && machine.helper.reason != null);
@@ -193,7 +189,9 @@ export function MachinesSettingsSection({
           if (authenticationRun.current !== run || run.cancelled) return;
           setMachine(refreshed);
           setStage(refreshed.state === 'ok' ? 'ready' : 'error');
-          setMessage(refreshed.state === 'ok' ? 'SSH monitoring reconnected.' : `${testResultCopy(refreshed)}.`);
+          setMessage(
+            refreshed.state === 'ok' ? 'SSH monitoring reconnected.' : `${testResultCopy(refreshed)}.`,
+          );
           if (refreshed.state === 'ok') onConnectionVerified?.();
           return;
         }
@@ -215,7 +213,9 @@ export function MachinesSettingsSection({
       if (authenticationRun.current !== run || run.cancelled) return;
       setAuthAttemptID(null);
       setStage('error');
-      setMessage(error instanceof Error ? error.message : 'Authentication status could not be checked. Try again.');
+      setMessage(
+        error instanceof Error ? error.message : 'Authentication status could not be checked. Try again.',
+      );
     }
   };
 
@@ -349,10 +349,10 @@ export function MachinesSettingsSection({
                       : machine?.actionRequired === 'verify_host_key'
                         ? 'Host key changed · Verify host identity'
                         : machine?.state === 'stale' || machine?.state === 'error'
-                      ? 'Offline'
-                      : machine?.state === 'ok' && machine.sessionCount === 0
-                        ? 'Connected · no recent agent sessions found'
-                        : 'Connected'}
+                          ? 'Offline'
+                          : machine?.state === 'ok' && machine.sessionCount === 0
+                            ? 'Connected · no recent agent sessions found'
+                            : 'Connected'}
               </div>
             </div>
             <div className="flex shrink-0 gap-2">
@@ -379,7 +379,7 @@ export function MachinesSettingsSection({
                 type="button"
                 variant="outline"
                 size="sm"
-                disabled={busy}
+                disabled={removeDisabled}
                 onClick={() => void removeHost()}
               >
                 {stage === 'removing' ? 'Removing…' : 'Remove'}
@@ -424,14 +424,22 @@ export function MachinesSettingsSection({
               'bg-destructive/10 text-destructive': stage === 'error',
             })}
           >
-            <span className={cn({ 'animate-pulse': stage === 'installing' || stage === 'authenticating' })}>{message}</span>
+            <span className={cn({ 'animate-pulse': stage === 'installing' || stage === 'authenticating' })}>
+              {message}
+            </span>
             {stage === 'authentication_required' && (
               <Button type="button" size="sm" className="ml-3" onClick={() => void authenticateInTerminal()}>
                 Authenticate in Terminal
               </Button>
             )}
             {stage === 'authenticating' && (
-              <Button type="button" variant="outline" size="sm" className="ml-3" onClick={() => void cancelAuthentication()}>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="ml-3"
+                onClick={() => void cancelAuthentication()}
+              >
                 Cancel
               </Button>
             )}

--- a/frontend/src/pages/coslash/features/sharing/ShareToHubDialog.tsx
+++ b/frontend/src/pages/coslash/features/sharing/ShareToHubDialog.tsx
@@ -599,8 +599,9 @@ export function ShareToHubDialog({
                                   {candidate.session.name ?? candidate.session.id}
                                 </span>
                                 <span className="text-muted-foreground block truncate pt-0.5 text-xs">
-                                  {candidate.session.sourceLabel} · {candidate.session.agent} · {candidate.session.branch ?? 'no branch'} ·
-                                  revision {candidate.session.mtime}
+                                  {candidate.session.sourceLabel} · {candidate.session.agent} ·{' '}
+                                  {candidate.session.branch ?? 'no branch'} · revision{' '}
+                                  {candidate.session.mtime}
                                 </span>
                               </span>
                               {candidate.previouslyShared && (

--- a/frontend/src/pages/coslash/features/sharing/model.test.ts
+++ b/frontend/src/pages/coslash/features/sharing/model.test.ts
@@ -120,7 +120,11 @@ describe('hub-share/v1 public consumer', () => {
 
   it('keeps local and SSH candidates with matching vendor IDs independently bound', () => {
     const local = session('same-id', 'alpha', now);
-    const ssh = { ...session('same-id', 'alpha', now), sourceId: 'r_0123456789abcdef', sourceLabel: 'SSH workspace' };
+    const ssh = {
+      ...session('same-id', 'alpha', now),
+      sourceId: 'r_0123456789abcdef',
+      sourceLabel: 'SSH workspace',
+    };
     expect(localSessionId(local)).toBe('local:codex:same-id');
     expect(localSessionId(ssh)).toBe('r_0123456789abcdef:codex:same-id');
   });

--- a/frontend/src/pages/coslash/hooks/use-sessions.test.ts
+++ b/frontend/src/pages/coslash/hooks/use-sessions.test.ts
@@ -5,7 +5,7 @@ import {
   sessionsRequestPath,
   synthesisRequestPath,
 } from '@/pages/coslash/hooks/use-sessions';
-import { LOCAL_SOURCE_ID, type Session } from '@/pages/coslash/lib/session';
+import { LOCAL_SOURCE_ID, withLocalSourceDefaults, type Session } from '@/pages/coslash/lib/session';
 
 function sampleSession(id: string, sourceId = LOCAL_SOURCE_ID): Session {
   return {
@@ -62,7 +62,7 @@ describe('decodeSessionsResponse', () => {
       ...legacy
     } = sampleSession('a');
     expect(decodeSessionsResponse([legacy])).toEqual({
-      sessions: [sampleSession('a')],
+      sessions: [withLocalSourceDefaults(legacy)],
       machines: [],
     });
   });
@@ -70,7 +70,10 @@ describe('decodeSessionsResponse', () => {
   it('accepts the source-aware envelope and preserves machines', () => {
     const sessions = [sampleSession('a'), sampleSession('b', 'r_0123456789abcdef')];
     const machines = [{ sourceId: 'local', label: 'Local Mac', state: 'ok', complete: true }];
-    expect(decodeSessionsResponse({ sessions, machines })).toEqual({ sessions, machines });
+    expect(decodeSessionsResponse({ sessions, machines })).toEqual({
+      sessions: sessions.map(withLocalSourceDefaults),
+      machines,
+    });
   });
 
   it('normalizes null remote collections so sparse facts cannot crash the board', () => {

--- a/frontend/src/pages/coslash/lib/machines.ts
+++ b/frontend/src/pages/coslash/lib/machines.ts
@@ -22,7 +22,8 @@ export const MACHINE_REASONS = [
   'history_truncated',
   'refresh_timeout',
   'authentication_failed',
-  'host_key_failed',
+  'host_key_confirmation_required',
+  'host_key_changed',
   'connection_failed',
   'sftp_unavailable',
   'permission_denied',
@@ -46,6 +47,11 @@ export const MACHINE_REASONS = [
 ] as const;
 export type MachineReason = (typeof MACHINE_REASONS)[number];
 
+export const MACHINE_AUTH_STATES = ['not_required', 'required', 'launching', 'waiting', 'ready'] as const;
+export type MachineAuthState = (typeof MACHINE_AUTH_STATES)[number];
+export const MACHINE_ACTIONS = ['authenticate', 'verify_host_key'] as const;
+export type MachineAction = (typeof MACHINE_ACTIONS)[number];
+
 export type AgentCoverage = {
   agent: string;
   candidateFiles: number;
@@ -60,6 +66,8 @@ export type MachineFact = {
   state: MachineState;
   complete: boolean;
   reason?: MachineReason;
+  actionRequired?: MachineAction;
+  authState?: MachineAuthState;
   lastSuccessAtMs?: number;
   lastCheckedAtMs?: number;
   sessionCount?: number;
@@ -202,6 +210,14 @@ export function decodeMachineFact(value: unknown): MachineFact {
   if (raw.reason != null) {
     if (typeof raw.reason !== 'string') throw new Error('Invalid machine fact');
     fact.reason = assertOneOf(raw.reason, MACHINE_REASONS);
+  }
+  if (raw.actionRequired != null) {
+    if (typeof raw.actionRequired !== 'string') throw new Error('Invalid machine fact');
+    fact.actionRequired = assertOneOf(raw.actionRequired, MACHINE_ACTIONS);
+  }
+  if (raw.authState != null) {
+    if (typeof raw.authState !== 'string') throw new Error('Invalid machine fact');
+    fact.authState = assertOneOf(raw.authState, MACHINE_AUTH_STATES);
   }
   for (const key of ['lastSuccessAtMs', 'lastCheckedAtMs', 'coverageSinceMs', 'roundTripMs'] as const) {
     const number = optionalNumber(raw[key]);

--- a/frontend/src/pages/coslash/lib/preview.test.ts
+++ b/frontend/src/pages/coslash/lib/preview.test.ts
@@ -135,9 +135,9 @@ describe('snapshot preview adapter', () => {
     expect(previewRequestPath({ sourceId: 'local', id: 'session/id' }, 42)).toBe(
       '/api/share-preview?id=session%2Fid&revision=42',
     );
-    expect(
-      previewRequestPath({ sourceId: 'r_0123456789abcdef', agent: 'codex', id: 'session/id' }, 42),
-    ).toBe('/api/share-preview?id=session%2Fid&revision=42&source=r_0123456789abcdef&agent=codex');
+    expect(previewRequestPath({ sourceId: 'r_0123456789abcdef', agent: 'codex', id: 'session/id' }, 42)).toBe(
+      '/api/share-preview?id=session%2Fid&revision=42&source=r_0123456789abcdef&agent=codex',
+    );
     expect(() => previewRequestPath({ sourceId: 'r_0123456789abcdef', id: 'session/id' }, 42)).toThrow(
       'remote preview requires the session agent',
     );

--- a/frontend/src/pages/coslash/lib/remote-api.test.ts
+++ b/frontend/src/pages/coslash/lib/remote-api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { retryRemoteRefreshAndWait } from './remote-api';
+import { remoteAuthenticationStatus, retryRemoteRefreshAndWait, startRemoteAuthentication } from './remote-api';
 
 const connectingMachine = {
   sourceId: 'r_0123456789abcdef',
@@ -57,5 +57,35 @@ describe('retryRemoteRefreshAndWait', () => {
 
     await expect(result).resolves.toEqual(readyMachine);
     expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('terminal authentication API', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('starts and decodes an opaque authentication attempt', async () => {
+    vi.stubGlobal('window', {
+      location: { hash: '', pathname: '/', search: '' },
+      history: { state: null, replaceState: vi.fn() },
+      sessionStorage: { getItem: vi.fn(() => null), setItem: vi.fn() },
+    });
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ id: 'a'.repeat(32), state: 'waiting' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(startRemoteAuthentication('jane@host')).resolves.toEqual({ id: 'a'.repeat(32), state: 'waiting' });
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/remote/auth/start');
+  });
+
+  it('rejects unknown authentication states', async () => {
+    vi.stubGlobal('window', {
+      location: { hash: '', pathname: '/', search: '' },
+      history: { state: null, replaceState: vi.fn() },
+      sessionStorage: { getItem: vi.fn(() => null), setItem: vi.fn() },
+    });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(Response.json({ id: 'a'.repeat(32), state: 'leaked' })));
+
+    await expect(remoteAuthenticationStatus('a'.repeat(32))).rejects.toThrow('Invalid authentication status');
   });
 });

--- a/frontend/src/pages/coslash/lib/remote-api.test.ts
+++ b/frontend/src/pages/coslash/lib/remote-api.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { remoteAuthenticationStatus, retryRemoteRefreshAndWait, startRemoteAuthentication } from './remote-api';
+import {
+  remoteAuthenticationStatus,
+  retryRemoteRefreshAndWait,
+  startRemoteAuthentication,
+} from './remote-api';
 
 const connectingMachine = {
   sourceId: 'r_0123456789abcdef',
@@ -74,7 +78,10 @@ describe('terminal authentication API', () => {
     const fetchMock = vi.fn().mockResolvedValue(Response.json({ id: 'a'.repeat(32), state: 'waiting' }));
     vi.stubGlobal('fetch', fetchMock);
 
-    await expect(startRemoteAuthentication('jane@host')).resolves.toEqual({ id: 'a'.repeat(32), state: 'waiting' });
+    await expect(startRemoteAuthentication('jane@host')).resolves.toEqual({
+      id: 'a'.repeat(32),
+      state: 'waiting',
+    });
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/remote/auth/start');
   });
 

--- a/frontend/src/pages/coslash/lib/remote-api.ts
+++ b/frontend/src/pages/coslash/lib/remote-api.ts
@@ -42,38 +42,56 @@ export type RemoteAuthAttempt = {
 };
 
 function decodeRemoteAuthAttempt(value: unknown): RemoteAuthAttempt {
-  if (value == null || typeof value !== 'object' || Array.isArray(value)) throw new Error('Invalid authentication status');
+  if (value == null || typeof value !== 'object' || Array.isArray(value))
+    throw new Error('Invalid authentication status');
   const raw = value as Record<string, unknown>;
-  if (typeof raw.id !== 'string' || !['waiting', 'ready', 'timed_out', 'cancelled', 'failed'].includes(String(raw.state))) {
+  if (
+    typeof raw.id !== 'string' ||
+    !['waiting', 'ready', 'timed_out', 'cancelled', 'failed'].includes(String(raw.state))
+  ) {
     throw new Error('Invalid authentication status');
   }
   return { id: raw.id, state: raw.state as RemoteAuthAttempt['state'] };
 }
 
-export async function startRemoteAuthentication(sshAlias: string, signal?: AbortSignal): Promise<RemoteAuthAttempt> {
+export async function startRemoteAuthentication(
+  sshAlias: string,
+  signal?: AbortSignal,
+): Promise<RemoteAuthAttempt> {
   const response = await apiFetch('/api/remote/auth/start', { ...remoteTestRequestInit(sshAlias), signal });
   const body: unknown = await response.json();
   if (!response.ok) throw new Error(decodeApiError(body).error);
   return decodeRemoteAuthAttempt(body);
 }
 
-export async function remoteAuthenticationStatus(id: string, signal?: AbortSignal): Promise<RemoteAuthAttempt> {
+export async function remoteAuthenticationStatus(
+  id: string,
+  signal?: AbortSignal,
+): Promise<RemoteAuthAttempt> {
   const response = await apiFetch(`/api/remote/auth/status?id=${encodeURIComponent(id)}`, { signal });
   const body: unknown = await response.json();
   if (!response.ok) throw new Error(decodeApiError(body).error);
   return decodeRemoteAuthAttempt(body);
 }
 
-export async function cancelRemoteAuthentication(id: string, signal?: AbortSignal): Promise<RemoteAuthAttempt> {
+export async function cancelRemoteAuthentication(
+  id: string,
+  signal?: AbortSignal,
+): Promise<RemoteAuthAttempt> {
   const response = await apiFetch('/api/remote/auth/cancel', {
-    method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ id }), signal,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id }),
+    signal,
   });
   const body: unknown = await response.json();
   if (!response.ok) throw new Error(decodeApiError(body).error);
   return decodeRemoteAuthAttempt(body);
 }
 
-export async function retryRemoteRefresh(signal?: AbortSignal): Promise<{ status: number; machine: MachineFact }> {
+export async function retryRemoteRefresh(
+  signal?: AbortSignal,
+): Promise<{ status: number; machine: MachineFact }> {
   const response = await apiFetch('/api/remote/retry', { method: 'POST', signal });
   const body: unknown = await response.json();
   if (!response.ok) {

--- a/frontend/src/pages/coslash/lib/remote-api.ts
+++ b/frontend/src/pages/coslash/lib/remote-api.ts
@@ -36,8 +36,45 @@ export async function testRemoteAlias(sshAlias: string): Promise<MachineFact> {
   return decodeMachineFact(await response.json());
 }
 
-export async function retryRemoteRefresh(): Promise<{ status: number; machine: MachineFact }> {
-  const response = await apiFetch('/api/remote/retry', { method: 'POST' });
+export type RemoteAuthAttempt = {
+  id: string;
+  state: 'waiting' | 'ready' | 'timed_out' | 'cancelled' | 'failed';
+};
+
+function decodeRemoteAuthAttempt(value: unknown): RemoteAuthAttempt {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) throw new Error('Invalid authentication status');
+  const raw = value as Record<string, unknown>;
+  if (typeof raw.id !== 'string' || !['waiting', 'ready', 'timed_out', 'cancelled', 'failed'].includes(String(raw.state))) {
+    throw new Error('Invalid authentication status');
+  }
+  return { id: raw.id, state: raw.state as RemoteAuthAttempt['state'] };
+}
+
+export async function startRemoteAuthentication(sshAlias: string, signal?: AbortSignal): Promise<RemoteAuthAttempt> {
+  const response = await apiFetch('/api/remote/auth/start', { ...remoteTestRequestInit(sshAlias), signal });
+  const body: unknown = await response.json();
+  if (!response.ok) throw new Error(decodeApiError(body).error);
+  return decodeRemoteAuthAttempt(body);
+}
+
+export async function remoteAuthenticationStatus(id: string, signal?: AbortSignal): Promise<RemoteAuthAttempt> {
+  const response = await apiFetch(`/api/remote/auth/status?id=${encodeURIComponent(id)}`, { signal });
+  const body: unknown = await response.json();
+  if (!response.ok) throw new Error(decodeApiError(body).error);
+  return decodeRemoteAuthAttempt(body);
+}
+
+export async function cancelRemoteAuthentication(id: string, signal?: AbortSignal): Promise<RemoteAuthAttempt> {
+  const response = await apiFetch('/api/remote/auth/cancel', {
+    method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ id }), signal,
+  });
+  const body: unknown = await response.json();
+  if (!response.ok) throw new Error(decodeApiError(body).error);
+  return decodeRemoteAuthAttempt(body);
+}
+
+export async function retryRemoteRefresh(signal?: AbortSignal): Promise<{ status: number; machine: MachineFact }> {
+  const response = await apiFetch('/api/remote/retry', { method: 'POST', signal });
   const body: unknown = await response.json();
   if (!response.ok) {
     const apiError = decodeApiError(body);
@@ -87,9 +124,23 @@ export async function waitForRemoteRefresh(
 // The retry endpoint acknowledges that collection has started, rather than
 // waiting for it to finish. Wait for its terminal health state before callers
 // reload the board, so it does not remain on the transient "connecting" view.
-export async function retryRemoteRefreshAndWait(): Promise<MachineFact> {
-  const { machine } = await retryRemoteRefresh();
-  return waitForRemoteRefresh(machine);
+export async function retryRemoteRefreshAndWait(signal?: AbortSignal): Promise<MachineFact> {
+  try {
+    const { machine } = await retryRemoteRefresh(signal);
+    return waitForRemoteRefresh(machine, signal);
+  } catch (error: unknown) {
+    // Authentication can make a shared master available just as the manager
+    // starts its own refresh. Waiting for that in-flight refresh is equivalent
+    // to retrying, and avoids presenting a successful reconnect as an error.
+    if (
+      error instanceof Error &&
+      (error as Error & { status?: unknown; code?: unknown }).status === 429 &&
+      (error as Error & { status?: unknown; code?: unknown }).code === 'remote_retry_throttled'
+    ) {
+      return waitForRemoteRefresh(undefined, signal);
+    }
+    throw error;
+  }
 }
 
 export async function setupRemoteHelper(

--- a/settings.schema.json
+++ b/settings.schema.json
@@ -49,7 +49,7 @@
       }
     },
     "remote": {
-      "description": "One optional Linux host monitored through an existing OpenSSH alias. SFTP is always available when permitted; the optional Linux collection helper requires explicit in-app consent before installation.",
+      "description": "One optional Linux host monitored through an existing OpenSSH alias or a simple user@host destination. SFTP is always available when permitted; the optional Linux collection helper requires explicit in-app consent before installation.",
       "type": "object",
       "additionalProperties": false,
       "required": ["id", "sshAlias", "enabled"],
@@ -62,7 +62,7 @@
           "type": "string",
           "minLength": 1,
           "maxLength": 255,
-          "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$"
+          "pattern": "^(?:[A-Za-z0-9][A-Za-z0-9._-]*|[A-Za-z0-9][A-Za-z0-9._-]*@[A-Za-z0-9][A-Za-z0-9.-]*)$"
         },
         "enabled": { "type": "boolean" }
       }


### PR DESCRIPTION
## Summary
- add explicit terminal-assisted SSH authentication and reconnect flow
- distinguish host-key confirmation from changed-key remediation
- coordinate auth attempts with SSH control-master lifecycle and cleanup
- add durable auth outcomes, machine action state, and lifecycle tests

## UI
<img width="630" height="674" alt="image" src="https://github.com/user-attachments/assets/f19fa619-ba40-40d9-9b07-019e2d2e32eb" />


## Validation
- `go test ./...`
- `npm run build`
- focused frontend authentication API tests
- `make release`
- `make smoke`

Closes ENG-1412.